### PR TITLE
use systemd units in slurm

### DIFF
--- a/components/rms/slurm/SPECS/slurm.spec
+++ b/components/rms/slurm/SPECS/slurm.spec
@@ -1158,10 +1158,6 @@ exit 0
 
 %if 0%{?suse_version}
 %{fillup_and_insserv -f}
-%else
-if [ $1 = 1 ]; then
-   [ -x /sbin/chkconfig ] && /sbin/chkconfig --add slurm
-fi
 %endif
 
 if [ -x /sbin/ldconfig ]; then
@@ -1196,9 +1192,7 @@ if [ "$1" = 0 ]; then
 fi
 
 %postun
-if [ "$1" -gt 1 ]; then
-    /etc/init.d/slurm condrestart
-elif [ "$1" -eq 0 ]; then
+if [ "$1" -eq 0 ]; then
     if [ -x /sbin/ldconfig ]; then
 	/sbin/ldconfig %{_libdir}
     fi
@@ -1208,9 +1202,6 @@ fi
 %endif
 
 %postun -n %{pname}-slurmdbd%{PROJ_DELIM}
-if [ "$1" -gt 1 ]; then
-    /etc/init.d/slurmdbd condrestart
-fi
 
 #############################################################################
 

--- a/components/rms/slurm/SPECS/slurm.spec
+++ b/components/rms/slurm/SPECS/slurm.spec
@@ -1159,7 +1159,9 @@ exit 0
 %if 0%{?suse_version}
 %{fillup_and_insserv -f}
 %endif
-
+%if 0%{?rhel_version} >= 700 || 0%{?centos_version} >= 700
+%systemd_post slurmd.service
+%endif
 if [ -x /sbin/ldconfig ]; then
     /sbin/ldconfig %{_libdir}
 fi
@@ -1172,6 +1174,9 @@ fi
 %endif
 
 %preun
+%if 0%{?rhel_version} >= 700 || 0%{?centos_version} >= 700
+%systemd_preun slurmd.service
+%endif
 if [ "$1" -eq 0 ]; then
     if [ -x /etc/init.d/slurm ]; then
 	[ -x /sbin/chkconfig ] && /sbin/chkconfig --del slurm
@@ -1200,8 +1205,14 @@ fi
 %if %{?insserv_cleanup:1}0
 %insserv_cleanup
 %endif
+%if 0%{?rhel_version} >= 700 || 0%{?centos_version} >= 700
+%systemd_postun_with_restart systemd.service
+%endif
 
 %postun -n %{pname}-slurmdbd%{PROJ_DELIM}
+%if 0%{?rhel_version} >= 700 || 0%{?centos_version} >= 700
+systemd_postun_with_restart slurmdbd.service
+%endif
 
 #############################################################################
 

--- a/components/rms/slurm/SPECS/slurm.spec
+++ b/components/rms/slurm/SPECS/slurm.spec
@@ -897,9 +897,9 @@ rm -rf $RPM_BUILD_ROOT
 
 %if 0%{?suse_version} >= 1200 || 0%{?rhel_version} >= 700 || 0%{?centos_version} >= 700
 
-%config /usr/lib/systemd/system/slurmctld.service
-%config /usr/lib/systemd/system/slurmd.service
-%config /usr/lib/systemd/system/slurmdbd.service
+/usr/lib/systemd/system/slurmctld.service
+/usr/lib/systemd/system/slurmd.service
+/usr/lib/systemd/system/slurmdbd.service
 
 %endif
 


### PR DESCRIPTION
This is my proposed fix for issue #388 Maybe the LSB init scripts can be removed later as well, I am not sure about SLES.