### PR TITLE
easybuild: update patch after version bump

### DIFF
--- a/components/dev-tools/easybuild/SOURCES/bootstrap_eb.py-apply-patch.patch
+++ b/components/dev-tools/easybuild/SOURCES/bootstrap_eb.py-apply-patch.patch
@@ -1,19 +1,20 @@
---- bootstrap_eb.py.old	2016-09-06 20:44:41.000000000 +0100
-+++ bootstrap_eb.py	2016-09-06 20:45:42.000000000 +0100
-@@ -68,6 +68,7 @@
+--- bootstrap_eb.py.old	2016-10-12 18:18:06.000000000 +0100
++++ bootstrap_eb.py	2016-10-13 11:44:18.000000000 +0100
+@@ -69,6 +69,8 @@
  
  EASYBUILD_BOOTSTRAP_SOURCEPATH = os.environ.pop('EASYBUILD_BOOTSTRAP_SOURCEPATH', None)
  EASYBUILD_BOOTSTRAP_SKIP_STAGE0 = os.environ.pop('EASYBUILD_BOOTSTRAP_SKIP_STAGE0', False)
++EASYBUILD_VERSION = os.environ.pop('EASYBUILD_VERSION', None)
 +PYTHON_VERSION = os.environ.pop('PYTHON_VERSION', None)
  
  # keep track of original environment (after clearing PYTHONPATH)
  orig_os_environ = copy.deepcopy(os.environ)
-@@ -488,6 +489,9 @@
+@@ -489,6 +491,9 @@
      # STAGE 1: install EasyBuild using easy_install to tmp dir
      templates = stage1(tmpdir, sourcepath)
  
 +    # Apply 'non-x86' patch
-+    os.system("cd %s/eb_stage1/lib/python%s/site-packages/easybuild_easyblocks-2.5.0-py%s.egg/easybuild/easyblocks; patch -p3 < %s/easybuild-easyblocks_non-x86.patch" % (tmpdir, PYTHON_VERSION, PYTHON_VERSION, sourcepath))
++    os.system("cd %s/eb_stage1/lib/python%s/site-packages/easybuild_easyblocks-%s-py%s.egg/easybuild/easyblocks; patch -p3 < %s/easybuild-easyblocks_non-x86.patch" % (tmpdir, PYTHON_VERSION, EASYBUILD_VERSION, PYTHON_VERSION, sourcepath))
 +
      # STAGE 2: install EasyBuild using EasyBuild (to final target installation dir)
      stage2(tmpdir, templates, install_path, distribute_egg_dir, sourcepath)

--- a/components/dev-tools/easybuild/SPECS/easybuild.spec
+++ b/components/dev-tools/easybuild/SPECS/easybuild.spec
@@ -72,6 +72,7 @@ patch -p0 < %{_sourcedir}/bootstrap_eb.py-apply-patch.patch
 export EASYBUILD_BOOTSTRAP_SKIP_STAGE0=1
 export EASYBUILD_BOOTSTRAP_SOURCEPATH=%{_sourcedir}
 export EASYBUILD_INSTALLPATH=%{install_path}
+export EASYBUILD_VERSION=%{version}
 export PATH=${LMOD_DIR}:${PATH}
 export PYTHON_VERSION=`python -c 'print ".".join(map(str, __import__("sys").version_info[:2]))'`
 

--- a/components/perf-tools/tau/SPECS/tau.spec
+++ b/components/perf-tools/tau/SPECS/tau.spec
@@ -26,6 +26,7 @@ BuildRequires: lmod%{PROJ_DELIM}
 %endif
 # Compiler dependencies
 BuildRequires: coreutils
+BuildRequires: wget
 %if %{compiler_family} == gnu
 BuildRequires: gnu-compilers%{PROJ_DELIM}
 Requires:      gnu-compilers%{PROJ_DELIM}


### PR DESCRIPTION
Currently used easybuild fix fails silently to apply non-x86 patch causing false positive. This fix is less version dependent.

Signed-off-by: Paul Osmialowski <pawel.osmialowski@arm.com>