### PR TITLE
aarch64: first batch of fixes

### DIFF
--- a/components/admin/lmod/SPECS/lmod.spec
+++ b/components/admin/lmod/SPECS/lmod.spec
@@ -95,6 +95,8 @@ if [ ! -z "\$SLURM_NODELIST" ];then
      return
 fi
 
+export LUA_CPATH="%{LUA_CPATH}"
+export LUA_PATH="%{LUA_PATH}"
 export LMOD_SETTARG_CMD=":"
 export LMOD_FULL_SETTARG_SUPPORT=no
 export LMOD_COLORIZE=no
@@ -127,6 +129,8 @@ EOF
 
 if ( \$?SLURM_NODELIST ) then
 
+    setenv LUA_CPATH "%{LUA_CPATH}"
+    setenv LUA_PATH "%{LUA_PATH}"
     setenv LMOD_SETTARG_CMD ":"
     setenv LMOD_FULL_SETTARG_SUPPORT "no"
     setenv LMOD_COLORIZE "no"

--- a/components/admin/pdsh/SPECS/pdsh.spec
+++ b/components/admin/pdsh/SPECS/pdsh.spec
@@ -319,6 +319,11 @@ from an allocated Torque job.
 
 %build
 
+# work around old config.guess on aarch64 systems
+%ifarch aarch64
+cp /usr/lib/rpm/config.guess config
+%endif
+
 ./configure --prefix=%{install_path} \
     --with-rcmd-rank-list="ssh mrsh rsh krb4 qsh mqsh exec xcpu" \
     %{?_enable_debug}       \

--- a/components/dev-tools/valgrind/SPECS/valgrind.spec
+++ b/components/dev-tools/valgrind/SPECS/valgrind.spec
@@ -16,7 +16,7 @@
 
 Summary:   Valgrind Memory Debugger
 Name:      %{pname}%{PROJ_DELIM}
-Version:   3.10.1
+Version:   3.11.0
 Release:   1
 License:   GPL
 URL:       http://www.valgrind.org/

--- a/components/io-libs/hdf5/SPECS/hdf5.spec
+++ b/components/io-libs/hdf5/SPECS/hdf5.spec
@@ -100,6 +100,11 @@ grids. You can also mix and match them in HDF5 files according to your needs.
 
 %build
 
+# override with newer config.guess for aarch64
+%ifarch aarch64
+cp /usr/lib/rpm/config.guess bin
+%endif
+
 # OpenHPC compiler/mpi designation
 export OHPC_COMPILER_FAMILY=%{compiler_family}
 . %{_sourcedir}/OHPC_setup_compiler

--- a/components/io-libs/phdf5/SPECS/hdf5.spec
+++ b/components/io-libs/phdf5/SPECS/hdf5.spec
@@ -119,6 +119,11 @@ grids. You can also mix and match them in HDF5 files according to your needs.
 
 %build
 
+# override with newer config.guess for aarch64
+%ifarch aarch64
+cp /usr/lib/rpm/config.guess bin
+%endif
+
 # OpenHPC compiler/mpi designation
 export OHPC_COMPILER_FAMILY=%{compiler_family}
 export OHPC_MPI_FAMILY=%{mpi_family}

--- a/components/mpi-families/mvapich2/SOURCES/mvapich2-2.1-get_cycles-aarch64.patch
+++ b/components/mpi-families/mvapich2/SOURCES/mvapich2-2.1-get_cycles-aarch64.patch
@@ -1,0 +1,23 @@
+diff -ruN mvapich2-2.1.old/src/mpid/ch3/channels/common/include/mv2_clock.h mvapich2-2.1/src/mpid/ch3/channels/common/include/mv2_clock.h
+--- mvapich2-2.1.old/src/mpid/ch3/channels/common/include/mv2_clock.h	2015-04-02 22:00:25.000000000 +0100
++++ mvapich2-2.1/src/mpid/ch3/channels/common/include/mv2_clock.h	2016-09-01 17:08:26.216406038 +0100
+@@ -81,6 +81,19 @@
+     asm volatile ("mov %0=ar.itc" : "=r" (ret));
+     return ret;
+ }
++#elif defined(__aarch64__)
++typedef unsigned long long cycles_t;
++static inline cycles_t get_cycles()
++{
++    cycles_t ret;
++
++    asm volatile("    isb                \n"
++                 "    mrs %0, cntvct_el0 \n"
++                 : "=r" (ret)
++                 :
++                 : "memory");
++    return ret;
++}
+ 
+ #else
+ #warning get_cycles not implemented for this architecture: attempt asm/timex.h

--- a/components/mpi-families/mvapich2/SPECS/mvapich2.spec
+++ b/components/mpi-families/mvapich2/SPECS/mvapich2.spec
@@ -72,6 +72,7 @@ Source2:   OHPC_setup_compiler
 Patch0:    winfree.patch
 # karl.w.schulz@intel.com (04/13/2016)
 Patch1:    minit.patch
+Patch2:    mvapich2-2.1-get_cycles-aarch64.patch
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
@@ -106,6 +107,7 @@ across multiple networks.
 %setup -q -n %{pname}-%{version}
 %patch0 -p1
 %patch1 -p0
+%patch2 -p1
 
 %build
 

--- a/components/mpi-families/openmpi/SPECS/openmpi.spec
+++ b/components/mpi-families/openmpi/SPECS/openmpi.spec
@@ -44,7 +44,13 @@ BuildRequires: intel_licenses
 # Base package name
 %define pname openmpi
 %define with_openib 1
+
+%ifarch aarch64
+%define with_psm 0
+%else
 %define with_psm 1
+%endif
+
 %define with_lustre 0
 %define with_slurm 1
 

--- a/components/parallel-libs/hypre/SPECS/hypre.spec
+++ b/components/parallel-libs/hypre/SPECS/hypre.spec
@@ -128,6 +128,11 @@ phenomena in the defense, environmental, energy, and biological sciences.
 
 %build
 
+# override with newer config.guess for aarch64
+%ifarch aarch64
+cp /usr/lib/rpm/config.guess src/config
+%endif
+
 export OHPC_COMPILER_FAMILY=%{compiler_family}
 export OHPC_MPI_FAMILY=%{mpi_family}
 . %{_sourcedir}/OHPC_setup_compiler

--- a/components/parallel-libs/petsc/SPECS/petsc.spec
+++ b/components/parallel-libs/petsc/SPECS/petsc.spec
@@ -124,6 +124,9 @@ module load scalapack openblas
         --FFLAGS="-fPIC" \
         --with-blas-lapack-dir=$MKLROOT/lib/intel64 \
 %else
+        --CFLAGS="-fPIC -DPIC" \
+        --CXXFLAGS="-fPIC -DPIC" \
+        --FFLAGS="-fPIC" \
         --with-blas-lapack-lib=$OPENBLAS_LIB/libopenblas.so \
         --with-scalapack-dir=$SCALAPACK_DIR \
 %endif

--- a/components/parallel-libs/trilinos/SOURCES/Trilinos-trilinos-aarch64.patch
+++ b/components/parallel-libs/trilinos/SOURCES/Trilinos-trilinos-aarch64.patch
@@ -1,0 +1,12 @@
+diff -ruN Trilinos-trilinos-release-12-4-2.old/packages/kokkos/core/src/Kokkos_Macros.hpp Trilinos-trilinos-release-12-4-2/packages/kokkos/core/src/Kokkos_Macros.hpp
+--- Trilinos-trilinos-release-12-4-2.old/packages/kokkos/core/src/Kokkos_Macros.hpp	2015-11-12 15:57:46.000000000 +0000
++++ Trilinos-trilinos-release-12-4-2/packages/kokkos/core/src/Kokkos_Macros.hpp	2016-09-10 19:40:37.762848897 +0100
+@@ -330,6 +330,8 @@
+           defined(__POWERPC__) || \
+           defined(__ppc__) || \
+           defined(__ppc64__) || \
++          defined(__AArch64__) || \
++          defined(__aarch64__) || \
+           defined(__PGIC__) )
+     #define KOKKOS_ENABLE_ASM 1
+   #endif

--- a/components/parallel-libs/trilinos/SPECS/trilinos.spec
+++ b/components/parallel-libs/trilinos/SPECS/trilinos.spec
@@ -72,6 +72,7 @@ Url:            http://trilinos.sandia.gov/index.html
 #Source0:        http://trilinos.csbsju.edu/download/files/trilinos-%{version}-Source.tar.bz2
 Source0:        https://github.com/trilinos/Trilinos/archive/trilinos-release-12-4-2.tar.gz
 Patch0:         trilinos-11.14.3-no-return-in-non-void.patch
+Patch1:         Trilinos-trilinos-aarch64.patch
 BuildRequires:  cmake >= 2.8
 #BuildRequires:  cppunit-devel
 BuildRequires:  doxygen
@@ -113,6 +114,7 @@ Trilinos top layer providing a common look-and-feel and infrastructure.
 #%setup -q -n %{pname}-%{version}-Source
 %setup -q -n  Trilinos-trilinos-release-12-4-2
 %patch0 -p1
+%patch1 -p1
 
 %build
 # OpenHPC compiler/mpi designation

--- a/components/perf-tools/mpiP/SPECS/mpiP.spec
+++ b/components/perf-tools/mpiP/SPECS/mpiP.spec
@@ -94,6 +94,11 @@ file.
 
 %build
 
+# override with newer config.guess for aarch64
+%ifarch aarch64
+cp /usr/lib/rpm/config.guess bin
+%endif
+
 # OpenHPC compiler/mpi designation
 
 # note: in order to support call-site demangling, we compile mpiP with gnu

--- a/components/serial-libs/openblas/SOURCES/fix-arm64-cpuid-return.patch
+++ b/components/serial-libs/openblas/SOURCES/fix-arm64-cpuid-return.patch
@@ -1,0 +1,25 @@
+From 63d4fcdecd40cb9eee8228680521ff93a80a8e11 Mon Sep 17 00:00:00 2001
+From: Eric Van Hensbergen <eric.vanhensbergen@arm.com>
+Date: Tue, 23 Aug 2016 11:29:27 -0500
+Subject: [PATCH] fix-arm64-cpuid-return
+
+---
+ cpuid_arm64.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cpuid_arm64.c b/cpuid_arm64.c
+index c7a27f8..95fc708 100644
+--- a/cpuid_arm64.c
++++ b/cpuid_arm64.c
+@@ -59,7 +59,7 @@ int get_feature(char *search)
+   	fclose(infile);
+ 
+ 
+-	if( p == NULL ) return;
++	if( p == NULL ) return(0);
+ 
+ 	t = strtok(p," ");
+ 	while( t = strtok(NULL," "))
+-- 
+2.7.4
+

--- a/components/serial-libs/openblas/SPECS/openblas.spec
+++ b/components/serial-libs/openblas/SPECS/openblas.spec
@@ -108,7 +108,7 @@ export OHPC_COMPILER_FAMILY=%{compiler_family}
 %endif
 # Temporary fix, OpenBLAS does not autodetect aarch64
 %ifarch aarch64
-%define openblas_target TARGET=ARMV8
+%define openblas_target TARGET=ARMV8 NUM_THREADS=256
 %endif
 
 make    %{?openblas_target} USE_THREAD=1 USE_OPENMP=1 \

--- a/components/serial-libs/openblas/SPECS/openblas.spec
+++ b/components/serial-libs/openblas/SPECS/openblas.spec
@@ -122,7 +122,7 @@ make    %{?openblas_target} USE_THREAD=1 USE_OPENMP=1 \
 export OHPC_COMPILER_FAMILY=%{compiler_family}
 . %{_sourcedir}/OHPC_setup_compiler
 
-make   PREFIX=%{buildroot}%{install_path} install 
+make   %{?openblas_target} PREFIX=%{buildroot}%{install_path} install
 
 # Delete info about host cpu
 %ifarch %ix86 x86_64

--- a/components/serial-libs/openblas/SPECS/openblas.spec
+++ b/components/serial-libs/openblas/SPECS/openblas.spec
@@ -77,6 +77,8 @@ Patch1:         c_xerbla_no-void-return.patch
 Patch2:         openblas-noexecstack.patch
 # PATCH-FIX-UPSTREAM openblas-gemv.patch
 Patch3:         openblas-gemv.patch
+# PATCH-FIX-UPSTREADM fix-arm64-cpuid-return.patch
+Patch4:         fix-arm64-cpuid-return.patch
 BuildRoot:      %{_tmppath}/%{pname}-%{version}-build
 ExclusiveArch:  %ix86 ia64 ppc ppc64 x86_64 aarch64
 DocDir:        %{OHPC_PUB}/doc/contrib
@@ -96,6 +98,7 @@ OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version.
 %patch1 -p1
 %patch2 -p1
 %patch3 -p1
+%patch4 -p1
 
 %build
 # OpenHPC compiler/mpi designation


### PR DESCRIPTION
With these patches, aarch64 on CentOS_7.2 builds 128 successful packages.  They are predominantly configuration fixes with a single patch against openblas to fix some bad code in the arm64 support.  I regressed them against x86_64 CentOS 7.2 and SuSe 12 SP 1 with no adverse effects on package builds.

Build test results against aarch64 available in my home project: https://build.openhpc.community/project/show/home:eric:OpenHPC:1.2:Factory

This is my first time really doing any sort of packaging work with Linux, I've mostly just stuck to code before, so be gentle.  Happy to take suggestions on ways of doing things better.

Signed-off-by: Eric Van Hensbergen <eric.vanhensbergen@arm.com>