### PR TITLE
spec-File Fixes for branch OpenHPC_1.1.1_Factory

### DIFF
--- a/components/admin/clustershell/SPECS/clustershell.spec
+++ b/components/admin/clustershell/SPECS/clustershell.spec
@@ -1,7 +1,7 @@
 %{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define pname clustershell
 

--- a/components/admin/conman/SPECS/conman.spec
+++ b/components/admin/conman/SPECS/conman.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # Base package name
 %define pname conman

--- a/components/admin/docs/SPECS/docs.spec
+++ b/components/admin/docs/SPECS/docs.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 Name:           docs%{PROJ_DELIM}
 Version:        1.1.1

--- a/components/admin/examples/SPECS/examples.spec
+++ b/components/admin/examples/SPECS/examples.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 Summary: Example source code and templates for use within OpenHPC environment.
 Name:    examples%{PROJ_DELIM}

--- a/components/admin/ganglia/SPECS/ganglia.spec
+++ b/components/admin/ganglia/SPECS/ganglia.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define pname ganglia
 

--- a/components/admin/genders/SPECS/genders.spec
+++ b/components/admin/genders/SPECS/genders.spec
@@ -10,7 +10,7 @@
 %include %{_sourcedir}/OHPC_macros
 
 %define pname genders
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 Name:    %{pname}%{PROJ_DELIM}
 Version: 1.22

--- a/components/admin/lmod-defaults/SPECS/lmod-defaults.spec
+++ b/components/admin/lmod-defaults/SPECS/lmod-defaults.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %{!?compiler_family: %define compiler_family gnu}
 %{!?mpi_family: %define mpi_family openmpi}

--- a/components/admin/lmod-defaults/SPECS/lmod-defaults.spec
+++ b/components/admin/lmod-defaults/SPECS/lmod-defaults.spec
@@ -11,7 +11,7 @@
 %include %{_sourcedir}/OHPC_macros
 %{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family: %define mpi_family openmpi}
 
 Summary:   OpenHPC default login environments

--- a/components/admin/lmod-defaults/SPECS/lmod-defaults.spec
+++ b/components/admin/lmod-defaults/SPECS/lmod-defaults.spec
@@ -12,7 +12,7 @@
 %{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %{!?compiler_family: %global compiler_family gnu}
-%{!?mpi_family: %define mpi_family openmpi}
+%{!?mpi_family: %global mpi_family openmpi}
 
 Summary:   OpenHPC default login environments
 Name:      lmod-defaults-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}

--- a/components/admin/lmod/SPECS/lmod.spec
+++ b/components/admin/lmod/SPECS/lmod.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define pname lmod
 

--- a/components/admin/lmod/SPECS/lmod.spec
+++ b/components/admin/lmod/SPECS/lmod.spec
@@ -13,13 +13,22 @@
 
 %define pname lmod
 
-%if 0%{?suse_version} <= 1220
-%define luaver 5.1
+%if 0%{!?lua_version:1}
+%define luaver %lua_version
 %else
 %define luaver 5.2
 %endif
+%if 0%{!?lua_archdir:1}
 %define lualibdir %{_libdir}/lua/%{luaver}
+%else
+%define lualibdir %lua_archdir
+%endif
+%if 0%{!?lua_noarchdir:1}
 %define luapkgdir %{_datadir}/lua/%{luaver}
+%else
+%define luapkgdir %lua_noarchdir
+%endif
+
 %define LUA_CPATH ?.so;?/?.so;%{lualibdir}/?.so
 %define LUA_PATH ?.lua;?/?.lua;%{luapkgdir}/?.lua
 

--- a/components/admin/losf/SPECS/losf.spec
+++ b/components/admin/losf/SPECS/losf.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define pname losf
 

--- a/components/admin/mrsh/SPECS/mrsh.spec
+++ b/components/admin/mrsh/SPECS/mrsh.spec
@@ -11,7 +11,7 @@
 %include %{_sourcedir}/OHPC_macros
 
 %define pname mrsh
-%{!?PROJ_DELIM:%define PROJ_DELIM  -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 
 Name:    %{pname}%{PROJ_DELIM}

--- a/components/admin/nagios-plugins/SPECS/nagios-plugins.spec
+++ b/components/admin/nagios-plugins/SPECS/nagios-plugins.spec
@@ -12,7 +12,7 @@
 # %global __strip /bin/true
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # Base package name
 %define pname nagios-plugins

--- a/components/admin/nagios/SPECS/nagios.spec
+++ b/components/admin/nagios/SPECS/nagios.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # Base package name
 %define pname nagios

--- a/components/admin/ndoutils/SPECS/ndoutils.spec
+++ b/components/admin/ndoutils/SPECS/ndoutils.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # Base package name
 %define pname ndoutils

--- a/components/admin/nrpe/SPECS/nrpe.spec
+++ b/components/admin/nrpe/SPECS/nrpe.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # Base package name
 %define pname nrpe

--- a/components/admin/ohpc-release-factory/SPECS/release.spec
+++ b/components/admin/ohpc-release-factory/SPECS/release.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 Summary:  OpenHPC release files
 Name:     ohpc-release-factory

--- a/components/admin/ohpc-release-rcs/RC1/SPECS/release.spec
+++ b/components/admin/ohpc-release-rcs/RC1/SPECS/release.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define RC_VER 1
 

--- a/components/admin/ohpc-release-rcs/RC2/SPECS/release.spec
+++ b/components/admin/ohpc-release-rcs/RC2/SPECS/release.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define RC_VER 2
 

--- a/components/admin/ohpc-release/SPECS/release.spec
+++ b/components/admin/ohpc-release/SPECS/release.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 Summary:  OpenHPC release files
 Name:     ohpc-release

--- a/components/admin/pdsh/SPECS/pdsh.spec
+++ b/components/admin/pdsh/SPECS/pdsh.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define pname pdsh
 

--- a/components/admin/powerman/SPECS/powerman.spec
+++ b/components/admin/powerman/SPECS/powerman.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define pname powerman
 

--- a/components/admin/prun/SPECS/prun.spec
+++ b/components/admin/prun/SPECS/prun.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define pname prun
 

--- a/components/compiler-families/gnu-compilers/SPECS/gnu-compilers.spec
+++ b/components/compiler-families/gnu-compilers/SPECS/gnu-compilers.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define pname gnu-compilers
 

--- a/components/compiler-families/intel-compilers-devel/SPECS/intel-compilers-devel.spec
+++ b/components/compiler-families/intel-compilers-devel/SPECS/intel-compilers-devel.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define pname intel-compilers-devel
 

--- a/components/dev-tools/R/SPECS/R-base.spec
+++ b/components/dev-tools/R/SPECS/R-base.spec
@@ -276,7 +276,7 @@ EOF
 set     ModulesVersion      "%{version}"
 EOF
 
-%{__mkdir} -p %{RPM_BUILD_ROOT}/%{_docdir}
+%{__mkdir} -p %{buildroot}/%{_docdir}
 
 export NO_BRP_CHECK_RPATH true
 

--- a/components/dev-tools/R/SPECS/R-base.spec
+++ b/components/dev-tools/R/SPECS/R-base.spec
@@ -32,7 +32,7 @@
 # compiler_family variable via rpmbuild or other
 # mechanisms.
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %{!?compiler_family: %define compiler_family gnu}
 

--- a/components/dev-tools/R/SPECS/R-base.spec
+++ b/components/dev-tools/R/SPECS/R-base.spec
@@ -34,7 +34,7 @@
 %include %{_sourcedir}/OHPC_macros
 %{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).

--- a/components/dev-tools/autoconf/SPECS/autoconf.spec
+++ b/components/dev-tools/autoconf/SPECS/autoconf.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define pname autoconf
 

--- a/components/dev-tools/automake/SPECS/automake.spec
+++ b/components/dev-tools/automake/SPECS/automake.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define pname automake
 

--- a/components/dev-tools/easybuild/SPECS/easybuild.spec
+++ b/components/dev-tools/easybuild/SPECS/easybuild.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # Base package name
 %define pname easybuild

--- a/components/dev-tools/libtool/SPECS/libtool.spec
+++ b/components/dev-tools/libtool/SPECS/libtool.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define pname libtool
 

--- a/components/dev-tools/numpy/SPECS/python-numpy.spec
+++ b/components/dev-tools/numpy/SPECS/python-numpy.spec
@@ -13,7 +13,7 @@
 #-ohpc-header-comp-begin----------------------------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # OpenHPC convention: the default assumes the gnu compiler family;
 # however, this can be overridden by specifing the compiler_family

--- a/components/dev-tools/numpy/SPECS/python-numpy.spec
+++ b/components/dev-tools/numpy/SPECS/python-numpy.spec
@@ -19,7 +19,7 @@
 # however, this can be overridden by specifing the compiler_family
 # variable via rpmbuild or other mechanisms.
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).
@@ -145,7 +145,7 @@ python setup.py install --root="%{buildroot}" --prefix="%{install_path}"
 %endif
 
 # OpenHPC module file
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 %{__mkdir_p} %{buildroot}%{OHPC_MODULEDEPS}/%{compiler_family}/%{pname}
 %{__cat} << EOF > %{buildroot}/%{OHPC_MODULEDEPS}/%{compiler_family}/%{pname}/%{version}
 #%Module1.0#####################################################################

--- a/components/dev-tools/scipy/SPECS/python-scipy.spec
+++ b/components/dev-tools/scipy/SPECS/python-scipy.spec
@@ -35,7 +35,7 @@
 # variable via rpmbuild or other mechanisms.
 
 %{!?compiler_family: %global compiler_family gnu}
-%{!?mpi_family: %define mpi_family openmpi}
+%{!?mpi_family: %global mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).
@@ -196,7 +196,7 @@ find %{buildroot}%{install_path}/lib64/python2.7/site-packages/scipy/weave -type
 %fdupes %{buildroot}%{install_path}/lib64/python2.7/site-packages
 %endif
 %{!?compiler_family: %global compiler_family gnu}
-%{!?mpi_family: %define mpi_family openmpi}
+%{!?mpi_family: %global mpi_family openmpi}
 # fix executability issue
 chmod +x %{buildroot}%{install_path}/lib64/python2.7/site-packages/%{pname}/io/arff/arffread.py
 chmod +x %{buildroot}%{install_path}/lib64/python2.7/site-packages/%{pname}/special/spfun_stats.py

--- a/components/dev-tools/scipy/SPECS/python-scipy.spec
+++ b/components/dev-tools/scipy/SPECS/python-scipy.spec
@@ -34,7 +34,7 @@
 # however, this can be overridden by specifing the compiler_family
 # variable via rpmbuild or other mechanisms.
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family: %define mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
@@ -195,7 +195,7 @@ find %{buildroot}%{install_path}/lib64/python2.7/site-packages/scipy/weave -type
 %if 0%{?sles_version} || 0%{?suse_version}
 %fdupes %{buildroot}%{install_path}/lib64/python2.7/site-packages
 %endif
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family: %define mpi_family openmpi}
 # fix executability issue
 chmod +x %{buildroot}%{install_path}/lib64/python2.7/site-packages/%{pname}/io/arff/arffread.py

--- a/components/dev-tools/scipy/SPECS/python-scipy.spec
+++ b/components/dev-tools/scipy/SPECS/python-scipy.spec
@@ -28,7 +28,7 @@
 #-ohpc-header-comp-begin----------------------------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # OpenHPC convention: the default assumes the gnu compiler family;
 # however, this can be overridden by specifing the compiler_family

--- a/components/dev-tools/spack/SPECS/spack.spec
+++ b/components/dev-tools/spack/SPECS/spack.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define pname spack
 

--- a/components/dev-tools/spack/SPECS/spack.spec
+++ b/components/dev-tools/spack/SPECS/spack.spec
@@ -68,7 +68,7 @@ prepend-path   MODULEPATH   %{install_path}/modules
 
 EOF
 
-%{__mkdir} -p %{RPM_BUILD_ROOT}/%{_docdir}
+%{__mkdir} -p %{buildroot}/%{_docdir}
 
 %clean
 rm -rf $RPM_BUILD_ROOT

--- a/components/dev-tools/valgrind/SPECS/valgrind.spec
+++ b/components/dev-tools/valgrind/SPECS/valgrind.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define pname valgrind
 %define PNAME %(echo %{pname} | tr [a-z] [A-Z])

--- a/components/distro-packages/ipmiutil/SPECS/ipmiutil.spec
+++ b/components/distro-packages/ipmiutil/SPECS/ipmiutil.spec
@@ -14,7 +14,7 @@
 # Copyright (c) 2012 Andy Cress
 #
 
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define pname ipmiutil
 

--- a/components/distro-packages/lua-bit/SPECS/lua-bitop.spec
+++ b/components/distro-packages/lua-bit/SPECS/lua-bitop.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define pname lua-bit
 

--- a/components/distro-packages/lua-bit/SPECS/lua-bitop.spec
+++ b/components/distro-packages/lua-bit/SPECS/lua-bitop.spec
@@ -13,13 +13,22 @@
 
 %define pname lua-bit
 
-%if 0%{?suse_version} <= 1220
-%define luaver 5.1
+%if 0%{!?lua_version:1}
+%define luaver %lua_version
 %else
 %define luaver 5.2
 %endif
+%if 0%{!?lua_archdir:1}
 %define lualibdir %{_libdir}/lua/%{luaver}
+%else
+%define lualibdir %lua_archdir
+%endif
+%if 0%{!?lua_noarchdir:1}
 %define luapkgdir %{_datadir}/lua/%{luaver}
+%else
+%define luapkgdir %lua_noarchdir
+%endif
+
 %define debug_package %{nil}
 
 Name:           %{pname}%{PROJ_DELIM}

--- a/components/distro-packages/lua-filesystem/SPECS/lua-filesystem.spec
+++ b/components/distro-packages/lua-filesystem/SPECS/lua-filesystem.spec
@@ -30,13 +30,22 @@
 #
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
-%if 0%{?suse_version} <= 1220
-%define luaver 5.1
+%if 0%{!?lua_version:1}
+%define luaver %lua_version
 %else
 %define luaver 5.2
 %endif
+%if 0%{!?lua_archdir:1}
 %define lualibdir %{_libdir}/lua/%{luaver}
+%else
+%define lualibdir %lua_archdir
+%endif
+%if 0%{!?lua_noarchdir:1}
 %define luapkgdir %{_datadir}/lua/%{luaver}
+%else
+%define luapkgdir %lua_noarchdir
+%endif
+
 %define debug_package %{nil}
 
 %define version_exp 1_6_3

--- a/components/distro-packages/lua-filesystem/SPECS/lua-filesystem.spec
+++ b/components/distro-packages/lua-filesystem/SPECS/lua-filesystem.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define pname lua-filesystem
 

--- a/components/distro-packages/lua-posix/SPECS/luaposix.spec
+++ b/components/distro-packages/lua-posix/SPECS/luaposix.spec
@@ -13,13 +13,21 @@
 
 %define pname lua-posix
 
-%if 0%{?suse_version} <= 1220
-%define luaver 5.1
+%if 0%{!?lua_version:1}
+%define luaver %lua_version
 %else
 %define luaver 5.2
 %endif
+%if 0%{!?lua_archdir:1}
 %define lualibdir %{_libdir}/lua/%{luaver}
+%else
+%define lualibdir %lua_archdir
+%endif
+%if 0%{!?lua_noarchdir:1}
 %define luapkgdir %{_datadir}/lua/%{luaver}
+%else
+%define luapkgdir %lua_noarchdir
+%endif
 %define debug_package %{nil}
 
 Name:           %{pname}%{PROJ_DELIM}

--- a/components/distro-packages/lua-posix/SPECS/luaposix.spec
+++ b/components/distro-packages/lua-posix/SPECS/luaposix.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define pname lua-posix
 

--- a/components/distro-packages/mxml/SPECS/mxml.spec
+++ b/components/distro-packages/mxml/SPECS/mxml.spec
@@ -29,7 +29,7 @@
 #-ohpc-header-comp-begin----------------------------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 #-ohpc-header-comp-end------------------------------------------------
 

--- a/components/distro-packages/psqlodbc/SPECS/psqlODBC.spec
+++ b/components/distro-packages/psqlodbc/SPECS/psqlODBC.spec
@@ -25,7 +25,7 @@
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
 
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define pname   psqlODBC
 %define tarname psqlodbc

--- a/components/distro-packages/sigar/SPECS/sigar.spec
+++ b/components/distro-packages/sigar/SPECS/sigar.spec
@@ -8,7 +8,7 @@
 #
 #----------------------------------------------------------------------------eh-
 
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define pname sigar
 %define debug_package %{nil}

--- a/components/io-libs/adios/SPECS/adios.spec
+++ b/components/io-libs/adios/SPECS/adios.spec
@@ -18,7 +18,7 @@
 # variable via rpmbuild or other mechanisms.
 
 %{!?compiler_family: %global compiler_family gnu}
-%{!?mpi_family:      %define mpi_family openmpi}
+%{!?mpi_family:      %global mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).

--- a/components/io-libs/adios/SPECS/adios.spec
+++ b/components/io-libs/adios/SPECS/adios.spec
@@ -11,7 +11,7 @@
 #-ohpc-header-comp-begin----------------------------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # OpenHPC convention: the default assumes the gnu compiler family;
 # however, this can be overridden by specifing the compiler_family

--- a/components/io-libs/adios/SPECS/adios.spec
+++ b/components/io-libs/adios/SPECS/adios.spec
@@ -17,7 +17,7 @@
 # however, this can be overridden by specifing the compiler_family
 # variable via rpmbuild or other mechanisms.
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family:      %define mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build

--- a/components/io-libs/hdf5/SPECS/hdf5.spec
+++ b/components/io-libs/hdf5/SPECS/hdf5.spec
@@ -35,7 +35,7 @@
 # however, this can be overridden by specifing the compiler_family
 # variable via rpmbuild or other mechanisms.
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).

--- a/components/io-libs/hdf5/SPECS/hdf5.spec
+++ b/components/io-libs/hdf5/SPECS/hdf5.spec
@@ -29,7 +29,7 @@
 #-ohpc-header-comp-begin----------------------------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # OpenHPC convention: the default assumes the gnu compiler family;
 # however, this can be overridden by specifing the compiler_family

--- a/components/io-libs/netcdf-CXX/SPECS/netcdf-cxx4.spec
+++ b/components/io-libs/netcdf-CXX/SPECS/netcdf-cxx4.spec
@@ -37,7 +37,7 @@
 # compiler_family and mpi_family variables via rpmbuild or other
 # mechanisms.
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family:      %define mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build

--- a/components/io-libs/netcdf-CXX/SPECS/netcdf-cxx4.spec
+++ b/components/io-libs/netcdf-CXX/SPECS/netcdf-cxx4.spec
@@ -30,7 +30,7 @@
 #-ohpc-header-comp-begin----------------------------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # OpenHPC convention: the default assumes the gnu toolchain and openmpi
 # MPI family; however, these can be overridden by specifing the

--- a/components/io-libs/netcdf-CXX/SPECS/netcdf-cxx4.spec
+++ b/components/io-libs/netcdf-CXX/SPECS/netcdf-cxx4.spec
@@ -38,7 +38,7 @@
 # mechanisms.
 
 %{!?compiler_family: %global compiler_family gnu}
-%{!?mpi_family:      %define mpi_family openmpi}
+%{!?mpi_family:      %global mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).

--- a/components/io-libs/netcdf-Fortran/SPECS/netcdf-fortran.spec
+++ b/components/io-libs/netcdf-Fortran/SPECS/netcdf-fortran.spec
@@ -37,7 +37,7 @@
 # compiler_family and mpi_family variables via rpmbuild or other
 # mechanisms.
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family:      %define mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build

--- a/components/io-libs/netcdf-Fortran/SPECS/netcdf-fortran.spec
+++ b/components/io-libs/netcdf-Fortran/SPECS/netcdf-fortran.spec
@@ -30,7 +30,7 @@
 #-ohpc-header-comp-begin----------------------------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # OpenHPC convention: the default assumes the gnu toolchain and openmpi
 # MPI family; however, these can be overridden by specifing the

--- a/components/io-libs/netcdf-Fortran/SPECS/netcdf-fortran.spec
+++ b/components/io-libs/netcdf-Fortran/SPECS/netcdf-fortran.spec
@@ -38,7 +38,7 @@
 # mechanisms.
 
 %{!?compiler_family: %global compiler_family gnu}
-%{!?mpi_family:      %define mpi_family openmpi}
+%{!?mpi_family:      %global mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).

--- a/components/io-libs/netcdf/SPECS/netcdf.spec
+++ b/components/io-libs/netcdf/SPECS/netcdf.spec
@@ -37,7 +37,7 @@
 # compiler_family and mpi_family variables via rpmbuild or other
 # mechanisms.
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family:      %define mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build

--- a/components/io-libs/netcdf/SPECS/netcdf.spec
+++ b/components/io-libs/netcdf/SPECS/netcdf.spec
@@ -30,7 +30,7 @@
 #-ohpc-header-comp-begin----------------------------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # OpenHPC convention: the default assumes the gnu toolchain and openmpi
 # MPI family; however, these can be overridden by specifing the

--- a/components/io-libs/netcdf/SPECS/netcdf.spec
+++ b/components/io-libs/netcdf/SPECS/netcdf.spec
@@ -38,7 +38,7 @@
 # mechanisms.
 
 %{!?compiler_family: %global compiler_family gnu}
-%{!?mpi_family:      %define mpi_family openmpi}
+%{!?mpi_family:      %global mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).

--- a/components/io-libs/phdf5/SPECS/hdf5.spec
+++ b/components/io-libs/phdf5/SPECS/hdf5.spec
@@ -37,7 +37,7 @@
 # compiler_family and mpi_family variables via rpmbuild or other
 # mechanisms.
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family:      %define mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build

--- a/components/io-libs/phdf5/SPECS/hdf5.spec
+++ b/components/io-libs/phdf5/SPECS/hdf5.spec
@@ -30,7 +30,7 @@
 #-ohpc-header-comp-begin----------------------------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # OpenHPC convention: the default assumes the gnu toolchain and openmpi
 # MPI family; however, these can be overridden by specifing the

--- a/components/io-libs/phdf5/SPECS/hdf5.spec
+++ b/components/io-libs/phdf5/SPECS/hdf5.spec
@@ -38,7 +38,7 @@
 # mechanisms.
 
 %{!?compiler_family: %global compiler_family gnu}
-%{!?mpi_family:      %define mpi_family openmpi}
+%{!?mpi_family:      %global mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).

--- a/components/lustre/lustre-client/SPECS/lustre.spec
+++ b/components/lustre/lustre-client/SPECS/lustre.spec
@@ -13,7 +13,7 @@
 %if 0%{?OHPC_BUILD}
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define debug_package %{nil}
 

--- a/components/lustre/shine/SPECS/shine.spec
+++ b/components/lustre/shine/SPECS/shine.spec
@@ -1,5 +1,5 @@
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # Base package name
 %define pname shine

--- a/components/mpi-families/impi-devel/SPECS/intel-mpi.spec
+++ b/components/mpi-families/impi-devel/SPECS/intel-mpi.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define compiler_family intel
 

--- a/components/mpi-families/mvapich2/SPECS/mvapich2.spec
+++ b/components/mpi-families/mvapich2/SPECS/mvapich2.spec
@@ -22,7 +22,7 @@
 # however, this can be overridden by specifing the compiler_family
 # variable via rpmbuild or other mechanisms.
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).

--- a/components/mpi-families/mvapich2/SPECS/mvapich2.spec
+++ b/components/mpi-families/mvapich2/SPECS/mvapich2.spec
@@ -16,7 +16,7 @@
 #-ohpc-header-comp-begin----------------------------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # OpenHPC convention: the default assumes the gnu compiler family;
 # however, this can be overridden by specifing the compiler_family

--- a/components/mpi-families/openmpi/SPECS/openmpi.spec
+++ b/components/mpi-families/openmpi/SPECS/openmpi.spec
@@ -13,7 +13,7 @@
 #-ohpc-header-comp-begin----------------------------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # OpenHPC convention: the default assumes the gnu compiler family;
 # however, this can be overridden by specifing the compiler_family

--- a/components/mpi-families/openmpi/SPECS/openmpi.spec
+++ b/components/mpi-families/openmpi/SPECS/openmpi.spec
@@ -19,7 +19,7 @@
 # however, this can be overridden by specifing the compiler_family
 # variable via rpmbuild or other mechanisms.
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).

--- a/components/parallel-libs/boost/SPECS/boost.spec
+++ b/components/parallel-libs/boost/SPECS/boost.spec
@@ -36,7 +36,7 @@
 # compiler_family and mpi_family variables via rpmbuild or other
 # mechanisms.
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family:      %define mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build

--- a/components/parallel-libs/boost/SPECS/boost.spec
+++ b/components/parallel-libs/boost/SPECS/boost.spec
@@ -37,7 +37,7 @@
 # mechanisms.
 
 %{!?compiler_family: %global compiler_family gnu}
-%{!?mpi_family:      %define mpi_family openmpi}
+%{!?mpi_family:      %global mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).

--- a/components/parallel-libs/boost/SPECS/boost.spec
+++ b/components/parallel-libs/boost/SPECS/boost.spec
@@ -29,7 +29,7 @@
 #-ohpc-header-comp-begin----------------------------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # OpenHPC convention: the default assumes the gnu toolchain and openmpi
 # MPI family; however, these can be overridden by specifing the

--- a/components/parallel-libs/fftw/SPECS/fftw.spec
+++ b/components/parallel-libs/fftw/SPECS/fftw.spec
@@ -20,7 +20,7 @@
 # compiler_family and mpi_family variables via rpmbuild or other
 # mechanisms.
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family:      %define mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build

--- a/components/parallel-libs/fftw/SPECS/fftw.spec
+++ b/components/parallel-libs/fftw/SPECS/fftw.spec
@@ -21,7 +21,7 @@
 # mechanisms.
 
 %{!?compiler_family: %global compiler_family gnu}
-%{!?mpi_family:      %define mpi_family openmpi}
+%{!?mpi_family:      %global mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).

--- a/components/parallel-libs/fftw/SPECS/fftw.spec
+++ b/components/parallel-libs/fftw/SPECS/fftw.spec
@@ -13,7 +13,7 @@
 #-ohpc-header-comp-begin----------------------------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # OpenHPC convention: the default assumes the gnu toolchain and openmpi
 # MPI family; however, these can be overridden by specifing the

--- a/components/parallel-libs/hypre/SPECS/hypre.spec
+++ b/components/parallel-libs/hypre/SPECS/hypre.spec
@@ -36,7 +36,7 @@
 # mechanisms.
 
 %{!?compiler_family: %global compiler_family gnu}
-%{!?mpi_family:      %define mpi_family openmpi}
+%{!?mpi_family:      %global mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).

--- a/components/parallel-libs/hypre/SPECS/hypre.spec
+++ b/components/parallel-libs/hypre/SPECS/hypre.spec
@@ -35,7 +35,7 @@
 # compiler_family and mpi_family variables via rpmbuild or other
 # mechanisms.
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family:      %define mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build

--- a/components/parallel-libs/hypre/SPECS/hypre.spec
+++ b/components/parallel-libs/hypre/SPECS/hypre.spec
@@ -28,7 +28,7 @@
 #-ohpc-header-comp-begin-----------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # OpenHPC convention: the default assumes the gnu toolchain and openmpi
 # MPI family; however, these can be overridden by specifing the

--- a/components/parallel-libs/mumps/SPECS/mumps.spec
+++ b/components/parallel-libs/mumps/SPECS/mumps.spec
@@ -36,7 +36,7 @@
 # mechanisms.
 
 %{!?compiler_family: %global compiler_family gnu}
-%{!?mpi_family:      %define mpi_family openmpi}
+%{!?mpi_family:      %global mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).

--- a/components/parallel-libs/mumps/SPECS/mumps.spec
+++ b/components/parallel-libs/mumps/SPECS/mumps.spec
@@ -35,7 +35,7 @@
 # compiler_family and mpi_family variables via rpmbuild or other
 # mechanisms.
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family:      %define mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build

--- a/components/parallel-libs/mumps/SPECS/mumps.spec
+++ b/components/parallel-libs/mumps/SPECS/mumps.spec
@@ -28,7 +28,7 @@
 #-ohpc-header-comp-begin-----------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # OpenHPC convention: the default assumes the gnu toolchain and openmpi
 # MPI family; however, these can be overridden by specifing the

--- a/components/parallel-libs/petsc/SPECS/petsc.spec
+++ b/components/parallel-libs/petsc/SPECS/petsc.spec
@@ -13,7 +13,7 @@
 #-ohpc-header-comp-begin-----------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # OpenHPC convention: the default assumes the gnu toolchain and openmpi
 # MPI family; however, these can be overridden by specifing the

--- a/components/parallel-libs/petsc/SPECS/petsc.spec
+++ b/components/parallel-libs/petsc/SPECS/petsc.spec
@@ -20,7 +20,7 @@
 # compiler_family and mpi_family variables via rpmbuild or other
 # mechanisms.
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family:      %define mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build

--- a/components/parallel-libs/petsc/SPECS/petsc.spec
+++ b/components/parallel-libs/petsc/SPECS/petsc.spec
@@ -21,7 +21,7 @@
 # mechanisms.
 
 %{!?compiler_family: %global compiler_family gnu}
-%{!?mpi_family:      %define mpi_family openmpi}
+%{!?mpi_family:      %global mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).

--- a/components/parallel-libs/scalapack/SPECS/scalapack.spec
+++ b/components/parallel-libs/scalapack/SPECS/scalapack.spec
@@ -36,7 +36,7 @@
 # mechanisms.
 
 %{!?compiler_family: %global compiler_family gnu}
-%{!?mpi_family:      %define mpi_family openmpi}
+%{!?mpi_family:      %global mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).

--- a/components/parallel-libs/scalapack/SPECS/scalapack.spec
+++ b/components/parallel-libs/scalapack/SPECS/scalapack.spec
@@ -35,7 +35,7 @@
 # compiler_family and mpi_family variables via rpmbuild or other
 # mechanisms.
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family:      %define mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build

--- a/components/parallel-libs/scalapack/SPECS/scalapack.spec
+++ b/components/parallel-libs/scalapack/SPECS/scalapack.spec
@@ -28,7 +28,7 @@
 #-ohpc-header-comp-begin-----------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # OpenHPC convention: the default assumes the gnu toolchain and openmpi
 # MPI family; however, these can be overridden by specifing the

--- a/components/parallel-libs/superlu_dist/SPECS/superlu_dist.spec
+++ b/components/parallel-libs/superlu_dist/SPECS/superlu_dist.spec
@@ -36,7 +36,7 @@
 # mechanisms.
 
 %{!?compiler_family: %global compiler_family gnu}
-%{!?mpi_family:      %define mpi_family openmpi}
+%{!?mpi_family:      %global mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).

--- a/components/parallel-libs/superlu_dist/SPECS/superlu_dist.spec
+++ b/components/parallel-libs/superlu_dist/SPECS/superlu_dist.spec
@@ -35,7 +35,7 @@
 # compiler_family and mpi_family variables via rpmbuild or other
 # mechanisms.
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family:      %define mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build

--- a/components/parallel-libs/superlu_dist/SPECS/superlu_dist.spec
+++ b/components/parallel-libs/superlu_dist/SPECS/superlu_dist.spec
@@ -28,7 +28,7 @@
 #-ohpc-header-comp-begin-----------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # OpenHPC convention: the default assumes the gnu toolchain and openmpi
 # MPI family; however, these can be overridden by specifing the

--- a/components/parallel-libs/trilinos/SPECS/trilinos.spec
+++ b/components/parallel-libs/trilinos/SPECS/trilinos.spec
@@ -13,7 +13,7 @@
 #-ohpc-header-comp-begin-----------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # OpenHPC convention: the default assumes the gnu toolchain and openmpi
 # MPI family; however, these can be overridden by specifing the

--- a/components/parallel-libs/trilinos/SPECS/trilinos.spec
+++ b/components/parallel-libs/trilinos/SPECS/trilinos.spec
@@ -20,7 +20,7 @@
 # compiler_family and mpi_family variables via rpmbuild or other
 # mechanisms.
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family:      %define mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build

--- a/components/parallel-libs/trilinos/SPECS/trilinos.spec
+++ b/components/parallel-libs/trilinos/SPECS/trilinos.spec
@@ -21,7 +21,7 @@
 # mechanisms.
 
 %{!?compiler_family: %global compiler_family gnu}
-%{!?mpi_family:      %define mpi_family openmpi}
+%{!?mpi_family:      %global mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).

--- a/components/perf-tools/cube/SOURCES/rpmlintrc
+++ b/components/perf-tools/cube/SOURCES/rpmlintrc
@@ -1,3 +1,5 @@
 addFilter("devel-file-in-non-devel-package")
 addFilter("suse-filelist-forbidden-backup-file")
 addFilter("buildroot")
+addFilter("library-without-ldconfig-postun")
+addFilter("library-without-ldconfig-postin")

--- a/components/perf-tools/imb/SPECS/imb.spec
+++ b/components/perf-tools/imb/SPECS/imb.spec
@@ -20,7 +20,7 @@
 # compiler_family and mpi_family variables via rpmbuild or other
 # mechanisms.
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family:      %define mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build

--- a/components/perf-tools/imb/SPECS/imb.spec
+++ b/components/perf-tools/imb/SPECS/imb.spec
@@ -21,7 +21,7 @@
 # mechanisms.
 
 %{!?compiler_family: %global compiler_family gnu}
-%{!?mpi_family:      %define mpi_family openmpi}
+%{!?mpi_family:      %global mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).

--- a/components/perf-tools/imb/SPECS/imb.spec
+++ b/components/perf-tools/imb/SPECS/imb.spec
@@ -13,7 +13,7 @@
 #-ohpc-header-comp-begin----------------------------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # OpenHPC convention: the default assumes the gnu toolchain and openmpi
 # MPI family; however, these can be overridden by specifing the

--- a/components/perf-tools/mpiP/SPECS/mpiP.spec
+++ b/components/perf-tools/mpiP/SPECS/mpiP.spec
@@ -20,7 +20,7 @@
 # mechanisms.
 
 %{!?compiler_family: %global compiler_family gnu}
-%{!?mpi_family:      %define mpi_family openmpi}
+%{!?mpi_family:      %global mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).

--- a/components/perf-tools/mpiP/SPECS/mpiP.spec
+++ b/components/perf-tools/mpiP/SPECS/mpiP.spec
@@ -12,7 +12,7 @@
 #-ohpc-header-comp-begin----------------------------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # OpenHPC convention: the default assumes the gnu toolchain and openmpi
 # MPI family; however, these can be overridden by specifing the

--- a/components/perf-tools/mpiP/SPECS/mpiP.spec
+++ b/components/perf-tools/mpiP/SPECS/mpiP.spec
@@ -19,7 +19,7 @@
 # compiler_family and mpi_family variables via rpmbuild or other
 # mechanisms.
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family:      %define mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build

--- a/components/perf-tools/papi/SPECS/papi.spec
+++ b/components/perf-tools/papi/SPECS/papi.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # Base package name
 %define pname papi

--- a/components/perf-tools/pdtoolkit/SPECS/pdtoolkit.spec
+++ b/components/perf-tools/pdtoolkit/SPECS/pdtoolkit.spec
@@ -16,7 +16,7 @@
 # compiler_family variable via rpmbuild or other
 # mechanisms.
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family:      %define mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build

--- a/components/perf-tools/pdtoolkit/SPECS/pdtoolkit.spec
+++ b/components/perf-tools/pdtoolkit/SPECS/pdtoolkit.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # OpenHPC convention: the default assumes the gnu toolchain and openmpi
 # MPI family; however, these can be overridden by specifing the

--- a/components/perf-tools/pdtoolkit/SPECS/pdtoolkit.spec
+++ b/components/perf-tools/pdtoolkit/SPECS/pdtoolkit.spec
@@ -17,7 +17,7 @@
 # mechanisms.
 
 %{!?compiler_family: %global compiler_family gnu}
-%{!?mpi_family:      %define mpi_family openmpi}
+%{!?mpi_family:      %global mpi_family openmpi}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).

--- a/components/perf-tools/tau/SPECS/tau.spec
+++ b/components/perf-tools/tau/SPECS/tau.spec
@@ -17,7 +17,7 @@
 
 %{!?compiler_family: %define compiler_family gnu}
 %{!?mpi_family: %define mpi_family openmpi}
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).

--- a/components/perf-tools/tau/SPECS/tau.spec
+++ b/components/perf-tools/tau/SPECS/tau.spec
@@ -15,7 +15,7 @@
 # compiler_family variable via rpmbuild or other
 # mechanisms.
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family: %define mpi_family openmpi}
 %{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 

--- a/components/perf-tools/tau/SPECS/tau.spec
+++ b/components/perf-tools/tau/SPECS/tau.spec
@@ -16,7 +16,7 @@
 # mechanisms.
 
 %{!?compiler_family: %global compiler_family gnu}
-%{!?mpi_family: %define mpi_family openmpi}
+%{!?mpi_family: %global mpi_family openmpi}
 %{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build

--- a/components/provisioning/warewulf-cluster/SPECS/warewulf-cluster.spec
+++ b/components/provisioning/warewulf-cluster/SPECS/warewulf-cluster.spec
@@ -11,7 +11,7 @@
 %{!?_rel:%{expand:%%global _rel 0.r%(test "1547" != "0000" && echo "1547" || svnversion | sed 's/[^0-9].*$//' | grep '^[0-9][0-9]*$' || echo 0000)}}
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define pname warewulf-cluster
 

--- a/components/provisioning/warewulf-common/SPECS/warewulf-common.spec
+++ b/components/provisioning/warewulf-common/SPECS/warewulf-common.spec
@@ -13,7 +13,7 @@
 %define wwpkgdir /srv/
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define pname warewulf-common
 

--- a/components/provisioning/warewulf-ipmi/SPECS/warewulf-ipmi.spec
+++ b/components/provisioning/warewulf-ipmi/SPECS/warewulf-ipmi.spec
@@ -11,7 +11,7 @@
 %{!?_rel:%{expand:%%global _rel 0.r%(test "1686" != "0000" && echo "1686" || svnversion | sed 's/[^0-9].*$//' | grep '^[0-9][0-9]*$' || git svn find-rev `git show -s --pretty=format:%h` || echo 0000)}}
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define pname warewulf-ipmi
 %define debug_package %{nil}

--- a/components/provisioning/warewulf-nhc/SPECS/warewulf-nhc.spec
+++ b/components/provisioning/warewulf-nhc/SPECS/warewulf-nhc.spec
@@ -11,7 +11,7 @@
 %{!?_rel:%{expand:%%global _rel 0.r%(test "1723" != "0000" && echo "1723" || svnversion | sed 's/[^0-9].*$//' | grep '^[0-9][0-9]*$' || git svn find-rev `git show -s --pretty=format:%h` || echo 0000)}}
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define pname warewulf-nhc
 %define sname nhc

--- a/components/provisioning/warewulf-provision/SPECS/warewulf-provision.spec
+++ b/components/provisioning/warewulf-provision/SPECS/warewulf-provision.spec
@@ -11,7 +11,7 @@
 %{!?_rel:%{expand:%%global _rel 0.r%(test "1686" != "0000" && echo "1686" || svnversion | sed 's/[^0-9].*$//' | grep '^[0-9][0-9]*$' || git svn find-rev `git show -s --pretty=format:%h` || echo 0000)}}
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define debug_package %{nil}
 %define wwpkgdir /srv/warewulf

--- a/components/provisioning/warewulf-vnfs/SPECS/warewulf-vnfs.spec
+++ b/components/provisioning/warewulf-vnfs/SPECS/warewulf-vnfs.spec
@@ -11,7 +11,7 @@
 %{!?_rel:%{expand:%%global _rel 0.r%(test "1686" != "0000" && echo "1686" || svnversion | sed 's/[^0-9].*$//' | grep '^[0-9][0-9]*$' || git svn find-rev `git show -s --pretty=format:%h` || echo 0000)}}
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define debug_package %{nil}
 

--- a/components/rms/munge/SPECS/munge.spec
+++ b/components/rms/munge/SPECS/munge.spec
@@ -30,6 +30,9 @@ Provides:       %{pname} = %{version}-%{release}
 BuildRequires:	libbz2-devel
 BuildRequires:	libopenssl-devel
 BuildRequires:	zlib-devel
+%if 0%{?suse_version} >= 1230
+BuildRequires:	systemd
+%endif
 %else
 %if 0%{?sles_version} || 0%{?suse_version}
 BuildRequires:	bzip2
@@ -239,7 +242,7 @@ fi
 %{_mandir}/*[^3]/*
 
 
-%if 0%{?rhel_version} > 600 || 0%{?centos_version} > 600
+%if 0%{?suse_version} >= 1230 || 0%{?rhel_version} > 600 || 0%{?centos_version} > 600
 %{_prefix}/lib/tmpfiles.d/munge.conf
 %endif
 

--- a/components/rms/munge/SPECS/munge.spec
+++ b/components/rms/munge/SPECS/munge.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define pname munge
 

--- a/components/rms/pmix/SPECS/pmix.spec
+++ b/components/rms/pmix/SPECS/pmix.spec
@@ -42,7 +42,7 @@
 %include %{_sourcedir}/OHPC_macros
 
 %define pname pmix
-%{!?PROJ_DELIM: %define PROJ_DELIM %{nil}}
+%{!?PROJ_DELIM: %global PROJ_DELIM %{nil}}
 
 #############################################################################
 #

--- a/components/rms/slurm/SPECS/slurm.spec
+++ b/components/rms/slurm/SPECS/slurm.spec
@@ -10,7 +10,7 @@
 
 %include %{_sourcedir}/OHPC_macros
 %include %{_sourcedir}/rpmmacros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 %define pname slurm
 

--- a/components/serial-libs/gsl/SPECS/gsl.spec
+++ b/components/serial-libs/gsl/SPECS/gsl.spec
@@ -13,7 +13,7 @@
 #-ohpc-header-comp-begin----------------------------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # OpenHPC convention: the default assumes the gnu compiler family;
 # however, this can be overridden by specifing the compiler_family

--- a/components/serial-libs/gsl/SPECS/gsl.spec
+++ b/components/serial-libs/gsl/SPECS/gsl.spec
@@ -138,7 +138,7 @@ EOF
 set     ModulesVersion      "%{version}"
 EOF
 
-%{__mkdir} -p %{RPM_BUILD_ROOT}/%{_docdir}
+%{__mkdir} -p %{buildroot}/%{_docdir}
 
 %clean
 rm -rf $RPM_BUILD_ROOT

--- a/components/serial-libs/gsl/SPECS/gsl.spec
+++ b/components/serial-libs/gsl/SPECS/gsl.spec
@@ -19,7 +19,7 @@
 # however, this can be overridden by specifing the compiler_family
 # variable via rpmbuild or other mechanisms.
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).

--- a/components/serial-libs/metis/SPECS/metis.spec
+++ b/components/serial-libs/metis/SPECS/metis.spec
@@ -19,7 +19,7 @@
 # however, this can be overridden by specifing the compiler_family
 # variable via rpmbuild or other mechanisms.
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).

--- a/components/serial-libs/metis/SPECS/metis.spec
+++ b/components/serial-libs/metis/SPECS/metis.spec
@@ -11,7 +11,7 @@
 # Serial metis build dependent on compiler toolchain
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 #-ohpc-header-comp-begin-----------------------------
 

--- a/components/serial-libs/openblas/SPECS/openblas.spec
+++ b/components/serial-libs/openblas/SPECS/openblas.spec
@@ -28,7 +28,7 @@
 #-ohpc-header-comp-begin-----------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # OpenHPC convention: the default assumes the gnu toolchain and openmpi
 # MPI family; however, these can be overridden by specifing the

--- a/components/serial-libs/openblas/SPECS/openblas.spec
+++ b/components/serial-libs/openblas/SPECS/openblas.spec
@@ -35,7 +35,7 @@
 # compiler_family and mpi_family variables via rpmbuild or other
 # mechanisms.
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).

--- a/components/serial-libs/superlu/SPECS/superlu.spec
+++ b/components/serial-libs/superlu/SPECS/superlu.spec
@@ -28,7 +28,7 @@
 #-ohpc-header-comp-begin-----------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %define PROJ_DELIM -ohpc}
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # OpenHPC convention: the default assumes the gnu toolchain and openmpi
 # MPI family; however, these can be overridden by specifing the

--- a/components/serial-libs/superlu/SPECS/superlu.spec
+++ b/components/serial-libs/superlu/SPECS/superlu.spec
@@ -35,7 +35,7 @@
 # compiler_family and mpi_family variables via rpmbuild or other
 # mechanisms.
 
-%{!?compiler_family: %define compiler_family gnu}
+%{!?compiler_family: %global compiler_family gnu}
 
 # Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
 # environment; if building outside, lmod remains a formal build dependency).


### PR DESCRIPTION
These fixes address the following issues:
1. munge: */lib/tmpfiles.d/munge.conf neither gets built nor installed
   on SUSE.
2. Macro definitions like %{!?foo: %define foo bar} should be avoided
   due to the scoping rules for rpm macros. a '%global' should be used
   instead of the '%define'. This affects %PROJ_DELIM, %compiler_family
   and %mpi_family
3. A macro %{RPM_BUILD_ROOT} does not exist. Either it is the shell variable
   ${RPM_BUILD_ROOT} or the macro %{buildroot}: this affected the packages 
   'R', 'spack' and 'gsl'.
4. An rpmlint check in 'cube' for running ldconfig in the %post and %postun
   scripts thru errors and raised the error level above the threshold.
   Since this package uses lmod to set up the environment, ldconfig should
   not be needed.
