### PR TITLE
Add NM_CONTROLLED=no option to ifcfg-ib0 

### DIFF
--- a/components/admin/examples/SOURCES/ifcfg-ib0
+++ b/components/admin/examples/SOURCES/ifcfg-ib0
@@ -4,3 +4,4 @@ IPADDR=master_ipoib
 NETMASK=ipoib_netmask
 ONBOOT=yes
 STARTMODE='auto'
+NM_CONTROLLED=no


### PR DESCRIPTION
Fixes interface initialization on RHEL7.2.

The pdf guide specifies (page 9 for 1.1 Centos7.2 installation):
```
[sms]# cp /opt/ohpc/pub/examples/network/centos/ifcfg-ib0 /etc/sysconfig/network-scripts
```
The template file is missing the `NM_CONTROLLED=no` entry. Without this entry, the interface is not initialized properly.