### PR TITLE
EasyBuild v3.2.1

### DIFF
--- a/components/dev-tools/easybuild/SPECS/easybuild.spec
+++ b/components/dev-tools/easybuild/SPECS/easybuild.spec
@@ -15,12 +15,12 @@
 %define pname easybuild
 %define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
-%define vsc_base_ver 2.5.7
-%define vsc_install_ver 0.10.25
+%define vsc_base_ver 2.5.8
+%define vsc_install_ver 0.10.26
 
 Summary:   Build and installation framework
 Name:      EasyBuild%{PROJ_DELIM}
-Version:   3.1.2
+Version:   3.2.1
 Release:   1
 License:   GPLv2
 Group:     %{PROJ_NAME}/dev-tools


### PR DESCRIPTION
Although the updating the bootstrap script is not strictly required, it's worthwhile since it was enhanced a bit to have better sanity checking, cfr. https://github.com/hpcugent/easybuild-framework/pull/2199 (it would have helped in catching the problem we had a while ago with having `$EASYBUILD_VERSION` set).