### PR TITLE
enable hwloc support in slurm

### DIFF
--- a/components/rms/slurm/SPECS/slurm.spec
+++ b/components/rms/slurm/SPECS/slurm.spec
@@ -135,6 +135,7 @@ BuildConflicts: post-build-checks
 %ifos linux
 BuildRequires: python
 %endif
+BuildRequires: hwloc-devel
 
 %ifos solaris
 Requires:	SUNWgnome-base-libs


### PR DESCRIPTION
This is used by the task/cgroup plugin, by xpuinfo and by pmix (if enabled)