### PR TITLE
Remove post-build-checks conflicts for slurm,munge,warewulf

### DIFF
--- a/components/provisioning/warewulf-ipmi/SPECS/warewulf-ipmi.spec
+++ b/components/provisioning/warewulf-ipmi/SPECS/warewulf-ipmi.spec
@@ -39,7 +39,7 @@ BuildRequires: autoconf
 BuildRequires: automake
 BuildRequires: warewulf-common%{PROJ_DELIM}
 Conflicts: warewulf < 3
-BuildConflicts: post-build-checks
+#!BuildIgnore: post-build-checks
 BuildRoot: %{?_tmppath}%{!?_tmppath:/var/tmp}/%{pname}-%{version}-%{release}-root
 DocDir: %{OHPC_PUB}/doc/contrib
 

--- a/components/provisioning/warewulf-provision/SPECS/warewulf-provision.spec
+++ b/components/provisioning/warewulf-provision/SPECS/warewulf-provision.spec
@@ -35,7 +35,7 @@ BuildRequires: automake
 BuildRequires: warewulf-common%{PROJ_DELIM}
 BuildRequires: libselinux-devel
 Conflicts: warewulf < 3
-BuildConflicts: post-build-checks
+#!BuildIgnore: post-build-checks
 BuildRoot: %{?_tmppath}%{!?_tmppath:/var/tmp}/%{pname}-%{version}-%{release}-root
 DocDir: %{OHPC_PUB}/doc/contrib
 Patch1: warewulf-provision.httpdconfdir.patch

--- a/components/rms/munge/SPECS/munge.spec
+++ b/components/rms/munge/SPECS/munge.spec
@@ -46,7 +46,7 @@ BuildRequires:	systemd
 %endif
 BuildRoot:	%{_tmppath}/%{pname}-%{version}
 DocDir:     %{OHPC_PUB}/doc/contrib
-BuildConflicts: post-build-checks
+#!BuildIgnore: post-build-checks
 
 Conflicts: munge 
 

--- a/components/rms/slurm/SPECS/slurm.spec
+++ b/components/rms/slurm/SPECS/slurm.spec
@@ -130,7 +130,7 @@ BuildRequires: klogd sysconfig
 %endif
 
 Requires: %{pname}-plugins%{PROJ_DELIM}
-BuildConflicts: post-build-checks
+#!BuildIgnore: post-build-checks
 
 %ifos linux
 BuildRequires: python


### PR DESCRIPTION
slurm, munge and warewulf all use BuildConflicts for post-build-checks.
I noticed that almost every other package in ohpc has #!BuildIgnore instead.
I'm not sure if this difference is intentional or not.

Privately, I'm using OBS 2.8 (build.openhpc.community uses OBS 2.7), and these three packages fail to build unless I make these changes.

According to this url, OBS previously didn't handle buildconflicts correctly and now does: https://github.com/openSUSE/open-build-service/issues/2004
