### PR TITLE
Also simplify the mpi selection

### DIFF
--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -56,7 +56,7 @@ BuildRequires: ohpc-buildroot
 # Compiler dependencies
 %if 0%{?ohpc_compiler_dependent} == 1
 
-%if "%{compiler_family}" == "gnu" 
+%if "%{compiler_family}" == "gnu"
 BuildRequires: gnu-compilers%{PROJ_DELIM} >= 7.1.0
 Requires:      gnu-compilers%{PROJ_DELIM} >= 7.1.0
 %endif
@@ -85,7 +85,7 @@ Requires:      gnu-7-compilers%{PROJ_DELIM}
 %if "%{mpi_family}" == "impi"
 BuildRequires: intel-mpi-devel%{PROJ_DELIM}
 Requires:      intel-mpi-devel%{PROJ_DELIM}
-%endif 
+%endif
 %if "%{mpi_family}" == "mpich"
 BuildRequires: mpich-%{compiler_family}%{PROJ_DELIM}
 Requires:      mpich-%{compiler_family}%{PROJ_DELIM}

--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -102,4 +102,7 @@ Requires:      openmpi-%{compiler_family}%{PROJ_DELIM}
 
 %global ohpc_setup_compiler %{expand:\
 	. %{OHPC_ADMIN}/ohpc/OHPC_setup_compiler %{compiler_family} \
+	%if 0%{?ohpc_mpi_dependent} == 1 \
+		. %{OHPC_ADMIN}/ohpc/OHPC_setup_mpi %{mpi_family} \
+	%endif \
 }

--- a/components/OHPC_setup_mpi
+++ b/components/OHPC_setup_mpi
@@ -16,6 +16,10 @@
 # Sets up build environment for supported MPI families
 #-----------------------------------------------------------------------
 
+if [ "$#" = "1" ]; then
+    OHPC_MPI_FAMILY=$1
+fi
+
 if [ -z "$OHPC_MPI_FAMILY" ]; then
     echo "Unknown OHPC_MPI_FAMILY"
     exit 1

--- a/components/dev-tools/scipy/SPECS/python-scipy.spec
+++ b/components/dev-tools/scipy/SPECS/python-scipy.spec
@@ -61,7 +61,7 @@ Requires:      openmpi-%{compiler_family}%{PROJ_DELIM}
 
 Name:           python-%{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Version:        0.19.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Scientific Tools for Python
 License:        BSD-3-Clause
 Group:          %{PROJ_NAME}/dev-tools
@@ -69,7 +69,6 @@ Url:            http://www.scipy.org
 Source0:        https://github.com/scipy/scipy/archive/v%{version}.tar.gz#$/%{pname}-%{version}.tar.gz
 BuildRequires:  blas-devel
 Source1:        OHPC_macros
-Source3:        OHPC_setup_mpi
 %if 0%{?sles_version} || 0%{?suse_version}
 BuildRequires:  fdupes
 %endif
@@ -121,9 +120,6 @@ EOF
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
 
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
-
 %if "%{compiler_family}" != "intel"
 module load openblas
 %endif
@@ -145,9 +141,6 @@ python setup.py config_fc --fcompiler=gnu95 --noarch build
 %install
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
-
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 
 %if %{compiler_family} == gnu
 module load openblas
@@ -227,6 +220,9 @@ EOF
 %doc LICENSE.txt
 
 %changelog
+* Tue May 23 2017 Adrian Reber <areber@redhat.com> - 0.19.0-2
+- Remove separate mpi setup; it is part of the %%ohpc_compiler macro
+
 * Fri May 12 2017 Karl W Schulz <karl.w.schulz@intel.com> - 0.19.0-1
 - switch to ohpc_compiler_dependent flag
 

--- a/components/io-libs/adios/SPECS/adios.spec
+++ b/components/io-libs/adios/SPECS/adios.spec
@@ -22,13 +22,12 @@
 Summary: The Adaptable IO System (ADIOS)
 Name:    %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Version: 1.11.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: BSD-3-Clause
 Group:   %{PROJ_NAME}/io-libs
 Url:     http://www.olcf.ornl.gov/center-projects/adios/
 Source0: http://users.nccs.gov/~pnorbert/adios-%{version}.tar.gz
 Source1: OHPC_macros
-Source3: OHPC_setup_mpi
 AutoReq: no
 
 BuildRequires: zlib-devel glib2-devel
@@ -83,8 +82,6 @@ sed -i "s|@64@|$LIBSUFF|" wrappers/numpy/setup*
 
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 
 module load autotools
 module load phdf5
@@ -152,8 +149,6 @@ chmod +x adios_config
 %install
 # OpenHPC compiler designation
 %ohpc_setup_compiler
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 export NO_BRP_CHECK_RPATH=true
 
 make DESTDIR=$RPM_BUILD_ROOT install
@@ -257,6 +252,9 @@ EOF
 %doc TODO
 
 %changelog
+* Tue May 23 2017 Adrian Reber <areber@redhat.com> - 1.11.0-2
+- Remove separate mpi setup; it is part of the %%ohpc_compiler macro
+
 * Fri May 12 2017 Karl W Schulz <karl.w.schulz@intel.com> - 1.11.0-1
 - switch to use of ohpc_compiler_dependent and ohpc_mpi_dependent flags
 

--- a/components/io-libs/netcdf-CXX/SPECS/netcdf-cxx4.spec
+++ b/components/io-libs/netcdf-CXX/SPECS/netcdf-cxx4.spec
@@ -39,12 +39,10 @@ Summary:        C++ Libraries for the Unidata network Common Data Form
 License:        NetCDF
 Group:          %{PROJ_NAME}/io-libs
 Version:        4.3.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Url:            http://www.unidata.ucar.edu/software/netcdf/
 Source0:	https://github.com/Unidata/netcdf-cxx4/archive/v%{version}.tar.gz
 Source101:	OHPC_macros
-Source103:	OHPC_setup_mpi
-
 
 BuildRequires:  zlib-devel >= 1.2.5
 BuildRequires:  phdf5-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
@@ -95,8 +93,6 @@ NetCDF data is:
 %build
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 
 module load phdf5
 module load netcdf
@@ -118,8 +114,6 @@ make %{?_smp_mflags}
 %install
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 
 module load phdf5
 module load netcdf
@@ -193,6 +187,9 @@ EOF
 %doc COPYRIGHT
 
 %changelog
+* Tue May 23 2017 Adrian Reber <areber@redhat.com> - 4.3.0-2
+- Remove separate mpi setup; it is part of the %%ohpc_compiler macro
+
 * Fri May 12 2017 Karl W Schulz <karl.w.schulz@intel.com> - 4.3.0-1
 - switch to use of ohpc_compiler_dependent and ohpc_mpi_dependent flags
 

--- a/components/io-libs/netcdf-Fortran/SPECS/netcdf-fortran.spec
+++ b/components/io-libs/netcdf-Fortran/SPECS/netcdf-fortran.spec
@@ -39,7 +39,7 @@ Summary:        Fortran Libraries for the Unidata network Common Data Form
 License:        NetCDF
 Group:          %{PROJ_NAME}/io-libs
 Version:        4.4.4
-Release:        1%{?dist}
+Release:        2%{?dist}
 Url:            http://www.unidata.ucar.edu/software/netcdf/
 Source0:	https://github.com/Unidata/netcdf-fortran/archive/v%{version}.tar.gz
 Source101:	OHPC_macros
@@ -93,8 +93,6 @@ NetCDF data is:
 %build
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 
 module load phdf5
 module load netcdf
@@ -120,8 +118,6 @@ make %{?_smp_mflags}
 %install
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 
 module load phdf5
 module load netcdf
@@ -195,6 +191,9 @@ EOF
 %doc README.md
 
 %changelog
+* Tue May 23 2017 Adrian Reber <areber@redhat.com> - 4.4.4-2
+- Remove separate mpi setup; it is part of the %%ohpc_compiler macro
+
 * Fri May 12 2017 Karl W Schulz <karl.w.schulz@intel.com> - 4.4.4-1
 - switch to use of ohpc_compiler_dependent and ohpc_mpi_dependent flags
 

--- a/components/io-libs/netcdf/SPECS/netcdf.spec
+++ b/components/io-libs/netcdf/SPECS/netcdf.spec
@@ -42,12 +42,10 @@ Summary:        C Libraries for the Unidata network Common Data Form
 License:        NetCDF
 Group:          %{PROJ_NAME}/io-libs
 Version:        4.4.1.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Url:            http://www.unidata.ucar.edu/software/netcdf/
 Source0:	https://github.com/Unidata/netcdf-c/archive/v%{version}.tar.gz
 Source101:	OHPC_macros
-Source103:	OHPC_setup_mpi
-
 
 BuildRequires:  zlib-devel >= 1.2.5
 BuildRequires:  m4
@@ -97,8 +95,6 @@ NetCDF data is:
 %build
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 
 module load phdf5
 export CPPFLAGS="-I$HDF5_INC"
@@ -120,8 +116,6 @@ make %{?_smp_mflags}
 %install
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 
 module load phdf5
 export CFLAGS="-L$HDF5_LIB -I$HDF5_INC"
@@ -194,6 +188,9 @@ EOF
 %doc README.md
 
 %changelog
+* Tue May 23 2017 Adrian Reber <areber@redhat.com> - 4.4.1.1-2
+- Remove separate mpi setup; it is part of the %%ohpc_compiler macro
+
 * Fri May 12 2017 Karl W Schulz <karl.w.schulz@intel.com> - 4.4.1.1-1
 - switch to use of ohpc_compiler_dependent and ohpc_mpi_dependent flags
 

--- a/components/io-libs/phdf5/SPECS/hdf5.spec
+++ b/components/io-libs/phdf5/SPECS/hdf5.spec
@@ -38,14 +38,13 @@
 Summary:   A general purpose library and file format for storing scientific data
 Name:      p%{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Version:   1.10.0
-Release:   1%{?dist}
+Release:   2%{?dist}
 License:   Hierarchical Data Format (HDF) Software Library and Utilities License
 Group:     %{PROJ_NAME}/io-libs
 URL:       http://www.hdfgroup.org/HDF5
 
 Source0:   https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/%{pname}-%{version}-patch1/src/%{pname}-%{version}-patch1.tar.bz2
 Source1:   OHPC_macros
-Source3:   OHPC_setup_mpi
 BuildRequires: zlib-devel
 
 #!BuildIgnore: post-build-checks rpmlint-Factory
@@ -75,8 +74,6 @@ cp /usr/lib/rpm/config.guess bin
 
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 
 export CC=mpicc
 export CXX=mpicxx
@@ -97,8 +94,6 @@ export MPICXX=mpicxx
 
 # OpenHPC compiler designation
 %ohpc_setup_compiler
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 
 export NO_BRP_CHECK_RPATH=true
 
@@ -157,6 +152,9 @@ EOF
 %doc README.txt
 
 %changelog
+* Tue May 23 2017 Adrian Reber <areber@redhat.com> - 1.10.0-2
+- Remove separate mpi setup; it is part of the %%ohpc_compiler macro
+
 * Fri May 12 2017 Karl W Schulz <karl.w.schulz@intel.com> - 1.10.0-1
 - switch to use of ohpc_compiler_dependent and ohpc_mpi_dependent flags
 

--- a/components/io-libs/sionlib/SPECS/sionlib.spec
+++ b/components/io-libs/sionlib/SPECS/sionlib.spec
@@ -20,13 +20,12 @@
 Summary:   Scalable Performance Measurement Infrastructure for Parallel Codes
 Name:      %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Version:   1.7.1
-Release:   1%{?dist}
+Release:   2%{?dist}
 License:   BSD
 Group:     %{PROJ_NAME}/io-tools
 URL:       http://www.fz-juelich.de/ias/jsc/EN/Expertise/Support/Software/SIONlib/_node.html
 Source0:   http://apps.fz-juelich.de/jsc/sionlib/download.php?version=%{version}#/%{pname}-%{version}.tar.gz
 Source1:   OHPC_macros
-Source3:   OHPC_setup_mpi
 Patch0:    gcc-6-7.patch
 
 # Default library install path
@@ -48,9 +47,6 @@ This is the %{compiler_family}-%{mpi_family} version.
 
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
-
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 
 %if %{compiler_family} == intel
 CONFIGURE_OPTIONS="--compiler=intel --disable-parutils "
@@ -87,8 +83,6 @@ sed -i 's|-g|-g -fpic|g' build-*/Makefile.defs
 
 # OpenHPC compiler designation
 %ohpc_setup_compiler
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 
 make DESTDIR=$RPM_BUILD_ROOT install
 
@@ -149,6 +143,9 @@ EOF
 %doc COPYRIGHT LICENSE README INSTALL RELEASE
 
 %changelog
+* Tue May 23 2017 Adrian Reber <areber@redhat.com> - 1.7.1-2
+- Remove separate mpi setup; it is part of the %%ohpc_compiler macro
+
 * Fri May 12 2017 Karl W Schulz <karl.w.schulz@intel.com> - 1.7.1-1
 - switch to use of ohpc_compiler_dependent and ohpc_mpi_dependent flags
 

--- a/components/parallel-libs/boost/SPECS/boost.spec
+++ b/components/parallel-libs/boost/SPECS/boost.spec
@@ -42,7 +42,7 @@ Version:        1.63.0
 
 %define version_exp 1_63_0
 
-Release:        0%{?dist}
+Release:        1%{?dist}
 License:        BSL-1.0
 Group:		%{PROJ_NAME}/parallel-libs
 Url:            http://www.boost.org
@@ -52,7 +52,6 @@ Source2:        mkl_boost_ublas_gemm.hpp
 Source3:        mkl_boost_ublas_matrix_prod.hpp
 Source100:      baselibs.conf
 Source101:	OHPC_macros
-Source103:	OHPC_setup_mpi
 
 %if 0%{?rhel_version} || 0%{?centos_version} || 0%{?rhel}
 BuildRequires:  bzip2-devel
@@ -104,8 +103,6 @@ see the boost-doc package.
 %ohpc_setup_compiler
 
 %if %build_mpi
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 export CC=mpicc
 export CXX=mpicxx
 export F77=mpif77
@@ -134,8 +131,6 @@ EOF
 %ohpc_setup_compiler
 
 %if %build_mpi
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 export CC=mpicc
 export CXX=mpicxx
 export F77=mpif77
@@ -205,6 +200,9 @@ EOF
 %doc INSTALL LICENSE_1_0.txt
 
 %changelog
+* Tue May 23 2017 Adrian Reber <areber@redhat.com> - 1.63.0-1
+- Remove separate mpi setup; it is part of the %%ohpc_compiler macro
+
 * Fri May 12 2017 Karl W Schulz <karl.w.schulz@intel.com> - 1.63.0-0
 - switch to use of ohpc_compiler_dependent and ohpc_mpi_dependent flags
 

--- a/components/parallel-libs/fftw/SPECS/fftw.spec
+++ b/components/parallel-libs/fftw/SPECS/fftw.spec
@@ -20,13 +20,12 @@
 Summary:   A Fast Fourier Transform library
 Name:      %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Version:   3.3.6
-Release:   1%{?dist}
+Release:   2%{?dist}
 License:   GPLv2+
 Group:     %{PROJ_NAME}/parallel-libs
 URL:       http://www.fftw.org
 Source0:   http://www.fftw.org/fftw-%{version}-pl2.tar.gz
 Source1:   OHPC_macros
-Source3:   OHPC_setup_mpi
 
 %define openmp        1
 %define mpi           1
@@ -60,8 +59,6 @@ BASEFLAGS="$BASEFLAGS --enable-openmp"
 %endif
 %if %{mpi}
 BASEFLAGS="$BASEFLAGS --enable-mpi"
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 %endif
 
 ./configure --prefix=%{install_path} ${BASEFLAGS} --enable-static=no || { cat config.log && exit 1; }
@@ -71,8 +68,6 @@ make
 %install
 # OpenHPC compiler designation
 %ohpc_setup_compiler
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 
 make DESTDIR=$RPM_BUILD_ROOT install
 
@@ -139,6 +134,9 @@ fi
 %doc AUTHORS ChangeLog CONVENTIONS COPYING COPYRIGHT INSTALL NEWS README TODO
 
 %changelog
+* Tue May 23 2017 Adrian Reber <areber@redhat.com> - 3.3.6-2
+- Remove separate mpi setup; it is part of the %%ohpc_compiler macro
+
 * Fri May 12 2017 Karl W Schulz <karl.w.schulz@intel.com> - 3.3.6-1
 - switch to use of ohpc_compiler_dependent and ohpc_mpi_dependent flags
 

--- a/components/parallel-libs/hypre/SPECS/hypre.spec
+++ b/components/parallel-libs/hypre/SPECS/hypre.spec
@@ -41,14 +41,13 @@ Requires:      openblas-%{compiler_family}%{PROJ_DELIM}
 
 Name:           %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Version:        2.11.1
-Release:        0%{?dist}
+Release:        1%{?dist}
 Summary:        Scalable algorithms for solving linear systems of equations
 License:        LGPL-2.1
 Group:          ohpc/parallel-libs
 Url:            http://www.llnl.gov/casc/hypre/
 Source:         https://computation.llnl.gov/project/linear_solvers/download/hypre-%{version}.tar.gz
 Source1:        OHPC_macros
-Source3:        OHPC_setup_mpi
 %if 0%{?suse_version} <= 1110
 %{!?python_sitearch: %global python_sitearch %(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
 %endif
@@ -89,8 +88,6 @@ cp /usr/lib/rpm/config.guess src/config
 %endif
 
 %ohpc_setup_compiler
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 
 module load superlu
 
@@ -137,8 +134,6 @@ cd ..
 
 %install
 %ohpc_setup_compiler
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 
 module load superlu
 
@@ -251,6 +246,9 @@ EOF
 %doc CHANGELOG COPYING.LESSER COPYRIGHT INSTALL README
 
 %changelog
+* Tue May 23 2017 Adrian Reber <areber@redhat.com> - 2.11.1-1
+- Remove separate mpi setup; it is part of the %%ohpc_compiler macro
+
 * Fri May 12 2017 Karl W Schulz <karl.w.schulz@intel.com> - 2.11.1-0
 - switch to use of ohpc_compiler_dependent and ohpc_mpi_dependent flags
 

--- a/components/parallel-libs/mumps/SPECS/mumps.spec
+++ b/components/parallel-libs/mumps/SPECS/mumps.spec
@@ -36,7 +36,7 @@
 
 Name:           %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Version:        5.1.1
-Release:        0%{?dist}
+Release:        1%{?dist}
 Summary:        A MUltifrontal Massively Parallel Sparse direct Solver
 License:        CeCILL-C
 Group:          %{PROJ_NAME}/parallel-libs
@@ -47,7 +47,6 @@ Source2:        Makefile.gnu.impi.inc
 Source3:        Makefile.mkl.intel.impi.inc
 Source4:        Makefile.mkl.intel.openmpi.inc
 Source5:        OHPC_macros
-Source7:        OHPC_setup_mpi
 Patch0:         mumps-5.0.1-shared-mumps.patch
 Patch1:         mumps-5.0.0-shared-pord.patch
 Patch2:         mumps-5.0.2-psxe2017.patch
@@ -82,8 +81,6 @@ C interfaces, and can interface with ordering tools such as Scotch.
 
 %build
 %ohpc_setup_compiler
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 
 # Enable scalapack linkage for blas/lapack with gnu builds
 %if "%{compiler_family}" != "intel"
@@ -209,6 +206,9 @@ EOF
 %doc ChangeLog CREDITS INSTALL LICENSE README VERSION
 
 %changelog
+* Tue May 23 2017 Adrian Reber <areber@redhat.com> - 5.1.1-1
+- Remove separate mpi setup; it is part of the %%ohpc_compiler macro
+
 * Fri May 12 2017 Karl W Schulz <karl.w.schulz@intel.com> - 5.1.1-0
 - switch to use of ohpc_compiler_dependent and ohpc_mpi_dependent flags
 

--- a/components/parallel-libs/petsc/SPECS/petsc.spec
+++ b/components/parallel-libs/petsc/SPECS/petsc.spec
@@ -27,10 +27,9 @@ Summary:        Portable Extensible Toolkit for Scientific Computation
 License:        2-clause BSD
 Group:          %{PROJ_NAME}/parallel-libs
 Version:        3.7.6
-Release:        0%{?dist}
+Release:        1%{?dist}
 Source0:        http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-%{version}.tar.gz
 Source1:        OHPC_macros
-Source3:        OHPC_setup_mpi
 Patch1:         petsc.rpath.patch
 Url:            http://www.mcs.anl.gov/petsc/
 BuildRequires:  phdf5-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
@@ -58,8 +57,6 @@ differential equations.
 %build
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 
 module load phdf5
 
@@ -181,6 +178,9 @@ EOF
 %doc CONTRIBUTING LICENSE
 
 %changelog
+* Tue May 23 2017 Adrian Reber <areber@redhat.com> - 3.7.6-1
+- Remove separate mpi setup; it is part of the %%ohpc_compiler macro
+
 * Fri May 12 2017 Karl W Schulz <karl.w.schulz@intel.com> - 3.7.6-0
 - switch to use of ohpc_compiler_dependent and ohpc_mpi_dependent flags
 

--- a/components/parallel-libs/scalapack/SPECS/scalapack.spec
+++ b/components/parallel-libs/scalapack/SPECS/scalapack.spec
@@ -44,13 +44,12 @@ Summary:        A subset of LAPACK routines redesigned for heterogenous computin
 License:        netlib ScaLAPACK License
 Group:          Development/Libraries/Parallel
 Version:        2.0.2
-Release:        13.1%{?dist}
+Release:        13.2%{?dist}
 # This is freely distributable without any restrictions.
 Url:            http://www.netlib.org/lapack-dev/
 Source0:        http://www.netlib.org/scalapack/scalapack-%{version}.tgz
 Source1:        baselibs.conf
 Source2:        OHPC_macros
-Source4:        OHPC_setup_mpi
 Patch0:         scalapack-2.0.2-shared-lib.patch
 
 %description
@@ -89,8 +88,6 @@ cp SLmake.inc.example SLmake.inc
 
 %build
 %ohpc_setup_compiler
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 %if "%{compiler_family}" != "intel"
 module load openblas
 %endif
@@ -160,6 +157,9 @@ EOF
 %doc README LICENSE
 
 %changelog
+* Tue May 23 2017 Adrian Reber <areber@redhat.com> - 2.0.2-13.2
+- Remove separate mpi setup; it is part of the %%ohpc_compiler macro
+
 * Fri May 12 2017 Karl W Schulz <karl.w.schulz@intel.com> - 2.0.2-13.1
 - switch to use of ohpc_compiler_dependent and ohpc_mpi_dependent flags
 

--- a/components/parallel-libs/superlu_dist/SPECS/superlu_dist.spec
+++ b/components/parallel-libs/superlu_dist/SPECS/superlu_dist.spec
@@ -44,14 +44,13 @@ Requires:      scalapack-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 
 Name:           %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Version:        4.2
-Release:        0%{?dist}
+Release:        1%{?dist}
 Summary:        A general purpose library for the direct solution of linear equations
 License:        BSD-3-Clause
 Group:          %{PROJ_NAME}/parallel-libs
 URL:            http://crd-legacy.lbl.gov/~xiaoye/SuperLU/
 Source0:        http://crd-legacy.lbl.gov/~xiaoye/SuperLU/superlu_dist_%{version}.tar.gz
 Source1:        OHPC_macros
-Source3:        OHPC_setup_mpi
 Patch0:         superlu_dist-4.1-sequence-point.patch
 Patch1:         superlu_dist-4.2-make.patch
 Patch2:         superlu_dist-4.1-example-no-return-in-non-void.patch
@@ -89,8 +88,6 @@ solutions.
 %build
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 
 module load metis
 
@@ -186,6 +183,9 @@ EOF
 %doc README
 
 %changelog
+* Tue May 23 2017 Adrian Reber <areber@redhat.com> - 4.2-1
+- Remove separate mpi setup; it is part of the %%ohpc_compiler macro
+
 * Fri May 12 2017 Karl W Schulz <karl.w.schulz@intel.com> - 4.2-0
 - switch to use of ohpc_compiler_dependent and ohpc_mpi_dependent flags
 

--- a/components/parallel-libs/trilinos/SPECS/trilinos.spec
+++ b/components/parallel-libs/trilinos/SPECS/trilinos.spec
@@ -20,14 +20,13 @@
 
 Name:           %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Version:        12.10.1
-Release:        0%{?dist}
+Release:        1%{?dist}
 Summary:        A collection of libraries of numerical algorithms
 License:        LGPL-2.0
 Group:          %{PROJ_NAME}/parallel-libs
 Url:            http://trilinos.sandia.gov/index.html
 Source0:        https://github.com/trilinos/Trilinos/archive/trilinos-release-%{ver_exp}.tar.gz
 Source1:        OHPC_macros
-Source3:        OHPC_setup_mpi
 Patch0:         trilinos-11.14.3-no-return-in-non-void.patch
 Patch1:         Trilinos-trilinos-aarch64.patch
 BuildRequires:  cmake >= 2.8
@@ -74,8 +73,6 @@ Trilinos top layer providing a common look-and-feel and infrastructure.
 %build
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 
 module load phdf5
 module load netcdf
@@ -229,6 +226,9 @@ EOF
 %doc Copyright.txt INSTALL LICENSE README RELEASE_NOTES
 
 %changelog
+* Tue May 23 2017 Adrian Reber <areber@redhat.com> - 12.10.1-1
+- Remove separate mpi setup; it is part of the %%ohpc_compiler macro
+
 * Fri May 12 2017 Karl W Schulz <karl.w.schulz@intel.com> - 12.10.1-0
 - switch to use of ohpc_compiler_dependent and ohpc_mpi_dependent flags
 

--- a/components/perf-tools/imb/SPECS/imb.spec
+++ b/components/perf-tools/imb/SPECS/imb.spec
@@ -20,13 +20,12 @@
 Summary:   Intel MPI Benchmarks (IMB)
 Name:      %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Version:   4.1
-Release:   1%{?dist}
+Release:   2%{?dist}
 License:   CPL
 Group:     %{PROJ_NAME}/perf-tools
 URL:       https://software.intel.com/en-us/articles/intel-mpi-benchmarks
 Source0:   %{PNAME}_%{version}.tgz
 Source1:   OHPC_macros
-Source3:   OHPC_setup_mpi
 
 # OpenHPC patches
 Patch1: imb.cc.patch
@@ -49,8 +48,6 @@ a range of message sizes.
 
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 
 cd src
 make all
@@ -60,8 +57,6 @@ cd -
 
 # OpenHPC compiler designation
 %ohpc_setup_compiler
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 
 %{__mkdir} -p %{buildroot}%{install_path}/bin
 cd src
@@ -119,6 +114,9 @@ EOF
 
 
 %changelog
+* Tue May 23 2017 Adrian Reber <areber@redhat.com> - 4.1-2
+- Remove separate mpi setup; it is part of the %%ohpc_compiler macro
+
 * Fri May 12 2017 Karl W Schulz <karl.w.schulz@intel.com> - 4.1-1
 - switch to use of ohpc_compiler_dependent and ohpc_mpi_dependent flags
 

--- a/components/perf-tools/mpiP/SPECS/mpiP.spec
+++ b/components/perf-tools/mpiP/SPECS/mpiP.spec
@@ -29,13 +29,12 @@ Requires:      gnu-compilers%{PROJ_DELIM}
 Summary:   mpiP: a lightweight profiling library for MPI applications.
 Name:      %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Version:   3.4.1
-Release:   1%{?dist}
+Release:   2%{?dist}
 License:   BSD-3
 Group:     %{PROJ_NAME}/perf-tools
 URL:       http://mpip.sourceforge.net/
 Source0:   http://sourceforge.net/projects/mpip/files/mpiP/mpiP-3.4.1/mpiP-%{version}.tar.gz
 Source1:   OHPC_macros
-Source3:   OHPC_setup_mpi
 Patch1:    mpip.unwinder.patch
 
 BuildRequires: binutils-devel
@@ -71,8 +70,6 @@ cp /usr/lib/rpm/config.guess bin
 # note: in order to support call-site demangling, we compile mpiP with gnu
 # see above where compiler_family is changed
 %ohpc_setup_compiler
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 
 CC=mpicc
 CXX=mpicxx
@@ -91,8 +88,6 @@ FC=mpif90
 # note: in order to support call-site demangling, we compile mpiP with gnu
 # see above where compiler_family is changed
 %ohpc_setup_compiler
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 
 make %{?_smp_mflags} shared
 make DESTDIR=$RPM_BUILD_ROOT install
@@ -145,6 +140,9 @@ rm -rf $RPM_BUILD_ROOT/%{install_path}/lib/*.a
 %doc ChangeLog doc/PORTING.txt doc/README doc/UserGuide.txt
 
 %changelog
+* Tue May 23 2017 Adrian Reber <areber@redhat.com> - 3.4.1-2
+- Remove separate mpi setup; it is part of the %%ohpc_compiler macro
+
 * Fri May 12 2017 Karl W Schulz <karl.w.schulz@intel.com> - 3.4.1-1
 - switch to use of ohpc_compiler_dependent and ohpc_mpi_dependent flags
 

--- a/components/perf-tools/scalasca/SPECS/scalasca.spec
+++ b/components/perf-tools/scalasca/SPECS/scalasca.spec
@@ -20,13 +20,12 @@
 Summary:   Toolset for performance analysis of large-scale parallel applications
 Name:      %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Version:   2.3.1
-Release:   1%{?dist}
+Release:   2%{?dist}
 License:   BSD
 Group:     %{PROJ_NAME}/perf-tools
 URL:       http://www.scalasca.org
 Source0:   http://apps.fz-juelich.de/scalasca/releases/scalasca/2.3/dist/scalasca-%{version}.tar.gz
 Source1:   OHPC_macros
-Source3:   OHPC_setup_mpi
 BuildRequires: scorep-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 BuildRequires: scorep-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  scorep-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
@@ -60,9 +59,6 @@ This is the %{compiler_family}-%{mpi_family} version.
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
 
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
-
 module load scorep
 
 %if %{compiler_family} == intel
@@ -91,8 +87,6 @@ CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --with-mpi=openmpi "
 
 # OpenHPC compiler designation
 %ohpc_setup_compiler
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 
 module load scorep
 
@@ -155,6 +149,9 @@ EOF
 
 
 %changelog
+* Tue May 23 2017 Adrian Reber <areber@redhat.com> - 2.3.1-2
+- Remove separate mpi setup; it is part of the %%ohpc_compiler macro
+
 * Fri May 12 2017 Karl W Schulz <karl.w.schulz@intel.com> - 2.3.1-1
 - switch to use of ohpc_compiler_dependent and ohpc_mpi_dependent flags
 

--- a/components/perf-tools/scorep/SPECS/scorep.spec
+++ b/components/perf-tools/scorep/SPECS/scorep.spec
@@ -20,13 +20,12 @@
 Summary:   Scalable Performance Measurement Infrastructure for Parallel Codes
 Name:      %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Version:   3.0
-Release:   1%{?dist}
+Release:   2%{?dist}
 License:   BSD
 Group:     %{PROJ_NAME}/perf-tools
 URL:       http://www.vi-hps.org/projects/score-p/
 Source0:   http://www.vi-hps.org/upload/packages/scorep/scorep-%{version}.tar.gz
 Source1:   OHPC_macros
-Source3:   OHPC_setup_mpi
 Patch0:    scorep-gcc7.patch
 
 %if 0%{?sles_version} || 0%{?suse_version}
@@ -66,9 +65,6 @@ This is the %{compiler_family}-%{mpi_family} version.
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
 
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
-
 module load papi
 module load pdtoolkit
 module load sionlib
@@ -101,8 +97,6 @@ export NO_BRP_CHECK_RPATH=true
 
 # OpenHPC compiler designation
 %ohpc_setup_compiler
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 
 module load papi
 
@@ -184,6 +178,9 @@ EOF
 %doc AUTHORS ChangeLog COPYING INSTALL OPEN_ISSUES README THANKS
 
 %changelog
+* Tue May 23 2017 Adrian Reber <areber@redhat.com> - 3.0-2
+- Remove separate mpi setup; it is part of the %%ohpc_compiler macro
+
 * Fri May 12 2017 Karl W Schulz <karl.w.schulz@intel.com> - 3.0-1
 - switch to use of ohpc_compiler_dependent and ohpc_mpi_dependent flags
 

--- a/components/perf-tools/tau/SPECS/tau.spec
+++ b/components/perf-tools/tau/SPECS/tau.spec
@@ -20,14 +20,13 @@
 Name: %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 
 Version:   2.26.1
-Release:   1%{?dist}
+Release:   2%{?dist}
 Summary:   Tuning and Analysis Utilities Profiling Package
 License:   Tuning and Analysis Utilities License
 Group:     %{PROJ_NAME}/perf-tools
 Url:       http://www.cs.uoregon.edu/research/tau/home.php
 Source0:   https://www.cs.uoregon.edu/research/tau/tau_releases/tau-%{version}.tar.gz
 Source1:   OHPC_macros
-Source3:   OHPC_setup_mpi
 Patch1:    tau-2.26.forceshared.patch
 Patch2:    tau-add-explicit-linking-option.patch
 
@@ -80,8 +79,6 @@ sed -i -e 's/^BITS.*/BITS = 64/' src/Profile/Makefile.skel
 %install
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
-export OHPC_MPI_FAMILY=%{mpi_family}
-. %{_sourcedir}/OHPC_setup_mpi
 module load papi
 module load pdtoolkit
 
@@ -239,6 +236,9 @@ EOF
 %doc Changes COPYRIGHT CREDITS INSTALL LICENSE README*
 
 %changelog
+* Tue May 23 2017 Adrian Reber <areber@redhat.com> - 2.26.1-2
+- Remove separate mpi setup; it is part of the %%ohpc_compiler macro
+
 * Fri May 12 2017 Karl W Schulz <karl.w.schulz@intel.com> - 2.26.1-1
 - switch to use of ohpc_compiler_dependent and ohpc_mpi_dependent flags
 


### PR DESCRIPTION
With the new flag %%ohpc_mpi_dependent the macro %%ohpc_setup_compiler
can automatically run the necessary things for MPI dependent packages.

With this change OHPC_setup_mpi is also removed from all SPEC files
as the ohpc-buildroot supplied version can be used by all packages.