### PR TITLE
Add new component 'shine' for Lustre

### DIFF
--- a/components/lustre/shine/SPECS/shine.spec
+++ b/components/lustre/shine/SPECS/shine.spec
@@ -1,0 +1,53 @@
+# Base package name
+%define pname shine
+
+Name:      %{pname}%{?PROJ_DELIM}
+Summary:   Lustre administration utility
+Version:   1.4
+Release:   1%{?dist}
+Source0:   http://downloads.sourceforge.net/lustre-shine/%{pname}/%{version}/%{pname}-%{version}.tar.gz
+License:   GPLv2
+Group:     Applications/System
+Vendor:    CEA
+Url:       http://lustre-shine.sourceforge.net/
+BuildRoot: %{_tmppath}/%{pname}-%{version}-%{release}-root-%(%{__id_u} -n)
+BuildArch: noarch
+Requires:  clustershell >= 1.5.1
+Provides:  %{pname} = %{version}
+
+%description
+Lustre administration utility.
+
+%prep
+%setup -q -n %{pname}-%{version}
+
+%build
+export SHINEVERSION=%{version}
+python setup.py build
+
+%install
+export SHINEVERSION=%{version}
+python setup.py install --root=%{buildroot} --record=INSTALLED_FILES
+mkdir -p %{buildroot}/%{_sysconfdir}/shine/models
+cp conf/*.conf* %{buildroot}/%{_sysconfdir}/shine
+cp conf/models/* %{buildroot}/%{_sysconfdir}/shine/models
+# man pages
+mkdir -p %{buildroot}/%{_mandir}/{man1,man5}
+gzip -c doc/shine.1 >%{buildroot}/%{_mandir}/man1/shine.1.gz
+gzip -c doc/shine.conf.5 >%{buildroot}/%{_mandir}/man5/shine.conf.5.gz
+
+%clean
+rm -rf %{buildroot}
+
+%files -f INSTALLED_FILES
+%defattr(-,root,root)
+%config(noreplace) %{_sysconfdir}/shine/*.conf
+%config %{_sysconfdir}/shine/*.conf.example
+%config %{_sysconfdir}/shine/models/*.lmf
+%doc LICENSE README ChangeLog
+%doc %{_mandir}/man1/shine.1.gz
+%doc %{_mandir}/man5/shine.conf.5.gz
+
+%changelog
+* Wed Feb 24 2016 <aurelien.degremont@cea.fr> - 1.4-1
+- Initial packaging for OpenHPC


### PR DESCRIPTION
Shine is a powerful CLI tool for Lustre administration.
It manages Lustre servers, clients and routers, scaling up
to thousands of servers or clients, in performance and usability.

It can start, format, check, mount, unmount and many other features.

```
# shine status -f scratch
[11:20] In progress for 1073 component(s) on 962 servers ...
nova[3148-3149]: Remote action status failed: No response

= FILESYSTEM STATUS (scratch) =
TYPE    # STATUS         NODES
----    - ------         -----
MDT     1 online         nova111
OST   144 online         nova[200-211]
CLI     2 CHECK FAILURE  nova[3148-3149]
CLI  1156 mounted        nova[1000-1617,2000-2221,2224-2359,3018-3062,3064-3197]
CLI     3 offline        nova[2222-2223,3063]
```

I tried to follow OpenHPC rules, but, as there is no official documentation for that, yet, may be I forgot some adaptations. Let me know if something needs to be fixed.
