### PR TITLE
Fix for issue #115

### DIFF
--- a/components/rms/slurm/SPECS/slurm.spec
+++ b/components/rms/slurm/SPECS/slurm.spec
@@ -360,7 +360,7 @@ are in other packages
 %package -n %{pname}-torque%{PROJ_DELIM}
 Summary: Torque/PBS wrappers for transition from Torque/PBS to Slurm
 Group: ohpc/rms
-Requires: slurm-perlapi
+Requires: slurm-perlapi%{PROJ_DELIM}
 %description -n %{pname}-torque%{PROJ_DELIM}
 Torque wrapper scripts used for helping migrate from Torque/PBS to Slurm
 


### PR DESCRIPTION
Fix for #115. This change adds the PROJ_DELIM tag to the slurm-perlapi dependency of slurm-torque-hpc, as specified in other dependencies.

Note that the slurm specfile seems a little inconsistent in where it uses "slurm" vs "%{pname}", and in where the "%{PROJ_DELIM}" tag is included. For example, the bluegene and aix packages are dependent on "slurm" instead of "%{pname}%{PROJ_DELIM}" so I suspect they won't build. However, lacking a convenient bluegene to test on, I thought I'd restrict this fix to the issue I actually encountered. ;)
