### PR TITLE
impi: Adjust version parsing to deal with spaces

### DIFF
--- a/components/mpi-families/impi-devel/SPECS/intel-mpi.spec
+++ b/components/mpi-families/impi-devel/SPECS/intel-mpi.spec
@@ -64,7 +64,7 @@ if [ -d ${topDir} ];then
 
     for dir in ${versions}; do
 	if [ -e ${topDir}/${dir}/linux/mpi/intel64/bin/mpiicc ];then
-	    version=`grep "^MPIVERSION=" ${topDir}/${dir}/linux/mpi/intel64/bin/mpiicc | cut -d '"' -f2`
+	    version=`grep "^MPIVERSION=" ${topDir}/${dir}/linux/mpi/intel64/bin/mpiicc | cut -d '"' -f2 | sed 's| Update |\.|'`
 	    if [ -z "${version}" ];then
 		echo "Error: unable to determine MPI version"
 		exit 1


### PR DESCRIPTION
This makes the version parsing replace " Update " with "." to prevent
spaces in generated module file names, which breaks other module
infrastructure.  This is specifically to address a problem with the impi
shipped with Parallel Studio Cluster Edition 2017 Update 1, in which
the version retrieved for automatic module file creation  was
"2017 Update 1". This now becomes "2017.1" thus resulting in a more
sensible module file name that doesn't break the remaining module
infrastructure..