### PR TITLE
Issue#257

### DIFF
--- a/docs/recipes/install/centos7.2/vanilla/steps.tex
+++ b/docs/recipes/install/centos7.2/vanilla/steps.tex
@@ -93,7 +93,7 @@ You can now mount the ISO image via the loop device. For details refer
 
 \begin{itemize*}
 \item OpenHPC:1.1.repo
-  (e.g. \href{http://build.openhpc.community/OpenHPC:/1.1/CentOS\_7.2/iso/README}
+  ( \href{http://build.openhpc.community/OpenHPC:/1.1/CentOS\_7.2/iso/README}
              {\color{blue}{http://build.openhpc.community/OpenHPC:/1.1/CentOS\_7.2/iso/README}} )
 \end{itemize*}
 

--- a/docs/recipes/install/centos7.2/vanilla/steps.tex
+++ b/docs/recipes/install/centos7.2/vanilla/steps.tex
@@ -89,6 +89,14 @@
 % ohpc_command fi
 % end_ohpc_run
 
+You can now mount the ISO image via the loop device. For details refer
+
+\begin{itemize*}
+\item OpenHPC:1.1.repo
+  (e.g. \href{http://build.openhpc.community/OpenHPC:/1.1/CentOS\_7.2/iso/README}
+             {\color{blue}{http://build.openhpc.community/OpenHPC:/1.1/CentOS\_7.2/iso/README}} )
+\end{itemize*}
+
 In addition to the \OHPC{} package repository, the {\em master} host also
 requires access to the standard base OS distro repositories in order to resolve
 necessary dependencies. For \baseOS{}, the requirements are to have access to

--- a/docs/recipes/install/common/enable_ohpc_repo.tex
+++ b/docs/recipes/install/common/enable_ohpc_repo.tex
@@ -2,10 +2,12 @@ To begin, enable use of the \OHPC{} repository by adding it to the local list
 of available package repositories. Note that this requires network access from
 your {\em master} server to the \OHPC{} repository, or alternatively, that
 the \OHPC{} repository be mirrored locally.  In cases where network external
-connectivity is available, \OHPC{} provides an \texttt{ohpc-release} package
-that includes GPG keys for package signing and repository enablement.  The
-example which follows illustrates installation of the \texttt{ohpc-release}
-package directly from the \OHPC{} build server.
+connectivity is available, \OHPC{} repository can be enabled either through
+installation of an \texttt{ohpc-release} RPM that includes GPG keys for package
+signing and repository enablement or by installing from the ISO image that 
+contains the \OHPC{} packages.  The example which follows illustrates 
+installation of the \texttt{ohpc-release} package directly from the \OHPC{}
+build server.
 
 %the addition of the \OHPC{} repository using
 %the \texttt{\$\{ohpc\_repo\}} variable.
@@ -17,8 +19,15 @@ package directly from the \OHPC{} build server.
 
 %\noindent Once set, the repository can be enabled via the following: 
 
+When installing from the ISO repo, yum should be configured with the online 
+\OHPC{} updates repo enabled.  To download the ISO directly from the \OHPC{} 
+build server,
 
+%the addition of the \OHPC{} repository using ISO image
 
+\begin{lstlisting}[language=bash,keywords={},basicstyle=\fontencoding{T1}\footnotesize\ttfamily,
+        literate={VER}{\OHPCVerTree{}}1 {OSREPO}{\OSRepo{}}1 {-}{-}1]
+[sms](*\#*) wget -O /tmp/OpenHPC-VER_OSREPO.iso http://build.openhpc.community/OpenHPC:/VER/OSREPO/iso/OpenHPC-VER_OSREPO.iso
+\end{lstlisting}
 
-
-
+%\noindent

--- a/docs/recipes/install/common/inputs.tex
+++ b/docs/recipes/install/common/inputs.tex
@@ -23,6 +23,7 @@ node counts. \\
 & \texttt{\$\{c\_bmc[0]\}}, \texttt{\$\{c\_bmc[1]\}}, ... & {\small \# BMC addresses for computes} \\
 & \texttt{\$\{c\_mac[0]\}}, \texttt{\$\{c\_mac[1]\}}, ... & {\small \# MAC addresses for computes} \\
 & \texttt{\$\{compute\_regex\}} & {\small \# Regex for matching compute node names (e.g. c*)} \\
+& \texttt{\$\{compute\_prefix\}} & {\small \# Delimiter for compute node names (e.g. c)} \\
 \end{tabular}
 
 \vspace*{0.2cm}

--- a/docs/recipes/install/sles12sp1/vanilla/steps.tex
+++ b/docs/recipes/install/sles12sp1/vanilla/steps.tex
@@ -77,6 +77,14 @@
 \subsection{Enable \OHPC{} repository for local use} \label{sec:enable_repo}
 \input{../../common/enable_ohpc_repo}
 
+You can now mount the ISO image via the loop device. For details refer
+
+\begin{itemize*}
+\item OpenHPC:1.1.repo
+  (e.g. \href{http://build.openhpc.community/OpenHPC:/1.1/SLE\_12\_SP1/iso/README}
+             {\color{blue}{http://build.openhpc.community/OpenHPC:/1.1/SLE\_12\_SP1/iso/README}} )
+\end{itemize*}
+
 In addition to the \OHPC{} package repository, the {\em master} host also
 requires access to the standard distro repositories in order to resolve
 necessary dependencies. For \baseOS{}, the requirements are to have access to

--- a/docs/recipes/install/sles12sp1/vanilla/steps.tex
+++ b/docs/recipes/install/sles12sp1/vanilla/steps.tex
@@ -81,7 +81,7 @@ You can now mount the ISO image via the loop device. For details refer
 
 \begin{itemize*}
 \item OpenHPC:1.1.repo
-  (e.g. \href{http://build.openhpc.community/OpenHPC:/1.1/SLE\_12\_SP1/iso/README}
+  ( \href{http://build.openhpc.community/OpenHPC:/1.1/SLE\_12\_SP1/iso/README}
              {\color{blue}{http://build.openhpc.community/OpenHPC:/1.1/SLE\_12\_SP1/iso/README}} )
 \end{itemize*}
 


### PR DESCRIPTION
Install guide to Include option to enable OpenHPC repository using ISO image and  an input variable that encapsulates compute node delimiter.
