### PR TITLE
OHPC_macros: fix build outside of OBS

### DIFF
--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -33,6 +33,12 @@
 
 DocDir:    %{OHPC_PUB}/doc/contrib
 
+%if 0%{?rhel} == 7
+	# OBS define's rhel_version to 700 for RHEL, in case we are
+	# not running in OBS
+	%global rhel_version 700
+%endif
+
 # OpenHPC packages require ohpc-filesystem which defines the basic
 # installation path layout
 %if 0%{?ohpc_bootstrap} == 0


### PR DESCRIPTION
When building the OpenHPC packages outside of OBS some builds for
CentOS/RHEL are failing as the necessary macros are not available. This
sets the 'rhel_version' macro to 700 if the 'rhel' macro equals 7.

Signed-off-by: Adrian Reber <areber@redhat.com>