### PR TITLE
add a build dep on librdmacm-devel to enable RDMA CM support

### DIFF
--- a/components/mpi-families/mvapich2/SPECS/mvapich2.spec
+++ b/components/mpi-families/mvapich2/SPECS/mvapich2.spec
@@ -86,6 +86,7 @@ Requires: prun%{PROJ_DELIM}
 
 BuildRequires: bison
 BuildRequires: libibmad-devel libibverbs-devel
+BuildRequires: librdmacm-devel
 
 # Default library install path
 %define install_path %{OHPC_MPI_STACKS}/%{name}/%version


### PR DESCRIPTION
I've noticed that the ohpc builds of mvapich2 don't support RDMA CM. It is possible to enable it by adding a build dep on librdmacm-devel.