### PR TITLE
Add support to build openHPC packages with different gnu compilers versions

### DIFF
--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -24,6 +24,7 @@ BuildRequires: ohpc-buildroot
 
 # Set the compiler to devtoolset-6 if it is on a RHEL 7 system
 %if 0%{?rhel} == 7
+	%{!?compiler_family: %global compiler_family dts6}
 	# OBS define's rhel_version to 700 for RHEL, in case we are
 	# not running in OBS
 	%global rhel_version 700
@@ -47,7 +48,16 @@ Requires:      gcc-c++ intel-compilers-devel%{PROJ_DELIM} \
 BuildRequires: intel_licenses \
 	%endif \
 	%endif \
-}
+	%if "%{compiler_family}" == "dts6" \
+BuildRequires: devtoolset-6 \
+Requires:      devtoolset-6 \
+BuildRequires: gnu-dts6-compilers%{PROJ_DELIM} \
+Requires:      gnu-dts6-compilers%{PROJ_DELIM} \
+	%endif \
+	%if "%{compiler_family}" == "gnu7" \
+BuildRequires: gnu-7-compilers%{PROJ_DELIM} \
+Requires:      gnu-7-compilers%{PROJ_DELIM} \
+	%endif
 
 %global ohpc_setup_compiler %{expand:\
 	. %{OHPC_ADMIN}/ohpc/OHPC_setup_compiler %{compiler_family} \

--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -20,7 +20,9 @@ DocDir:    %{OHPC_PUB}/doc/contrib
 Requires: ohpc-filesystem
 # All openHPC need ohpc-buildroot during build as it pulls in required
 # build depenencies and also provides the compiler and mpi setup scripts
+%if 0%{?ohpc_bootstrap} == 0
 BuildRequires: ohpc-buildroot
+%endif
 
 # Set the compiler to devtoolset-6 if it is on a RHEL 7 system
 %if 0%{?rhel} == 7

--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -10,4 +10,45 @@
 %global OHPC_MODULES    %{OHPC_PUB}/modulefiles
 %global OHPC_MODULEDEPS %{OHPC_PUB}/moduledeps
 %global debug_package   %{nil}
+%global dist            .ohpc.1.3
 
+%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
+
+DocDir:    %{OHPC_PUB}/doc/contrib
+
+# All openHPC package require ohpc-filesystem for the basic FS layout
+Requires: ohpc-filesystem
+# All openHPC need ohpc-buildroot during build as it pulls in required
+# build depenencies and also provides the compiler and mpi setup scripts
+BuildRequires: ohpc-buildroot
+
+# Set the compiler to devtoolset-6 if it is on a RHEL 7 system
+%if 0%{?rhel} == 7
+	# OBS define's rhel_version to 700 for RHEL, in case we are
+	# not running in OBS
+	%global rhel_version 700
+%endif
+
+# OpenHPC convention: the default assumes the gnu compiler family;
+# however, this can be overridden by specifing the compiler_family
+# variable via rpmbuild or other mechanisms.
+
+%{!?compiler_family: %global compiler_family gnu}
+
+%global ohpc_compiler() \
+	%if "%{compiler_family}" == "gnu" \
+BuildRequires: gnu-compilers%{PROJ_DELIM} \
+Requires:      gnu-compilers%{PROJ_DELIM} \
+	%endif \
+	%if "%{compiler_family}" == "intel" \
+BuildRequires: gcc-c++ intel-compilers-devel%{PROJ_DELIM} \
+Requires:      gcc-c++ intel-compilers-devel%{PROJ_DELIM} \
+	%if 0%{OHPC_BUILD} \
+BuildRequires: intel_licenses \
+	%endif \
+	%endif \
+}
+
+%global ohpc_setup_compiler %{expand:\
+	. %{OHPC_ADMIN}/ohpc/OHPC_setup_compiler %{compiler_family} \
+}

--- a/components/OHPC_setup_compiler
+++ b/components/OHPC_setup_compiler
@@ -13,7 +13,14 @@ if [ "$OHPC_COMPILER_FAMILY" = "gnu" ]; then
     export FC=gfortran
     export F77=gfortran
     module purge
-    module load gnu
+    module load gnu/5.4.0
+elif [ "$OHPC_COMPILER_FAMILY" = "gnu7" ]; then
+    export CC=gcc
+    export CXX=g++
+    export FC=gfortran
+    export F77=gfortran
+    module purge
+    module load gnu/7.1.0
 elif [ "$OHPC_COMPILER_FAMILY" = "intel" ]; then
     export CC=icc
     export CXX=icpc
@@ -21,6 +28,16 @@ elif [ "$OHPC_COMPILER_FAMILY" = "intel" ]; then
     export F77=ifort
     module purge
     module load intel
+elif [ "$OHPC_COMPILER_FAMILY" = "dts6" ]; then
+    # dts is the devtoolset-6 software collection
+    # on top of CentOS7/RHEL7 which brings gcc 6.2.1
+    # http://mirror.centos.org/centos/7/sclo/$basearch/rh/
+    export CC=gcc
+    export CXX=g++
+    export FC=gfortran
+    export F77=gfortran
+    module purge
+    module load gnu/6
 else
     echo "Unsupported OHPC_COMPILER_FAMILY -> $OHPC_COMPILER_FAMILY"
     exit 1

--- a/components/OHPC_setup_compiler
+++ b/components/OHPC_setup_compiler
@@ -1,3 +1,7 @@
+if [ "$#" = "1" ]; then
+    OHPC_COMPILER_FAMILY=$1
+fi
+
 if [ -z "$OHPC_COMPILER_FAMILY" ]; then
     echo "Unknown OHPC_COMPILER_FAMILY"
     exit 1

--- a/components/OHPC_setup_compiler
+++ b/components/OHPC_setup_compiler
@@ -7,6 +7,7 @@ if [ -z "$OHPC_COMPILER_FAMILY" ]; then
     exit 1
 fi
 
+export toolset=gcc
 if [ "$OHPC_COMPILER_FAMILY" = "gnu" ]; then
     export CC=gcc
     export CXX=g++
@@ -22,6 +23,7 @@ elif [ "$OHPC_COMPILER_FAMILY" = "gnu7" ]; then
     module purge
     module load gnu/7.1.0
 elif [ "$OHPC_COMPILER_FAMILY" = "intel" ]; then
+    export toolset=intel-linux
     export CC=icc
     export CXX=icpc
     export FC=ifort
@@ -42,6 +44,3 @@ else
     echo "Unsupported OHPC_COMPILER_FAMILY -> $OHPC_COMPILER_FAMILY"
     exit 1
 fi
-
-
-

--- a/components/admin/lmod/SPECS/lmod.spec
+++ b/components/admin/lmod/SPECS/lmod.spec
@@ -8,6 +8,8 @@
 #
 #----------------------------------------------------------------------------eh-
 
+%global ohpc_bootstrap 1
+
 %include %{_sourcedir}/OHPC_macros
 %{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 

--- a/components/admin/ohpc-filesystem/SOURCES/OHPC_setup_compiler
+++ b/components/admin/ohpc-filesystem/SOURCES/OHPC_setup_compiler
@@ -1,0 +1,1 @@
+../../../OHPC_setup_compiler

--- a/components/admin/ohpc-filesystem/SOURCES/OHPC_setup_mpi
+++ b/components/admin/ohpc-filesystem/SOURCES/OHPC_setup_mpi
@@ -1,0 +1,1 @@
+../../../OHPC_setup_mpi

--- a/components/admin/ohpc-filesystem/SPECS/ohpc-filesystem.spec
+++ b/components/admin/ohpc-filesystem/SPECS/ohpc-filesystem.spec
@@ -1,0 +1,52 @@
+Name: ohpc-filesystem
+Version: 1
+Release: 2.ohpc
+Summary: Common openHPC directories
+
+Group: ohpc/admin
+License: ASL 2.0
+Source0: OHPC_setup_compiler
+Source1: OHPC_setup_mpi
+
+BuildArch: noarch
+
+%description
+This package own the top level common directories and should be required
+by every openHPC package.
+
+%package -n ohpc-buildroot
+Summary: Common scripts to build openHPC packages
+Group: ohpc/admin
+Requires: lmod-ohpc
+Requires: ohpc-filesystem
+
+%description -n ohpc-buildroot
+Common scripts to build openHPC packages.
+
+%install
+# The ohpc-filesystems owns all the common directories
+mkdir -p $RPM_BUILD_ROOT/opt/ohpc/pub/{apps,doc,compiler,libs,moduledeps,modulefiles,mpi}
+mkdir -p $RPM_BUILD_ROOT/opt/ohpc/admin/ohpc
+install -p -m 644 %{SOURCE0} $RPM_BUILD_ROOT/opt/ohpc/admin/ohpc
+install -p -m 644 %{SOURCE1} $RPM_BUILD_ROOT/opt/ohpc/admin/ohpc
+
+%files
+%dir /opt/ohpc/
+%dir /opt/ohpc/admin/
+%dir /opt/ohpc/pub/
+%dir /opt/ohpc/pub/apps/
+%dir /opt/ohpc/pub/doc/
+%dir /opt/ohpc/pub/compiler/
+%dir /opt/ohpc/pub/libs/
+%dir /opt/ohpc/pub/moduledeps/
+%dir /opt/ohpc/pub/modulefiles/
+%dir /opt/ohpc/pub/mpi/
+
+%files -n ohpc-buildroot
+%dir /opt/ohpc/admin/ohpc/
+/opt/ohpc/admin/ohpc/OHPC_setup_compiler
+/opt/ohpc/admin/ohpc/OHPC_setup_mpi
+
+%changelog
+* Wed Feb 08 2017 Adrian Reber <areber@redhat.com> - 1.2
+- Initial release

--- a/components/dev-tools/R/SPECS/R-base.spec
+++ b/components/dev-tools/R/SPECS/R-base.spec
@@ -26,60 +26,30 @@
 #
 #-------------------------------------------------------------------------------
 
-
-# OpenHPC convention: the default assumes the gnu toolchain and openmpi
-# MPI family; however, these can be overridden by specifing the
-# compiler_family variable via rpmbuild or other
-# mechanisms.
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
+%ohpc_compiler
 
-%{!?compiler_family: %global compiler_family gnu}
-
-# Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
-# environment; if building outside, lmod remains a formal build dependency).
-%if !0%{?OHPC_BUILD}
-BuildRequires: lmod%{PROJ_DELIM}
+%if "%{compiler_family}" != "intel"
+BuildRequires: openblas-%{compiler_family}%{PROJ_DELIM}
+Requires:      openblas-%{compiler_family}%{PROJ_DELIM}
 %endif
-# Compiler dependencies
-%if %{compiler_family} == gnu
-BuildRequires: gnu-compilers%{PROJ_DELIM}
-Requires:      gnu-compilers%{PROJ_DELIM}
-BuildRequires: openblas-gnu%{PROJ_DELIM}
-Requires:      openblas-gnu%{PROJ_DELIM}
-%endif
-%if %{compiler_family} == intel
-BuildRequires: gcc-c++ intel-compilers%{PROJ_DELIM}
-Requires:      gcc-c++ intel-compilers%{PROJ_DELIM}
-%if 0%{?OHPC_BUILD}
-BuildRequires: intel_licenses
-%endif
-%endif
-
-#-ohpc-header-comp-end------------------------------------------------
-
 
 %define 	pname R_base
 %define 	PNAME %(echo %{pname} | tr [a-z] [A-Z])
-
 
 Name:		%{pname}%{PROJ_DELIM}
 Release:	1%{?dist}
 Version:        3.3.2
 Source:         https://cran.r-project.org/src/base/R-3/R-%{version}.tar.gz
 Source1:        OHPC_macros
-Source2:        OHPC_setup_compiler
 Patch:          tre.patch
 Url:            http://www.r-project.org/
-DocDir:         %{OHPC_PUB}/doc/contrib
 Summary:        R is a language and environment for statistical computing and graphics (S-Plus like).
 License:        GPL-2.0 or GPL-3.0
 Group:          %{PROJ_NAME}/dev-tools
-BuildRoot:	%{_tmppath}/%{pname}-%{version}-%{release}-root
 
 # Default library install path
 %define         install_path %{OHPC_LIBS}/%{compiler_family}/%{pname}/%version
-%define         debug_package %{nil}
 
 BuildRequires:  cairo-devel
 BuildRequires:  libjpeg-devel
@@ -89,7 +59,7 @@ BuildRequires:  perl
 BuildRequires:  readline-devel
 %if 0%{?suse_version} > 1020
 %if 0%{?suse_version} < 1230
-%if 0%{?suse_version} > 1120 
+%if 0%{?suse_version} > 1120
 %endif
 %else
 BuildRequires:  xdg-utils
@@ -101,15 +71,15 @@ BuildRequires:  xz-devel
 BuildRequires:  pcre-devel
 BuildRequires:  libcurl-devel
 ### Moved to CENTOS only until SLES has a newer texinfo version
-###BuildRequires:  texinfo >= 5.1 
+###BuildRequires:  texinfo >= 5.1
 BuildRequires:  tk-devel
 # BuildRequires:  xorg-x11-devel
 # CentOS needs X11 headers/libs like Intrisic.h which suse provides
-%if 0%{?suse_version}  
+%if 0%{?suse_version}
 #BuildRequires:  texlive-fonts-extra
 %else
 BuildRequires:  libXt-devel
-BuildRequires:  texinfo >= 5.1 
+BuildRequires:  texinfo >= 5.1
 BuildRequires:  bzip2-devel
 %endif
 Requires:       cairo >= 1.2
@@ -118,7 +88,7 @@ Requires:       freetype2
 Requires:       make
 Requires:       readline
 Requires:       xdg-utils
-%if 0%{?suse_version}  
+%if 0%{?suse_version}
 BuildRequires:  libicu52_1
 Requires:	libicu52_1
 %else
@@ -160,35 +130,31 @@ Provides:       R-utils = %{version}
 #!BuildIgnore: post-build-checks rpmlint-Factory
 
 %description
-R is a language and environment for statistical computing and graphics. 
-It is a GNU project which is similar to the S language and environment 
-which was developed at Bell Laboratories (formerly AT&T, now Lucent Technologies) 
-by John Chambers and colleagues. 
+R is a language and environment for statistical computing and graphics.
+It is a GNU project which is similar to the S language and environment
+which was developed at Bell Laboratories (formerly AT&T, now Lucent Technologies)
+by John Chambers and colleagues.
 
-R can be considered as a different implementation of S.  There are some important 
+R can be considered as a different implementation of S.  There are some important
 differences, but much code written for S runs unaltered under R.
 
-R provides a wide variety of statistical (linear and nonlinear modelling, 
-classical statistical tests, time-series analysis, classification, clustering, …) 
+R provides a wide variety of statistical (linear and nonlinear modelling,
+classical statistical tests, time-series analysis, classification, clustering, …)
 and graphical techniques, and is highly extensible.
 
-%prep 
-export OHPC_COMPILER_FAMILY=%{compiler_family}
-. %{_sourcedir}/OHPC_setup_compiler
-
+%prep
 %setup -n R-%{version}
 # disabling patch - 9/21/16 karl.w.schulz@intel.com
 #%patch -p1
 
-%build 
+%build
 # OpenHPC compiler designation
-export OHPC_COMPILER_FAMILY=%{compiler_family}
-. %{_sourcedir}/OHPC_setup_compiler
+%ohpc_setup_compiler
 
 export R_BROWSER="xdg-open"
 export R_PDFVIEWER="xdg-open"
 
-%if %{compiler_family} == gnu
+%if "%{compiler_family}" != "intel"
 module load openblas
 BLAS="-L${OPENBLAS_LIB} -lopenblas"
 %else
@@ -205,27 +171,17 @@ echo "MKL options flag .... $MKL "
             --without-system-zlib \
             --without-system-bzlib \
             --without-x \
-              LIBnn=lib64 
+              LIBnn=lib64
 
 
 make %{?_smp_mflags}
 
-
-%install 
+%install
 # OpenHPC compiler designation
-export OHPC_COMPILER_FAMILY=%{compiler_family}
-. %{_sourcedir}/OHPC_setup_compiler
-
+%ohpc_setup_compiler
 make DESTDIR=%{buildroot} install
-
 # there is a backup file in survival for 3.1.3
 %{__rm} -f %{buildroot}%{_libdir}/R/library/survival/NEWS.Rd.orig
-
-# Install ld.so.conf.d file to ensure other applications access the shared lib
-%{__mkdir_p} %{buildroot}/etc/ld.so.conf.d
-cat << EOF >%{buildroot}/etc/ld.so.conf.d/R.conf
-%{_libdir}/R/lib
-EOF
 
 # OpenHPC module file
 
@@ -282,14 +238,6 @@ EOF
 
 %{__mkdir} -p %{buildroot}/%{_docdir}
 
-export NO_BRP_CHECK_RPATH true
-
-%post
-/sbin/ldconfig
-
-%postun
-/sbin/ldconfig
-
 %files
 %defattr(-,root,root)
 %{OHPC_HOME}
@@ -297,9 +245,9 @@ export NO_BRP_CHECK_RPATH true
 %doc COPYING
 %doc README
 
-# ld.so.conf
-%config /etc/ld.so.conf.d/R.conf
-
 %changelog
+* Tue Feb 21 2017 Adrian Reber <areber@redhat.com> - 3.3.1-1
+- Switching to %%ohpc_compiler macro
+
 * Wed Feb 08 2017 Adrian Reber <adrian@lisas.de> - 3.3.1
 - fix building on CentOS 7.3

--- a/components/distro-packages/lua-bit/SPECS/lua-bitop.spec
+++ b/components/distro-packages/lua-bit/SPECS/lua-bitop.spec
@@ -8,6 +8,8 @@
 #
 #----------------------------------------------------------------------------eh-
 
+%global ohpc_bootstrap 1
+
 %include %{_sourcedir}/OHPC_macros
 %{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 

--- a/components/distro-packages/lua-filesystem/SPECS/lua-filesystem.spec
+++ b/components/distro-packages/lua-filesystem/SPECS/lua-filesystem.spec
@@ -8,6 +8,8 @@
 #
 #----------------------------------------------------------------------------eh-
 
+%global ohpc_bootstrap 1
+
 %include %{_sourcedir}/OHPC_macros
 %{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 

--- a/components/distro-packages/lua-posix/SPECS/luaposix.spec
+++ b/components/distro-packages/lua-posix/SPECS/luaposix.spec
@@ -8,6 +8,8 @@
 #
 #----------------------------------------------------------------------------eh-
 
+%global ohpc_bootstrap 1
+
 %include %{_sourcedir}/OHPC_macros
 %{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 

--- a/components/io-libs/adios/SPECS/adios.spec
+++ b/components/io-libs/adios/SPECS/adios.spec
@@ -8,35 +8,10 @@
 #
 #----------------------------------------------------------------------------eh-
 
-#-ohpc-header-comp-begin----------------------------------------------
-
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
+%ohpc_compiler
 
-# OpenHPC convention: the default assumes the gnu compiler family;
-# however, this can be overridden by specifing the compiler_family
-# variable via rpmbuild or other mechanisms.
-
-%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family:      %global mpi_family openmpi}
-
-# Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
-# environment; if building outside, lmod remains a formal build dependency).
-%if !0%{?OHPC_BUILD}
-BuildRequires: lmod%{PROJ_DELIM}
-%endif
-# Compiler dependencies
-%if %{compiler_family} == gnu
-BuildRequires: gnu-compilers%{PROJ_DELIM}
-Requires:      gnu-compilers%{PROJ_DELIM}
-%endif
-%if %{compiler_family} == intel
-BuildRequires: gcc-c++ intel-compilers-devel%{PROJ_DELIM}
-Requires:      gcc-c++ intel-compilers-devel%{PROJ_DELIM}
-%if 0%{OHPC_BUILD}
-BuildRequires: intel_licenses
-%endif
-%endif
 
 # MPI dependencies
 %if %{mpi_family} == impi
@@ -56,12 +31,7 @@ BuildRequires: openmpi-%{compiler_family}%{PROJ_DELIM}
 Requires:      openmpi-%{compiler_family}%{PROJ_DELIM}
 %endif
 
-#-ohpc-header-comp-end------------------------------------------------
-
 %{!?with_lustre: %global with_lustre 0}
-
-# not generating a debug package, CentOS build breaks without this if no debug package defined
-%define debug_package %{nil}
 
 # Base package name
 %define pname adios
@@ -70,14 +40,12 @@ Requires:      openmpi-%{compiler_family}%{PROJ_DELIM}
 Summary: The Adaptable IO System (ADIOS)
 Name:    %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Version: 1.11.0
-Release: 1
+Release: 1%{?dist}
 License: BSD-3-Clause
 Group:   %{PROJ_NAME}/io-libs
-DocDir:  %{OHPC_PUB}/doc/contrib
 Url:     http://www.olcf.ornl.gov/center-projects/adios/
-Source0: http://users.nccs.gov/~pnorbert/adios-%{version}.tar.gz 
+Source0: http://users.nccs.gov/~pnorbert/adios-%{version}.tar.gz
 Source1: OHPC_macros
-Source2: OHPC_setup_compiler
 Source3: OHPC_setup_mpi
 AutoReq: no
 
@@ -132,13 +100,9 @@ LIBSUFF=64
 sed -i "s|@64@|$LIBSUFF|" wrappers/numpy/setup*
 
 # OpenHPC compiler/mpi designation
-export OHPC_COMPILER_FAMILY=%{compiler_family}
+%ohpc_setup_compiler
 export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_compiler
 . %{_sourcedir}/OHPC_setup_mpi
-%if %{compiler_family} == intel
-export CFLAGS="-fp-model strict $CFLAGS"
-%endif
 
 module load autotools
 module load phdf5
@@ -150,7 +114,7 @@ TOPDIR=$PWD
 export CFLAGS="-fPIC -I$TOPDIR/src/public -I$MPI_DIR/include -I$NETCDF_INC -I$HDF5_INC -pthread -lpthread -L$NETCDF_LIB -lnetcdf -L$HDF5_LIB"
 
 # These lines break intel builds, but are required for gnu mvapich2
-%if %{compiler_family} == gnu
+%if "%{compiler_family}" != "intel"
 export LDFLAGS="-L$NETCDF_LIB -L$HDF5_LIB"
 export LIBS="-pthread -lpthread -lnetcdf"
 %endif
@@ -163,7 +127,7 @@ export MPICC=mpicc
 export MPIFC=mpif90
 export MPICXX=mpicxx
 
-%if %{compiler_family} == intel
+%if "%{compiler_family}" == "intel"
 export CFLAGS="-fp-model strict $CFLAGS"
 %endif
 
@@ -205,9 +169,8 @@ chmod +x adios_config
 
 %install
 # OpenHPC compiler designation
-export OHPC_COMPILER_FAMILY=%{compiler_family}
+%ohpc_setup_compiler
 export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_compiler
 . %{_sourcedir}/OHPC_setup_mpi
 export NO_BRP_CHECK_RPATH=true
 
@@ -217,7 +180,7 @@ make DESTDIR=$RPM_BUILD_ROOT install
 export PPATH="/lib64/python2.7/site-packages"
 export PATH=$(pwd):$PATH
 
-%if %{compiler_family} == gnu
+%if "%{compiler_family}" != "intel"
 module load openblas
 %endif
 module load numpy
@@ -312,3 +275,5 @@ EOF
 %doc TODO
 
 %changelog
+* Tue Feb 21 2017 Adrian Reber <areber@redhat.com> - 1.11.0-1
+- Switching to %%ohpc_compiler macro

--- a/components/io-libs/netcdf-CXX/SPECS/netcdf-cxx4.spec
+++ b/components/io-libs/netcdf-CXX/SPECS/netcdf-cxx4.spec
@@ -24,39 +24,14 @@
 #
 #-------------------------------------------------------------------------------
 #
-# netcdf-cxx4 spec file 
+# netcdf-cxx4 spec file
 # netcdf-cxx4 library build that is dependent on compiler toolchain
 #
-#-ohpc-header-comp-begin----------------------------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
+%ohpc_compiler
 
-# OpenHPC convention: the default assumes the gnu toolchain and openmpi
-# MPI family; however, these can be overridden by specifing the
-# compiler_family and mpi_family variables via rpmbuild or other
-# mechanisms.
-
-%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family:      %global mpi_family openmpi}
-
-# Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
-# environment; if building outside, lmod remains a formal build dependency).
-%if !0%{?OHPC_BUILD}
-BuildRequires: lmod%{PROJ_DELIM}
-%endif
-# Compiler dependencies
-%if %{compiler_family} == gnu
-BuildRequires: gnu-compilers%{PROJ_DELIM}
-Requires:      gnu-compilers%{PROJ_DELIM}
-%endif
-%if %{compiler_family} == intel
-BuildRequires: gcc-c++ intel-compilers-devel%{PROJ_DELIM}
-Requires:      gcc-c++ intel-compilers-devel%{PROJ_DELIM}
-%if 0%{?OHPC_BUILD}
-BuildRequires: intel_licenses
-%endif
-%endif
 
 # MPI dependencies
 %if %{mpi_family} == impi
@@ -76,9 +51,6 @@ BuildRequires: openmpi-%{compiler_family}%{PROJ_DELIM}
 Requires:      openmpi-%{compiler_family}%{PROJ_DELIM}
 %endif
 
-#-ohpc-header-comp-end------------------------------------------------
-
-
 # Base package name
 
 %define pname netcdf-cxx
@@ -89,15 +61,12 @@ Summary:        C++ Libraries for the Unidata network Common Data Form
 License:        NetCDF
 Group:          %{PROJ_NAME}/io-libs
 Version:        4.3.0
-Release:        1
+Release:        1%{?dist}
 Url:            http://www.unidata.ucar.edu/software/netcdf/
-DocDir:         %{OHPC_PUB}/doc/contrib
 Source0:	https://github.com/Unidata/netcdf-cxx4/archive/v%{version}.tar.gz
 Source101:	OHPC_macros
-Source102:	OHPC_setup_compiler
 Source103:	OHPC_setup_mpi
 
-BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root
 
 BuildRequires:  zlib-devel >= 1.2.5
 BuildRequires:  phdf5-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
@@ -106,8 +75,6 @@ Requires:       netcdf-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 
 
 #!BuildIgnore: post-build-checks rpmlint-Factory
-
-%define debug_package %{nil}
 
 # Default library install path
 %define install_path %{OHPC_LIBS}/%{compiler_family}/%{mpi_family}/%{pname}/%version
@@ -149,9 +116,8 @@ NetCDF data is:
 
 %build
 # OpenHPC compiler/mpi designation
-export OHPC_COMPILER_FAMILY=%{compiler_family} 
+%ohpc_setup_compiler
 export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_compiler
 . %{_sourcedir}/OHPC_setup_mpi
 
 module load phdf5
@@ -169,11 +135,12 @@ export LDFLAGS="-L$HDF5_LIB -L$NETCDF_LIB"
     --disable-doxygen \
     --disable-static || { cat config.log && exit 1; }
 
+make %{?_smp_mflags}
+
 %install
 # OpenHPC compiler/mpi designation
-export OHPC_COMPILER_FAMILY=%{compiler_family} 
+%ohpc_setup_compiler
 export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_compiler
 . %{_sourcedir}/OHPC_setup_mpi
 
 module load phdf5
@@ -241,20 +208,12 @@ EOF
 
 %{__mkdir_p} ${RPM_BUILD_ROOT}/%{_docdir}
 
-
-%post -p /sbin/ldconfig
-
-%postun -p /sbin/ldconfig
-
-%clean
-rm -rf $RPM_BUILD_ROOT
-
-
 %files
 %defattr(-,root,root,-)
 %{OHPC_HOME}
 %{OHPC_PUB}
 %doc COPYRIGHT
 
-
 %changelog
+* Wed Feb 22 2017 Adrian Reber <areber@redhat.com> - 4.3.0-1
+- Switching to %%ohpc_compiler macro

--- a/components/io-libs/netcdf/SPECS/netcdf.spec
+++ b/components/io-libs/netcdf/SPECS/netcdf.spec
@@ -24,39 +24,14 @@
 #
 #-------------------------------------------------------------------------------
 #
-# netcdf spec file 
+# netcdf spec file
 # netcdf library build that is dependent on compiler toolchain
 #
-#-ohpc-header-comp-begin----------------------------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
+%ohpc_compiler
 
-# OpenHPC convention: the default assumes the gnu toolchain and openmpi
-# MPI family; however, these can be overridden by specifing the
-# compiler_family and mpi_family variables via rpmbuild or other
-# mechanisms.
-
-%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family:      %global mpi_family openmpi}
-
-# Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
-# environment; if building outside, lmod remains a formal build dependency).
-%if !0%{?OHPC_BUILD}
-BuildRequires: lmod%{PROJ_DELIM}
-%endif
-# Compiler dependencies
-%if %{compiler_family} == gnu
-BuildRequires: gnu-compilers%{PROJ_DELIM}
-Requires:      gnu-compilers%{PROJ_DELIM}
-%endif
-%if %{compiler_family} == intel
-BuildRequires: gcc-c++ intel-compilers-devel%{PROJ_DELIM}
-Requires:      gcc-c++ intel-compilers-devel%{PROJ_DELIM}
-%if 0%{?OHPC_BUILD}
-BuildRequires: intel_licenses
-%endif
-%endif
 
 # MPI dependencies
 %if %{mpi_family} == impi
@@ -76,9 +51,6 @@ BuildRequires: openmpi-%{compiler_family}%{PROJ_DELIM}
 Requires:      openmpi-%{compiler_family}%{PROJ_DELIM}
 %endif
 
-#-ohpc-header-comp-end------------------------------------------------
-
-
 # Base package name
 
 %define pname netcdf
@@ -91,24 +63,19 @@ Summary:        C Libraries for the Unidata network Common Data Form
 License:        NetCDF
 Group:          %{PROJ_NAME}/io-libs
 Version:        4.4.1.1
-Release:        1
+Release:        1%{?dist}
 Url:            http://www.unidata.ucar.edu/software/netcdf/
-DocDir:         %{OHPC_PUB}/doc/contrib
 Source0:	https://github.com/Unidata/netcdf-c/archive/v%{version}.tar.gz
 Source101:	OHPC_macros
-Source102:	OHPC_setup_compiler
 Source103:	OHPC_setup_mpi
 
 
-BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root
 BuildRequires:  zlib-devel >= 1.2.5
 BuildRequires:  m4
 BuildRequires:  phdf5-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:       phdf5-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 
 #!BuildIgnore: post-build-checks rpmlint-Factory
-
-%define debug_package %{nil}
 
 # Default library install path
 %define install_path %{OHPC_LIBS}/%{compiler_family}/%{mpi_family}/%{pname}/%version
@@ -150,16 +117,15 @@ NetCDF data is:
 
 %build
 # OpenHPC compiler/mpi designation
-export OHPC_COMPILER_FAMILY=%{compiler_family} 
+%ohpc_setup_compiler
 export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_compiler
 . %{_sourcedir}/OHPC_setup_mpi
 
 module load phdf5
 export CPPFLAGS="-I$HDF5_INC"
 export LDFLAGS="-L$HDF5_LIB"
 export CFLAGS="-L$HDF5_LIB -I$HDF5_INC"
-export CC=mpicc 
+export CC=mpicc
 
 ./configure --prefix=%{install_path} \
     --enable-shared \
@@ -170,11 +136,12 @@ export CC=mpicc
     --disable-doxygen \
     --disable-static || { cat config.log && exit 1; }
 
+make %{?_smp_mflags}
+
 %install
 # OpenHPC compiler/mpi designation
-export OHPC_COMPILER_FAMILY=%{compiler_family} 
+%ohpc_setup_compiler
 export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_compiler
 . %{_sourcedir}/OHPC_setup_mpi
 
 module load phdf5
@@ -240,14 +207,6 @@ EOF
 
 %{__mkdir_p} ${RPM_BUILD_ROOT}/%{_docdir}
 
-%post -p /sbin/ldconfig
-
-%postun -p /sbin/ldconfig
-
-%clean
-rm -rf $RPM_BUILD_ROOT
-
-
 %files
 %defattr(-,root,root,-)
 %{OHPC_HOME}
@@ -256,3 +215,5 @@ rm -rf $RPM_BUILD_ROOT
 %doc README.md
 
 %changelog
+* Mon Feb 20 2017 Adrian Reber <areber@redhat.com> - 4.4.1.1-1
+- Switching to %%ohpc_compiler macro

--- a/components/io-libs/phdf5/SPECS/hdf5.spec
+++ b/components/io-libs/phdf5/SPECS/hdf5.spec
@@ -27,37 +27,10 @@
 # Parallel HDF5 library build that is dependent on compiler
 # toolchain and MPI
 
-#-ohpc-header-comp-begin----------------------------------------------
-
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
+%ohpc_compiler
 
-# OpenHPC convention: the default assumes the gnu toolchain and openmpi
-# MPI family; however, these can be overridden by specifing the
-# compiler_family and mpi_family variables via rpmbuild or other
-# mechanisms.
-
-%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family:      %global mpi_family openmpi}
-
-# Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
-# environment; if building outside, lmod remains a formal build dependency).
-%if !0%{?OHPC_BUILD}
-BuildRequires: lmod%{PROJ_DELIM}
-%endif
-# Compiler dependencies
-BuildRequires: coreutils
-%if %{compiler_family} == gnu
-BuildRequires: gnu-compilers%{PROJ_DELIM} 
-Requires:      gnu-compilers%{PROJ_DELIM} 
-%endif
-%if %{compiler_family} == intel
-BuildRequires: gcc-c++ intel-compilers-devel%{PROJ_DELIM} 
-Requires:      gcc-c++ intel-compilers-devel%{PROJ_DELIM} 
-%if 0%{?OHPC_BUILD}
-BuildRequires: intel_licenses
-%endif
-%endif
 
 # MPI dependencies
 %if %{mpi_family} == impi
@@ -88,22 +61,17 @@ Requires:      openmpi-%{compiler_family}%{PROJ_DELIM}
 Summary:   A general purpose library and file format for storing scientific data
 Name:      p%{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Version:   1.8.17
-Release:   1
+Release:   1%{?dist}
 License:   Hierarchical Data Format (HDF) Software Library and Utilities License
 Group:     %{PROJ_NAME}/io-libs
 URL:       http://www.hdfgroup.org/HDF5
-DocDir:    %{OHPC_PUB}/doc/contrib
 
 Source0:   http://www.hdfgroup.org/ftp/HDF5/releases/%{pname}-%{version}/src/%{pname}-%{version}.tar.bz2
 Source1:   OHPC_macros
-Source2:   OHPC_setup_compiler
 Source3:   OHPC_setup_mpi
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildRequires: zlib-devel
 
 #!BuildIgnore: post-build-checks rpmlint-Factory
-
-%define debug_package %{nil}
 
 # Default library install path
 %define install_path %{OHPC_LIBS}/%{compiler_family}/%{mpi_family}/%{pname}/%version
@@ -129,18 +97,17 @@ cp /usr/lib/rpm/config.guess bin
 %endif
 
 # OpenHPC compiler/mpi designation
-export OHPC_COMPILER_FAMILY=%{compiler_family}
+%ohpc_setup_compiler
 export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_compiler
 . %{_sourcedir}/OHPC_setup_mpi
 
-export CC=mpicc 
-export CXX=mpicxx 
-export F77=mpif77 
-export FC=mpif90 
-export MPICC=mpicc 
-export MPIFC=mpifc 
-export MPICXX=mpicxx 
+export CC=mpicc
+export CXX=mpicxx
+export F77=mpif77
+export FC=mpif90
+export MPICC=mpicc
+export MPIFC=mpifc
+export MPICXX=mpicxx
 
 ./configure --prefix=%{install_path} \
 	    --enable-fortran         \
@@ -152,9 +119,8 @@ export MPICXX=mpicxx
 %install
 
 # OpenHPC compiler designation
-export OHPC_COMPILER_FAMILY=%{compiler_family}
+%ohpc_setup_compiler
 export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_compiler
 . %{_sourcedir}/OHPC_setup_mpi
 
 export NO_BRP_CHECK_RPATH=true
@@ -207,9 +173,6 @@ EOF
 
 %{__mkdir_p} ${RPM_BUILD_ROOT}/%{_docdir}
 
-%clean
-rm -rf $RPM_BUILD_ROOT
-
 %files
 %defattr(-,root,root,-)
 %{OHPC_HOME}
@@ -218,5 +181,5 @@ rm -rf $RPM_BUILD_ROOT
 %doc README.txt
 
 %changelog
-
-
+* Mon Feb 20 2017 Adrian Reber <areber@redhat.com> - 1.8.17-1
+- Switching to %%ohpc_compiler macro

--- a/components/io-libs/sionlib/SOURCES/gcc-6-7.patch
+++ b/components/io-libs/sionlib/SOURCES/gcc-6-7.patch
@@ -1,0 +1,11 @@
+--- configure.org	2017-02-22 02:38:23.740476450 -0500
++++ configure	2017-02-22 02:38:47.962057298 -0500
+@@ -453,7 +453,7 @@
+                   GFORTRAN=`which gfortran 2> /dev/null`
+                   case ${COMPVER} in
+                   4.0.*|4.1.*) ;;
+-                  4.*|5.*)     MD=Makefile.defs.linux-gomp
++                  4.*|5.*|6.*|7.*)     MD=Makefile.defs.linux-gomp
+                                GFORTRAN="yes"
+                                ;;
+                   esac

--- a/components/io-libs/sionlib/SPECS/sionlib.spec
+++ b/components/io-libs/sionlib/SPECS/sionlib.spec
@@ -10,37 +10,10 @@
 
 # Scalasca library that is is dependent on compiler toolchain and MPI
 
-#-ohpc-header-comp-begin----------------------------------------------
-
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
+%ohpc_compiler
 
-# OpenHPC convention: the default assumes the gnu toolchain and openmpi
-# MPI family; however, these can be overridden by specifing the
-# compiler_family and mpi_family variables via rpmbuild or other
-# mechanisms.
-
-%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family:      %global mpi_family openmpi}
-
-# Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
-# environment; if building outside, lmod remains a formal build dependency).
-%if !0%{?OHPC_BUILD}
-BuildRequires: lmod%{PROJ_DELIM}
-%endif
-# Compiler dependencies
-BuildRequires: coreutils
-%if %{compiler_family} == gnu
-BuildRequires: gnu-compilers%{PROJ_DELIM}
-Requires:      gnu-compilers%{PROJ_DELIM}
-%endif
-%if %{compiler_family} == intel
-BuildRequires: gcc-c++ intel-compilers-devel%{PROJ_DELIM}
-Requires:      gcc-c++ intel-compilers-devel%{PROJ_DELIM}
-%if 0%{?OHPC_BUILD}
-BuildRequires: intel_licenses
-%endif
-%endif
 
 # MPI dependencies
 %if %{mpi_family} == impi
@@ -60,8 +33,6 @@ BuildRequires: openmpi-%{compiler_family}%{PROJ_DELIM}
 Requires:      openmpi-%{compiler_family}%{PROJ_DELIM}
 %endif
 
-#-ohpc-header-comp-end------------------------------------------------
-
 # Base package name
 %define pname sionlib
 %define PNAME %(echo %{pname} | tr [a-z] [A-Z])
@@ -69,26 +40,21 @@ Requires:      openmpi-%{compiler_family}%{PROJ_DELIM}
 Summary:   Scalable Performance Measurement Infrastructure for Parallel Codes
 Name:      %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Version:   1.7.0
-Release:   1
+Release:   1%{?dist}
 License:   BSD
 Group:     %{PROJ_NAME}/perf-tools
 URL:       http://www.fz-juelich.de/ias/jsc/EN/Expertise/Support/Software/SIONlib/_node.html
 Source0:   http://apps.fz-juelich.de/jsc/sionlib/download.php?version=%{version}#/%{pname}-%{version}.tar.gz
 Source1:   OHPC_macros
-Source2:   OHPC_setup_compiler
 Source3:   OHPC_setup_mpi
-BuildRoot: %{_tmppath}/%{pname}-%{version}-%{release}-root
-DocDir:    %{OHPC_PUB}/doc/contrib
-
-%define debug_package %{nil}
-
+Patch0:    gcc-6-7.patch
 
 # Default library install path
 %define install_path %{OHPC_LIBS}/%{compiler_family}/%{mpi_family}/%{pname}/%version
 
 %description
-SIONlib is a library for writing and reading binary data to/from several 
-thousands of processors into one or a small number of physical files. 
+SIONlib is a library for writing and reading binary data to/from several
+thousands of processors into one or a small number of physical files.
 
 This is the %{compiler_family}-%{mpi_family} version.
 
@@ -96,12 +62,12 @@ This is the %{compiler_family}-%{mpi_family} version.
 %prep
 
 %setup -q -n %{pname}
+%patch0 -p0
 
 %build
 
 # OpenHPC compiler/mpi designation
-export OHPC_COMPILER_FAMILY=%{compiler_family}
-. %{_sourcedir}/OHPC_setup_compiler
+%ohpc_setup_compiler
 
 export OHPC_MPI_FAMILY=%{mpi_family}
 . %{_sourcedir}/OHPC_setup_mpi
@@ -133,20 +99,20 @@ CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --mpi=openmpi "
 sed -i 's|-m$(PREC)||g' build-*/Makefile.defs
 %endif
 
+make
 
 %install
 
 # OpenHPC compiler designation
-export OHPC_COMPILER_FAMILY=%{compiler_family}
+%ohpc_setup_compiler
 export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_compiler
 . %{_sourcedir}/OHPC_setup_mpi
 
 make DESTDIR=$RPM_BUILD_ROOT install
 
 # don't package static libs
 rm -f $RPM_BUILD_ROOT%{install_path}/lib/*la
-    
+
 # clean buildroot
 sed -i 's|%{buildroot}||g' %{buildroot}%{install_path}/bin/sionconfig
 sed -i 's|%{buildroot}||g' %{buildroot}%{install_path}/examples/simple/Makefile.defs
@@ -194,21 +160,12 @@ EOF
 
 %{__mkdir} -p $RPM_BUILD_ROOT/%{_docdir}
 
-%clean
-rm -rf $RPM_BUILD_ROOT
-
-%post
-/sbin/ldconfig || exit 1
-%postun -p /sbin/ldconfig
-
-%preun
-
 %files
 %defattr(-,root,root,-)
 %{OHPC_HOME}
 %{OHPC_PUB}
 %doc COPYRIGHT LICENSE README INSTALL RELEASE
 
-
 %changelog
-
+* Wed Feb 22 2017 Adrian Reber <areber@redhat.com> - 1.7.0-1
+- Switching to %%ohpc_compiler macro

--- a/components/mpi-families/mpich/SPECS/mpich.spec
+++ b/components/mpi-families/mpich/SPECS/mpich.spec
@@ -58,12 +58,10 @@ Message Passing Interface (MPI) standard.
     || { cat config.log && exit 1; }
 
 make %{?_smp_mflags}
-
 %install
 # OpenHPC compiler designation
 %ohpc_setup_compiler
 make %{?_smp_mflags} DESTDIR=$RPM_BUILD_ROOT install
-
 # Remove .la files detected by rpm
 rm $RPM_BUILD_ROOT/%{install_path}/lib/*.la
 

--- a/components/mpi-families/mvapich2/SPECS/mvapich2.spec
+++ b/components/mpi-families/mvapich2/SPECS/mvapich2.spec
@@ -108,10 +108,8 @@ across multiple networks.
 	    --enable-fast=O3 || { cat config.log && exit 1; }
 
 make
-
 %install
 %ohpc_setup_compiler
-
 # 06/04/15 - karl.w.schulz@intel.com; run serial build for fortran deps
 make DESTDIR=$RPM_BUILD_ROOT install
 

--- a/components/mpi-families/openmpi/SPECS/openmpi.spec
+++ b/components/mpi-families/openmpi/SPECS/openmpi.spec
@@ -9,7 +9,6 @@
 #----------------------------------------------------------------------------eh-
 
 # OpenMPI stack that is dependent on compiler toolchain
-
 %include %{_sourcedir}/OHPC_macros
 
 %ohpc_compiler
@@ -39,7 +38,7 @@ Name:      %{pname}-psm2-%{compiler_family}%{PROJ_DELIM}
 Name:      %{pname}-%{compiler_family}%{PROJ_DELIM}
 %endif
 
-Version:   1.10.6
+Version:   1.10.4
 Release:   1%{?dist}
 License:   BSD-3-Clause
 Group:     %{PROJ_NAME}/mpi-families
@@ -136,6 +135,8 @@ BASEFLAGS="--prefix=%{install_path} --disable-static --enable-builtin-atomics --
   BASEFLAGS="$BASEFLAGS --with-io-romio-flags=--with-file-system=testfs+ufs+nfs+lustre"
 %endif
 
+export BASEFLAGS
+
 %if %{with_tm}
 cp %{SOURCE3} .
 %{__chmod} 700 pbs-config
@@ -150,7 +151,6 @@ make %{?_smp_mflags}
 # OpenHPC compiler designation
 %ohpc_setup_compiler
 make %{?_smp_mflags} DESTDIR=$RPM_BUILD_ROOT install
-
 # Remove .la files detected by rpm
 
 rm $RPM_BUILD_ROOT/%{install_path}/lib/*.la

--- a/components/parallel-libs/mumps/SPECS/mumps.spec
+++ b/components/parallel-libs/mumps/SPECS/mumps.spec
@@ -25,38 +25,14 @@
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
 
-#-ohpc-header-comp-begin-----------------------------
-
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
+%ohpc_compiler
 
-# OpenHPC convention: the default assumes the gnu toolchain and openmpi
-# MPI family; however, these can be overridden by specifing the
-# compiler_family and mpi_family variables via rpmbuild or other
-# mechanisms.
-
-%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family:      %global mpi_family openmpi}
 
-# Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
-# environment; if building outside, lmod remains a formal build dependency).
-%if !0%{?OHPC_BUILD}
-BuildRequires: lmod%{PROJ_DELIM}
-%endif
-# Compiler dependencies
-BuildRequires: coreutils
-%if %{compiler_family} == gnu
-BuildRequires: gnu-compilers%{PROJ_DELIM}
-Requires:      gnu-compilers%{PROJ_DELIM}
+%if "%{compiler_family}" != "intel"
 BuildRequires: scalapack-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:      scalapack-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-%endif
-%if %{compiler_family} == intel
-BuildRequires: gcc-c++ intel-compilers-devel%{PROJ_DELIM}
-Requires:      gcc-c++ intel-compilers-devel%{PROJ_DELIM}
-%if 0%{?OHPC_BUILD}
-BuildRequires: intel_licenses
-%endif
 %endif
 
 # MPI dependencies
@@ -77,15 +53,13 @@ BuildRequires: mpich-%{compiler_family}%{PROJ_DELIM}
 Requires:      mpich-%{compiler_family}%{PROJ_DELIM}
 %endif
 
-#-ohpc-header-comp-end-------------------------------
-
 # Base package name
 %define pname mumps
 %define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Name:           %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Version:        5.0.2
-Release:        0
+Release:        0%{?dist}
 Summary:        A MUltifrontal Massively Parallel Sparse direct Solver
 License:        CeCILL-C
 Group:          %{PROJ_NAME}/parallel-libs
@@ -96,23 +70,16 @@ Source2:        Makefile.gnu.impi.inc
 Source3:        Makefile.mkl.intel.impi.inc
 Source4:        Makefile.mkl.intel.openmpi.inc
 Source5:        OHPC_macros
-Source6:        OHPC_setup_compiler
 Source7:        OHPC_setup_mpi
 Patch0:         mumps-5.0.1-shared-mumps.patch
 Patch1:         mumps-5.0.0-shared-pord.patch
 Patch2:         mumps-5.0.2-psxe2017.patch
-BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-DocDir:         %{OHPC_PUB}/doc/contrib
 
 %if 0%{?suse_version}
 BuildRequires: libgomp1
 %else
 BuildRequires: libgomp
 %endif
-
-Provides:      libpord.so.%{version}()(64bit)
-
-%define debug_package %{nil}
 
 # Default library install path
 %define install_path %{OHPC_LIBS}/%{compiler_family}/%{mpi_family}/%{pname}/%version
@@ -127,76 +94,64 @@ C interfaces, and can interface with ordering tools such as Scotch.
 %setup -q -n MUMPS_%{version}
 %patch0 -p1
 %patch1 -p1
-%if %{compiler_family} == intel
+%if "%{compiler_family}" == "intel"
 %patch2 -p2
 %endif
 
 %build
-
-export OHPC_COMPILER_FAMILY=%{compiler_family}
+%ohpc_setup_compiler
 export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_compiler
 . %{_sourcedir}/OHPC_setup_mpi
 
 # Enable scalapack linkage for blas/lapack with gnu builds
-%if %{compiler_family} == gnu
+%if "%{compiler_family}" != "intel"
 module load scalapack openblas
 %endif
 
 # Select appropriate Makefile.inc with MKL
-%if %{mpi_family} == impi
+%if "%{mpi_family}" == "impi"
 export LIBS="-L$MPI_DIR/lib -lmpi"
-%if %{compiler_family} == gnu
+%if "%{compiler_family}" == "gnu"
 cp -f %{S:2} Makefile.inc
 %endif
-%if %{compiler_family} == intel
+%if "%{compiler_family}" == "intel"
 cp -f %{S:3} Makefile.inc
 %endif
-%endif 
+%endif
 
-%if %{mpi_family} == mpich
+%if "%{mpi_family}" == "mpich"
 export LIBS="-L$MPI_DIR/lib -lmpi"
-%if %{compiler_family} == gnu
+%if "%{compiler_family}" == "intel"
+cp -f %{S:3} Makefile.inc
+%else
 cp -f %{S:2} Makefile.inc
 %endif
-%if %{compiler_family} == intel
-cp -f %{S:3} Makefile.inc
 %endif
-%endif 
-%if %{mpi_family} == mvapich2
+%if "%{mpi_family}" == "mvapich2"
 export LIBS="-L$MPI_DIR/lib -lmpi"
-%if %{compiler_family} == gnu
+%if "%{compiler_family}" == "intel"
+cp -f %{S:3} Makefile.inc
+%else
 cp -f %{S:2} Makefile.inc
 %endif
-%if %{compiler_family} == intel
-cp -f %{S:3} Makefile.inc
 %endif
-%endif 
 
-%if %{mpi_family} == openmpi
+%if "%{mpi_family}" == "openmpi"
 export LIBS="-L$MPI_DIR/lib -lmpi_mpifh -lmpi"
-%if %{compiler_family} == gnu
+%if "%{compiler_family}" == "intel"
+cp -f %{S:4} Makefile.inc
+%else
 cp -f %{S:1} Makefile.inc
 %endif
-%if %{compiler_family} == intel
-cp -f %{S:4} Makefile.inc
 %endif
-%endif 
 
-#export LD_LIBRARY_PATH=%{_libdir}/mpi/gcc/openmpi/%_lib
 make MUMPS_MPI=$OHPC_MPI_FAMILY \
      FC=mpif77 \
      MUMPS_LIBF77="$LIBS" \
      OPTC="$RPM_OPT_FLAGS" all
 
 
-
 %install
-
-export OHPC_COMPILER_FAMILY=%{compiler_family}
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_compiler
-. %{_sourcedir}/OHPC_setup_mpi
 
 %{__mkdir} -p %{buildroot}%{install_path}/lib
 %{__mkdir} -p %{buildroot}%{install_path}/include
@@ -208,7 +163,7 @@ rm PORD/lib/sort*
 mv PORD/lib/*so* lib/.
 mv PORD/include/* include/.
 
-install -m 644 lib/*so* %{buildroot}%{install_path}/lib
+install -m 755 lib/*so* %{buildroot}%{install_path}/lib
 install -m 644 include/* %{buildroot}%{install_path}/include
 install -m 644 Makefile.inc %{buildroot}%{install_path}/etc
 
@@ -265,9 +220,6 @@ EOF
 
 %{__mkdir} -p %{buildroot}/%{_docdir}
 
-%post -p /sbin/ldconfig
-%postun -p /sbin/ldconfig
-
 %files
 %defattr(-,root,root,-)
 %{OHPC_HOME}
@@ -275,4 +227,5 @@ EOF
 %doc ChangeLog CREDITS INSTALL LICENSE README VERSION
 
 %changelog
-
+* Wed Feb 22 2017 Adrian Reber <areber@redhat.com> - 5.0.2-0
+- Switching to %%ohpc_compiler macro

--- a/components/parallel-libs/petsc/SPECS/petsc.spec
+++ b/components/parallel-libs/petsc/SPECS/petsc.spec
@@ -10,38 +10,14 @@
 
 # petsc library that is is dependent on compiler toolchain and MPI
 
-#-ohpc-header-comp-begin-----------------------------
-
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
+%ohpc_compiler
 
-# OpenHPC convention: the default assumes the gnu toolchain and openmpi
-# MPI family; however, these can be overridden by specifing the
-# compiler_family and mpi_family variables via rpmbuild or other
-# mechanisms.
-
-%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family:      %global mpi_family openmpi}
 
-# Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
-# environment; if building outside, lmod remains a formal build dependency).
-%if !0%{?OHPC_BUILD}
-BuildRequires: lmod%{PROJ_DELIM}
-%endif
-# Compiler dependencies
-BuildRequires: coreutils
-%if %{compiler_family} == gnu
-BuildRequires: gnu-compilers%{PROJ_DELIM}
-Requires:      gnu-compilers%{PROJ_DELIM}
+%if "%{compiler_family}" != "intel"
 BuildRequires: scalapack-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:      scalapack-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-%endif
-%if %{compiler_family} == intel
-BuildRequires: gcc-c++ intel-compilers-devel%{PROJ_DELIM}
-Requires:      gcc-c++ intel-compilers-devel%{PROJ_DELIM}
-%if 0%{?OHPC_BUILD}
-BuildRequires: intel_licenses
-%endif
 %endif
 
 # MPI dependencies
@@ -62,8 +38,6 @@ BuildRequires: mpich-%{compiler_family}%{PROJ_DELIM}
 Requires:      mpich-%{compiler_family}%{PROJ_DELIM}
 %endif
 
-#-ohpc-header-comp-end-------------------------------
-
 # Base package name
 %define pname petsc
 %define PNAME %(echo %{pname} | tr [a-z] [A-Z])
@@ -73,32 +47,27 @@ Summary:        Portable Extensible Toolkit for Scientific Computation
 License:        2-clause BSD
 Group:          %{PROJ_NAME}/parallel-libs
 Version:        3.7.5
-Release:        0
+Release:        0%{?dist}
 
 Source0:        http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-%{version}.tar.gz
 Source1:        OHPC_macros
-Source2:        OHPC_setup_compiler
 Source3:        OHPC_setup_mpi
 Patch1:         petsc.rpath.patch
 Url:            http://www.mcs.anl.gov/petsc/
-BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-DocDir:         %{OHPC_PUB}/doc/contrib
 BuildRequires:  phdf5-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 BuildRequires:  python
 BuildRequires:  valgrind%{PROJ_DELIM}
 BuildRequires:  xz
 BuildRequires:  zlib-devel
 
-%include %{_sourcedir}/OHPC_macros
 #!BuildIgnore: post-build-checks
-%define debug_package %{nil}
 
 # Default library install path
 %define install_path %{OHPC_LIBS}/%{compiler_family}/%{mpi_family}/%{pname}/%version
 
 %description
 PETSc is a suite of data structures and routines for the scalable
-(parallel) solution of scientific applications modeled by partial 
+(parallel) solution of scientific applications modeled by partial
 differential equations.
 
 %prep
@@ -108,15 +77,14 @@ differential equations.
 
 %build
 # OpenHPC compiler/mpi designation
-export OHPC_COMPILER_FAMILY=%{compiler_family}
+%ohpc_setup_compiler
 export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_compiler
 . %{_sourcedir}/OHPC_setup_mpi
 
 module load phdf5
 
 # Enable scalapack linkage for blas/lapack with gnu builds
-%if %{compiler_family} == gnu
+%if "%{compiler_family}" != "intel"
 module load scalapack openblas
 %endif
 
@@ -226,13 +194,6 @@ EOF
 
 %{__mkdir} -p $RPM_BUILD_ROOT/%{_docdir}
 
-%clean
-rm -rf $RPM_BUILD_ROOT
-
-%post -p /sbin/ldconfig
-%postun -p /sbin/ldconfig
-
-
 %files
 %defattr(-,root,root,-)
 %{OHPC_HOME}
@@ -240,3 +201,5 @@ rm -rf $RPM_BUILD_ROOT
 %doc CONTRIBUTING LICENSE
 
 %changelog
+* Wed Feb 22 2017 Adrian Reber <areber@redhat.com> - 3.7.5-0
+- Switching to %%ohpc_compiler macro

--- a/components/perf-tools/scalasca/SPECS/scalasca.spec
+++ b/components/perf-tools/scalasca/SPECS/scalasca.spec
@@ -10,37 +10,10 @@
 
 # Scalasca library that is is dependent on compiler toolchain and MPI
 
-#-ohpc-header-comp-begin----------------------------------------------
-
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
+%ohpc_compiler
 
-# OpenHPC convention: the default assumes the gnu toolchain and openmpi
-# MPI family; however, these can be overridden by specifing the
-# compiler_family and mpi_family variables via rpmbuild or other
-# mechanisms.
-
-%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family:      %global mpi_family openmpi}
-
-# Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
-# environment; if building outside, lmod remains a formal build dependency).
-%if !0%{?OHPC_BUILD}
-BuildRequires: lmod%{PROJ_DELIM}
-%endif
-# Compiler dependencies
-BuildRequires: coreutils
-%if %{compiler_family} == gnu
-BuildRequires: gnu-compilers%{PROJ_DELIM}
-Requires:      gnu-compilers%{PROJ_DELIM}
-%endif
-%if %{compiler_family} == intel
-BuildRequires: gcc-c++ intel-compilers-devel%{PROJ_DELIM}
-Requires:      gcc-c++ intel-compilers-devel%{PROJ_DELIM}
-%if 0%{?OHPC_BUILD}
-BuildRequires: intel_licenses
-%endif
-%endif
 
 # MPI dependencies
 %if %{mpi_family} == impi
@@ -60,8 +33,6 @@ BuildRequires: openmpi-%{compiler_family}%{PROJ_DELIM}
 Requires:      openmpi-%{compiler_family}%{PROJ_DELIM}
 %endif
 
-#-ohpc-header-comp-end------------------------------------------------
-
 # Base package name
 %define pname scalasca
 %define PNAME %(echo %{pname} | tr [a-z] [A-Z])
@@ -69,23 +40,17 @@ Requires:      openmpi-%{compiler_family}%{PROJ_DELIM}
 Summary:   Toolset for performance analysis of large-scale parallel applications
 Name:      %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Version:   2.3.1
-Release:   1
+Release:   1%{?dist}
 License:   BSD
 Group:     %{PROJ_NAME}/perf-tools
 URL:       http://www.scalasca.org
 Source0:   http://apps.fz-juelich.de/scalasca/releases/scalasca/2.3/dist/scalasca-%{version}.tar.gz
 Source1:   OHPC_macros
-Source2:   OHPC_setup_compiler
 Source3:   OHPC_setup_mpi
-BuildRoot: %{_tmppath}/%{pname}-%{version}-%{release}-root
 BuildRequires: scorep-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 BuildRequires: scorep-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  scorep-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-DocDir:    %{OHPC_PUB}/doc/contrib
 BuildRequires: zlib-devel
-
-%define debug_package %{nil}
-
 
 # Default library install path
 %define install_path %{OHPC_LIBS}/%{compiler_family}/%{mpi_family}/%{pname}/%version
@@ -113,8 +78,7 @@ This is the %{compiler_family}-%{mpi_family} version.
 %build
 
 # OpenHPC compiler/mpi designation
-export OHPC_COMPILER_FAMILY=%{compiler_family}
-. %{_sourcedir}/OHPC_setup_compiler
+%ohpc_setup_compiler
 
 export OHPC_MPI_FAMILY=%{mpi_family}
 . %{_sourcedir}/OHPC_setup_mpi
@@ -146,9 +110,8 @@ CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --with-mpi=openmpi "
 %install
 
 # OpenHPC compiler designation
-export OHPC_COMPILER_FAMILY=%{compiler_family}
+%ohpc_setup_compiler
 export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_compiler
 . %{_sourcedir}/OHPC_setup_mpi
 
 module load scorep
@@ -204,15 +167,6 @@ EOF
 
 %{__mkdir} -p $RPM_BUILD_ROOT/%{_docdir}
 
-%clean
-rm -rf $RPM_BUILD_ROOT
-
-%post
-/sbin/ldconfig || exit 1
-%postun -p /sbin/ldconfig
-
-%preun
-
 %files
 %defattr(-,root,root,-)
 %{OHPC_HOME}
@@ -221,4 +175,5 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
-
+* Wed Feb 22 2017 Adrian Reber <areber@redhat.com> - 2.3.1-1
+- Switching to %%ohpc_compiler macro

--- a/components/perf-tools/scorep/SOURCES/scorep-gcc7.patch
+++ b/components/perf-tools/scorep/SOURCES/scorep-gcc7.patch
@@ -1,0 +1,25 @@
+--- a/src/adapters/compiler/gcc-plugin/scorep_plugin_inst_descriptor.inc.c	2016-09-15 11:18:25.155032658 -0400
++++ b/src/adapters/compiler/gcc-plugin/scorep_plugin_inst_descriptor.inc.c	2017-02-22 14:25:04.482098291 -0500
+@@ -194,7 +194,7 @@
+                                         TREE_TYPE( region_descr_value ) );
+ 
+     /* Align the struct generously, so that it works for 32 and 64 bit */
+-    DECL_ALIGN( region_descr_var )      = 64 * BITS_PER_UNIT;
++    SET_DECL_ALIGN( region_descr_var, 64 * BITS_PER_UNIT);
+     DECL_USER_ALIGN( region_descr_var ) = 1;
+ 
+     /* The struct is 64 bytes, because of reserved entries */
+--- a/src/adapters/compiler/gcc-plugin/scorep_plugin_tree-flow.h	2016-09-15 11:18:25.151032708 -0400
++++ b/src/adapters/compiler/gcc-plugin/scorep_plugin_tree-flow.h	2017-02-22 14:25:04.482098291 -0500
+@@ -20,6 +20,11 @@
+ /* Test for GCC >= 4.9.0 */
+ #if SCOREP_GCC_PLUGIN_TARGET_VERSION >= 4009
+ 
++#if BUILDING_GCC_VERSION >= 7000
++#include "memmodel.h"
++#include "tree-vrp.h"
++#endif
++
+ #include "stringpool.h"
+ #include "basic-block.h"
+ #include "tree-ssa-alias.h"

--- a/components/perf-tools/scorep/SPECS/scorep.spec
+++ b/components/perf-tools/scorep/SPECS/scorep.spec
@@ -13,34 +13,9 @@
 #-ohpc-header-comp-begin----------------------------------------------
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
+%ohpc_compiler
 
-# OpenHPC convention: the default assumes the gnu toolchain and openmpi
-# MPI family; however, these can be overridden by specifing the
-# compiler_family and mpi_family variables via rpmbuild or other
-# mechanisms.
-
-%{!?compiler_family: %global compiler_family gnu}
 %{!?mpi_family:      %global mpi_family openmpi}
-
-# Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
-# environment; if building outside, lmod remains a formal build dependency).
-%if !0%{?OHPC_BUILD}
-BuildRequires: lmod%{PROJ_DELIM}
-%endif
-# Compiler dependencies
-BuildRequires: coreutils
-%if %{compiler_family} == gnu
-BuildRequires: gnu-compilers%{PROJ_DELIM}
-Requires:      gnu-compilers%{PROJ_DELIM}
-%endif
-%if %{compiler_family} == intel
-BuildRequires: gcc-c++ intel-compilers-devel%{PROJ_DELIM}
-Requires:      gcc-c++ intel-compilers-devel%{PROJ_DELIM}
-%if 0%{?OHPC_BUILD}
-BuildRequires: intel_licenses
-%endif
-%endif
 
 # MPI dependencies
 %if %{mpi_family} == impi
@@ -60,8 +35,6 @@ BuildRequires: openmpi-%{compiler_family}%{PROJ_DELIM}
 Requires:      openmpi-%{compiler_family}%{PROJ_DELIM}
 %endif
 
-#-ohpc-header-comp-end------------------------------------------------
-
 # Base package name
 %define pname scorep
 %define PNAME %(echo %{pname} | tr [a-z] [A-Z])
@@ -69,16 +42,14 @@ Requires:      openmpi-%{compiler_family}%{PROJ_DELIM}
 Summary:   Scalable Performance Measurement Infrastructure for Parallel Codes
 Name:      %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Version:   3.0
-Release:   1
+Release:   1%{?dist}
 License:   BSD
 Group:     %{PROJ_NAME}/perf-tools
 URL:       http://www.vi-hps.org/projects/score-p/
 Source0:   http://www.vi-hps.org/upload/packages/scorep/scorep-%{version}.tar.gz
 Source1:   OHPC_macros
-Source2:   OHPC_setup_compiler
 Source3:   OHPC_setup_mpi
-BuildRoot: %{_tmppath}/%{pname}-%{version}-%{release}-root
-DocDir:    %{OHPC_PUB}/doc/contrib
+Patch0:    scorep-gcc7.patch
 BuildRequires: automake
 BuildRequires: papi%{PROJ_DELIM}
 Requires:      papi%{PROJ_DELIM}
@@ -87,9 +58,6 @@ Requires     : pdtoolkit-%{compiler_family}%{PROJ_DELIM}
 BuildRequires: sionlib-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires     : sionlib-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 BuildRequires: zlib-devel
-
-%define debug_package %{nil}
-
 
 # Default library install path
 %define install_path %{OHPC_LIBS}/%{compiler_family}/%{mpi_family}/%{pname}/%version
@@ -104,14 +72,13 @@ This is the %{compiler_family}-%{mpi_family} version.
 
 
 %prep
-
 %setup -q -n %{pname}-%{version}
+%patch0 -p1
 
 %build
 
 # OpenHPC compiler/mpi designation
-export OHPC_COMPILER_FAMILY=%{compiler_family}
-. %{_sourcedir}/OHPC_setup_compiler
+%ohpc_setup_compiler
 
 export OHPC_MPI_FAMILY=%{mpi_family}
 . %{_sourcedir}/OHPC_setup_mpi
@@ -147,9 +114,8 @@ CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --with-mpi=openmpi "
 export NO_BRP_CHECK_RPATH=true
 
 # OpenHPC compiler designation
-export OHPC_COMPILER_FAMILY=%{compiler_family}
+%ohpc_setup_compiler
 export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_compiler
 . %{_sourcedir}/OHPC_setup_mpi
 
 module load papi
@@ -208,21 +174,12 @@ EOF
 
 %{__mkdir} -p $RPM_BUILD_ROOT/%{_docdir}
 
-%clean
-rm -rf $RPM_BUILD_ROOT
-
-%post
-/sbin/ldconfig || exit 1
-%postun -p /sbin/ldconfig
-
-%preun
-
 %files
 %defattr(-,root,root,-)
 %{OHPC_HOME}
 %{OHPC_PUB}
 %doc ChangeLog COPYING INSTALL OPEN_ISSUES README
 
-
 %changelog
-
+* Wed Feb 22 2017 Adrian Reber <areber@redhat.com> - 3.0-1
+- Switching to %%ohpc_compiler macro

--- a/components/serial-libs/gsl/SPECS/gsl.spec
+++ b/components/serial-libs/gsl/SPECS/gsl.spec
@@ -10,36 +10,8 @@
 
 # Serial GSL library build that is dependent on compiler toolchain
 
-#-ohpc-header-comp-begin----------------------------------------------
-
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
-
-# OpenHPC convention: the default assumes the gnu compiler family;
-# however, this can be overridden by specifing the compiler_family
-# variable via rpmbuild or other mechanisms.
-
-%{!?compiler_family: %global compiler_family gnu}
-
-# Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
-# environment; if building outside, lmod remains a formal build dependency).
-%if !0%{?OHPC_BUILD}
-BuildRequires: lmod%{PROJ_DELIM}
-%endif
-# Compiler dependencies
-%if %{compiler_family} == gnu
-BuildRequires: gnu-compilers%{PROJ_DELIM}
-Requires:      gnu-compilers%{PROJ_DELIM}
-%endif
-%if %{compiler_family} == intel
-BuildRequires: gcc-c++ intel-compilers-devel%{PROJ_DELIM}
-Requires:      gcc-c++ intel-compilers-devel%{PROJ_DELIM}
-%if 0%{OHPC_BUILD}
-BuildRequires: intel_licenses
-%endif
-%endif
-
-#-ohpc-header-comp-end------------------------------------------------
+%ohpc_compiler
 
 # Base package name
 %define pname gsl
@@ -48,19 +20,14 @@ BuildRequires: intel_licenses
 Summary:   GNU Scientific Library (GSL)
 Name:      %{pname}-%{compiler_family}%{PROJ_DELIM}
 Version:   2.2.1
-Release:   1
+Release:   1%{?dist}
 License:   GPL
 Group:     %{PROJ_NAME}/serial-libs
 URL:       http://www.gnu.org/software/gsl
 Source0:   https://ftp.gnu.org/gnu/%{pname}/%{pname}-%{version}.tar.gz
 Source1:   OHPC_macros
-Source2:   OHPC_setup_compiler
-BuildRoot: %{_tmppath}/%{pname}-%{version}-%{release}-root
-DocDir:    %{OHPC_PUB}/doc/contrib
 
 #!BuildIgnore: post-build-checks rpmlint-Factory
-
-%define debug_package %{nil}
 
 # Default library install path
 %define install_path %{OHPC_LIBS}/%{compiler_family}/%{pname}/%version
@@ -79,8 +46,7 @@ lends itself to being used in very high level languages (VHLLs).
 
 %build
 # OpenHPC compiler/mpi designation
-export OHPC_COMPILER_FAMILY=%{compiler_family}
-. %{_sourcedir}/OHPC_setup_compiler
+%ohpc_setup_compiler
 
 %if %{compiler_family} == intel
 export CFLAGS="-fp-model strict $CFLAGS"
@@ -91,9 +57,7 @@ make %{?_smp_mflags}
 
 %install
 # OpenHPC compiler designation
-export OHPC_COMPILER_FAMILY=%{compiler_family}
-. %{_sourcedir}/OHPC_setup_compiler
-
+%ohpc_setup_compiler
 make %{?_smp_mflags} DESTDIR=$RPM_BUILD_ROOT install
 
 # Remove static libraries
@@ -149,3 +113,5 @@ rm -rf $RPM_BUILD_ROOT
 %doc AUTHORS BUGS ChangeLog COPYING INSTALL NEWS README THANKS TODO
 
 %changelog
+* Mon Feb 20 2017 Adrian Reber <areber@redhat.com> - 2.2.1-1
+- Switching to %%ohpc_compiler macro

--- a/components/serial-libs/metis/SPECS/metis.spec
+++ b/components/serial-libs/metis/SPECS/metis.spec
@@ -11,36 +11,7 @@
 # Serial metis build dependent on compiler toolchain
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
-
-#-ohpc-header-comp-begin-----------------------------
-
-# OpenHPC convention: the default assumes the gnu compiler family;
-# however, this can be overridden by specifing the compiler_family
-# variable via rpmbuild or other mechanisms.
-
-%{!?compiler_family: %global compiler_family gnu}
-
-# Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
-# environment; if building outside, lmod remains a formal build dependency).
-%if !0%{?OHPC_BUILD}
-BuildRequires: lmod%{PROJ_DELIM}
-%endif
-# Compiler dependencies
-BuildRequires: coreutils
-%if %{compiler_family} == gnu
-BuildRequires: gnu-compilers%{PROJ_DELIM} 
-Requires:      gnu-compilers%{PROJ_DELIM}
-%endif
-%if %{compiler_family} == intel
-BuildRequires: gcc-c++ intel-compilers-devel%{PROJ_DELIM}
-Requires:      gcc-c++ intel-compilers-devel%{PROJ_DELIM}
-%if 0%{?OHPC_BUILD}
-BuildRequires: intel_licenses
-%endif
-%endif
-
-#-ohpc-header-comp-end-------------------------------
+%ohpc_compiler
 
 # Base package name
 %define pname metis
@@ -49,23 +20,18 @@ BuildRequires: intel_licenses
 Name:    %{pname}-%{compiler_family}%{PROJ_DELIM}
 Summary: Serial Graph Partitioning and Fill-reducing Matrix Ordering
 Version: 5.1.0
-Release: 1
+Release: 1%{?dist}
 License: Apache License 2.0
 Group:   %{PROJ_NAME}/serial-libs
 URL:     http://glaros.dtc.umn.edu/gkhome/metis/metis/overview
 Source0: http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/metis-%{version}.tar.gz
 Source1: OHPC_macros
-Source2: OHPC_setup_compiler
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildRequires: make
 BuildRequires: pkgconfig
 BuildRequires: cmake
 Requires:      libmetis0 = %{version}
 Provides:      libmetis = %{version}
 Provides:      libmetis0 = %{version}
-DocDir:        %{OHPC_PUB}/doc/contrib
-
-%define debug_package %{nil}
 
 # Default library install path
 %define install_path %{OHPC_LIBS}/%{compiler_family}/%{pname}/%version
@@ -102,19 +68,15 @@ shown to produce high quality results and scale to very large problems.
 %prep
 %setup -q -n %{pname}-%{version}
 %build
-
 # OpenHPC compiler/mpi designation
-export OHPC_COMPILER_FAMILY=%{compiler_family}
-. %{_sourcedir}/OHPC_setup_compiler
+%ohpc_setup_compiler
 
 make config shared=1 prefix=%{install_path}
 make
 
 %install
-
 # OpenHPC compiler/mpi designation
-export OHPC_COMPILER_FAMILY=%{compiler_family}
-. %{_sourcedir}/OHPC_setup_compiler
+%ohpc_setup_compiler
 
 make install DESTDIR=${RPM_BUILD_ROOT}
 
@@ -160,18 +122,13 @@ EOF
 
 %{__mkdir} -p %{buildroot}/%{_docdir}
 
-%post -n libmetis0
-/sbin/ldconfig
-
-%postun -n libmetis0
-/sbin/ldconfig
-
-%clean
-rm -fr %buildroot
-
 %files
 %defattr(-,root,root)
 %{OHPC_HOME}
 
 %{OHPC_PUB}
 %doc BUILD.txt Changelog Install.txt LICENSE.txt
+
+%changelog
+* Mon Feb 20 2017 Adrian Reber <areber@redhat.com> - 5.1.0-1
+- Switching to %%ohpc_compiler macro


### PR DESCRIPTION
The following commits are a bit larger change. This adds the possibility to change between the original gnu compiler (5.4.0) a gnu 6.x compiler based on the software collection devtoolset-6 (https://www.softwarecollections.org/en/scls/rhscl/devtoolset-6/) and a gcc 7 based gnu-compiler package.

To change the used compiler the compiler_family variable needs to be set to either gnu (5.4), dts6 (6.x) or gnu7 (pre gcc 7).

The results of the rebuilds can be found in my copr repositories:

https://copr.fedorainfracloud.org/coprs/adrian/ohpc-gcc7/packages/
https://copr.fedorainfracloud.org/coprs/adrian/ohpc-dts6/packages/

To make it easier to add additional compilers many (almost) identical macros have been move from the individual SPEC files to the common OHPC_macros files. Thus every compiler dependent SPEC had to be changed. So, alltough many files had to be changed the good thing is that a lot of code could be removed:

45 files changed, 617 insertions(+), 1702 deletions(-)

As this change also required adapting the OHPC_setup_compiler file I moved this file to a central package so that it exists only once and does not need to be part of every SPEC file.
The two new base packages are ohpc-filesystem which is required now by every openHPC package. This package only provides the base directories of the openHPC tree. Instead of every package owning /opt/ohpc this is now part of this new package. Details in that corresponding commit message.
The other new base package is ohpc-buildroot which provides OHPC_setup_compiler and OHPC_setup_mpi. In addition ohpc-buildroot also requires the lmod-ohpc package. This package seems to be automatically pulled in by the OpenSuse Build Service. Instead of relying on implicit functionality of the build system those dependencies are now explicitly listed.

The new macros are now %ohpc_compiler which replaces the initial compiler section of almost every SPEC file. The second new macro is %ohpc_setup_compiler which replaces the explicit call to OHPC_setup_compiler by a single macro.

In addition unnecessary parts of the spec files have been removed. ldconfig never needs to be executed as the libraries are not in paths ldconfig looks into. '%clean' section are also not required in RPM for a long time. BuildRoot is also always set by RPM automatically.