### PR TITLE
[RFC] openmpi: support multiple Open MPI versions in parallel

### DIFF
--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -73,6 +73,9 @@ BuildRequires: ohpc-buildroot
 	%global mpi_family openmpiv1.10
 %endif
 
+# This returns 'openmpi' without version suffix, if openmpi* is selected.
+%global openmpi %(eval echo -n %{mpi_family} | cut -c 1-7)
+
 # Compiler dependencies
 %if 0%{?ohpc_compiler_dependent} == 1
 

--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -57,7 +57,21 @@ BuildRequires: ohpc-buildroot
 # variables via rpmbuild or other mechanisms.
 
 %{!?compiler_family: %global compiler_family gnu7}
+
+# mpi_family can either be mvapich2, mpich or different openmpi versions.
+# Historically openmpi was the 1.10 branch so that if openmpi is selected
+# it will automatically be replaced with openmpiv1.10. This can be removed
+# once the 1.10 branch is no longer part of OpenHPC.
+
 %{!?mpi_family: %global mpi_family openmpi}
+
+%if "%{mpi_family}" == "openmpi"
+	# Special treatment for "openmpi". "openmpi" used to be
+	# Open MPI 1.10.x. Now that multiple Open MPI versions
+	# are available in OpenHPC this re-defines %%{mpi_family}
+	# to openmpi-version
+	%global mpi_family openmpiv1.10
+%endif
 
 # Compiler dependencies
 %if 0%{?ohpc_compiler_dependent} == 1
@@ -91,18 +105,9 @@ Requires:      gnu-7-compilers%{PROJ_DELIM}
 %if "%{mpi_family}" == "impi"
 BuildRequires: intel-mpi-devel%{PROJ_DELIM}
 Requires:      intel-mpi-devel%{PROJ_DELIM}
-%endif
-%if "%{mpi_family}" == "mpich"
-BuildRequires: mpich-%{compiler_family}%{PROJ_DELIM}
-Requires:      mpich-%{compiler_family}%{PROJ_DELIM}
-%endif
-%if "%{mpi_family}" == "mvapich2"
-BuildRequires: mvapich2-%{compiler_family}%{PROJ_DELIM}
-Requires:      mvapich2-%{compiler_family}%{PROJ_DELIM}
-%endif
-%if "%{mpi_family}" == "openmpi"
-BuildRequires: openmpi-%{compiler_family}%{PROJ_DELIM}
-Requires:      openmpi-%{compiler_family}%{PROJ_DELIM}
+%else
+BuildRequires: %{mpi_family}-%{compiler_family}%{PROJ_DELIM}
+Requires:      %{mpi_family}-%{compiler_family}%{PROJ_DELIM}
 %endif
 %endif
 

--- a/components/OHPC_setup_mpi
+++ b/components/OHPC_setup_mpi
@@ -32,6 +32,14 @@ fi
 
 if [ "$OHPC_MPI_FAMILY" = "openmpi" ]; then
     module load openmpi
+elif [ "$OHPC_MPI_FAMILY" = "openmpiv1.10" ]; then
+    module load openmpi/1.10.7
+elif [ "$OHPC_MPI_FAMILY" = "openmpiv2.0" ]; then
+    module load openmpi/2.0.3
+elif [ "$OHPC_MPI_FAMILY" = "openmpiv2.1" ]; then
+    module load openmpi/2.1.1
+elif [ "$OHPC_MPI_FAMILY" = "openmpiv3.0" ]; then
+    module load openmpi/3.0.0rc1
 elif [ "$OHPC_MPI_FAMILY" = "impi" ]; then
     module load impi
 elif [ "$OHPC_MPI_FAMILY" = "mvapich2" ]; then
@@ -42,6 +50,3 @@ else
     echo "Unsupported OHPC_MPI_FAMILY -> $OHPC_MPI_FAMILY"
     exit 1
 fi
-
-
-

--- a/components/dev-tools/scipy/SPECS/python-scipy.spec
+++ b/components/dev-tools/scipy/SPECS/python-scipy.spec
@@ -32,31 +32,10 @@
 
 %global gnu_family gnu7
 
-%{!?mpi_family: %global mpi_family openmpi}
-
 %if "%{compiler_family}" != "intel"
 BuildRequires: openblas-%{compiler_family}%{PROJ_DELIM}
 Requires: openblas-%{compiler_family}%{PROJ_DELIM}
 %endif
-
-# MPI dependencies
-%if %{mpi_family} == impi
-BuildRequires: intel-mpi%{PROJ_DELIM}
-Requires:      intel-mpi%{PROJ_DELIM}
-%endif
-%if %{mpi_family} == mpich
-BuildRequires: mpich-%{compiler_family}%{PROJ_DELIM}
-Requires:      mpich-%{compiler_family}%{PROJ_DELIM}
-%endif
-%if %{mpi_family} == mvapich2
-BuildRequires: mvapich2-%{compiler_family}%{PROJ_DELIM}
-Requires:      mvapich2-%{compiler_family}%{PROJ_DELIM}
-%endif
-%if %{mpi_family} == openmpi
-BuildRequires: openmpi-%{compiler_family}%{PROJ_DELIM}
-Requires:      openmpi-%{compiler_family}%{PROJ_DELIM}
-%endif
-
 
 # Base package name
 %define pname scipy
@@ -113,7 +92,7 @@ module load fftw
 
 module load numpy
 
-%if %{compiler_family} == intel
+%if "%{compiler_family}" == "intel"
 cat > site.cfg << EOF
 [mkl]
 library_dirs = $MKLROOT/lib/intel64

--- a/components/io-libs/sionlib/SPECS/sionlib.spec
+++ b/components/io-libs/sionlib/SPECS/sionlib.spec
@@ -48,23 +48,23 @@ This is the %{compiler_family}-%{mpi_family} version.
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
 
-%if %{compiler_family} == intel
+%if "%{compiler_family}" == "intel"
 CONFIGURE_OPTIONS="--compiler=intel --disable-parutils "
 %endif
 
-%if %{mpi_family} == impi
+%if "%{mpi_family}" == "impi"
 CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --mpi=intel2 "
 %endif
 
-%if %{mpi_family} == mpich
+%if "%{mpi_family}" == "mpich"
 CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --mpi=mpich3 "
 %endif
 
-%if %{mpi_family} == mvapich2
+%if "%{mpi_family}" == "mvapich2"
 CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --mpi=mpich3 "
 %endif
 
-%if %{mpi_family} == openmpi
+%if "%{openmpi}" == "openmpi"
 CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --mpi=openmpi "
 %endif
 

--- a/components/parallel-libs/mumps/SPECS/mumps.spec
+++ b/components/parallel-libs/mumps/SPECS/mumps.spec
@@ -117,7 +117,7 @@ cp -f %{S:2} Makefile.inc
 %endif
 %endif
 
-%if "%{mpi_family}" == "openmpi"
+%if "%{openmpi}" == "openmpi"
 export LIBS="-L$MPI_DIR/lib -lmpi_mpifh -lmpi"
 %if "%{compiler_family}" == "intel"
 cp -f %{S:4} Makefile.inc
@@ -203,8 +203,8 @@ EOF
 
 %files
 %defattr(-,root,root,-)
-%{OHPC_HOME}
-%{OHPC_PUB}
+%{install_path}
+%{OHPC_MODULEDEPS}/%{compiler_family}-%{mpi_family}/%{pname}
 %doc ChangeLog CREDITS INSTALL LICENSE README VERSION
 
 %changelog

--- a/components/parallel-libs/petsc/SPECS/petsc.spec
+++ b/components/parallel-libs/petsc/SPECS/petsc.spec
@@ -79,8 +79,8 @@ module load scalapack openblas
         --with-blas-lapack-lib=$OPENBLAS_LIB/libopenblas.so \
         --with-scalapack-dir=$SCALAPACK_DIR \
 %endif
-%if %{mpi_family} == impi
-%if %{compiler_family} == intel
+%if "%{mpi_family}" == "impi"
+%if "%{compiler_family}" == "intel"
         --with-cc=mpiicc    \
         --with-cxx=mpiicpc  \
         --with-fc=mpiifort  \

--- a/components/perf-tools/scalasca/SPECS/scalasca.spec
+++ b/components/perf-tools/scalasca/SPECS/scalasca.spec
@@ -61,23 +61,23 @@ This is the %{compiler_family}-%{mpi_family} version.
 
 module load scorep
 
-%if %{compiler_family} == intel
+%if "%{compiler_family}" == "intel"
 CONFIGURE_OPTIONS="--with-nocross-compiler-suite=intel "
 %endif
 
-%if %{mpi_family} == impi
+%if "%{mpi_family}" == "impi"
 CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --with-mpi=intel3 "
 %endif
 
-%if %{mpi_family} == mpich
+%if "%{mpi_family}" == "mpich"
 CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --with-mpi=mpich3 "
 %endif
 
-%if %{mpi_family} == mvapich2
+%if "%{mpi_family}" == "mvapich2"
 CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --with-mpi=mpich3 "
 %endif
 
-%if %{mpi_family} == openmpi
+%if "%{openmpi}" == "openmpi"
 CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --with-mpi=openmpi "
 %endif
 

--- a/components/perf-tools/scorep/SPECS/scorep.spec
+++ b/components/perf-tools/scorep/SPECS/scorep.spec
@@ -69,23 +69,23 @@ module load papi
 module load pdtoolkit
 module load sionlib
 
-%if %{compiler_family} == intel
+%if "%{compiler_family}" == "intel"
 CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --with-nocross-compiler-suite=intel "
 %endif
 
-%if %{mpi_family} == impi
+%if "%{mpi_family}" == "impi"
 CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --with-mpi=intel3 "
 %endif
 
-%if %{mpi_family} == mpich
+%if "%{mpi_family}" == "mpich"
 CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --with-mpi=mpich3 "
 %endif
 
-%if %{mpi_family} == mvapich2
+%if "%{mpi_family}" == "mvapich2"
 CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --with-mpi=mpich3 "
 %endif
 
-%if %{mpi_family} == openmpi
+%if "%{openmpi}" == "openmpi"
 CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --with-mpi=openmpi "
 %endif
 

--- a/components/perf-tools/tau/SPECS/tau.spec
+++ b/components/perf-tools/tau/SPECS/tau.spec
@@ -88,7 +88,7 @@ export fcomp=mpiifort
 export fcomp=gfortran
 %endif
 
-%if %{mpi_family} == impi
+%if "%{mpi_family}" == "impi"
 export MPI_INCLUDE_DIR=$I_MPI_ROOT/include64
 export MPI_LIB_DIR=$I_MPI_ROOT/lib64
 %else
@@ -152,7 +152,7 @@ sed -i "s|$TAUROOT|%{install_path}|g" $(egrep -IR "$TAUROOT" %buildroot%{install
 sed -i "s|/x86_64/lib|/lib|g" $(egrep -IR "/x86_64/lib" %buildroot%{install_path}|awk -F : '{print $1}')
 
 # replace hard paths with env vars
-%if %{mpi_family} == impi
+%if "%{mpi_family}" == "impi"
 sed -i "s|$I_MPI_ROOT|\$\{I_MPI_ROOT\}|g" $(egrep -IR "$I_MPI_ROOT" %buildroot%{install_path}|awk -F : '{print $1}')
 %else
 sed -i "s|$MPI_DIR|\$\{MPI_DIR\}|g" $(egrep -IR "$MPI_DIR" %buildroot%{install_path}|awk -F : '{print $1}')
@@ -162,7 +162,7 @@ sed -i "s|$PDTOOLKIT_DIR|\$\{PDTOOLKIT_DIR\}|g" $(egrep -IR "$PDTOOLKIT_DIR" %bu
 
 # link other bindings
 pushd %{buildroot}%{install_path}/lib
-%if %{compiler_family} == intel
+%if "%{compiler_family}" == "intel"
 ln -s shared-callpath-param-icpc-papi-mpi-pdt-openmp-profile-trace shared-mpi
 %else
 ln -s shared-callpath-param-papi-mpi-pdt-openmp-profile-trace shared-mpi


### PR DESCRIPTION
In order to support the installation of multiple Open MPI versions in
parallel and the compilation of dependent software packages, the
Open MPI spec file, OHPC_macros and OHPC_setup_mpi has been enhanced.

In addition to defining mpi_family like mvapich2, mpich and openmpi the
mpi_family can be defined as openmpiv1.10, openmpiv2.0, openmpiv2.1 and
openmpiv3.0 (rc1 currently). This enables to compile and install the
complete Open MPI dependent software stack in parallel to each other.

Using 'modules av' gives now the following after loading the compiler
module:

            ------ /opt/ohpc/pub/moduledeps/gnu ------
 openmpi/1.10.7    openmpi/2.0.3    openmpi/2.1.1    openmpi/3.0.0rc1 (D)

Loading one of the Open MPI modules makes software based on that version
available:

            -------- /opt/ohpc/pub/moduledeps/gnu-openmpiv2.1 ------
 imb/4.1

Signed-off-by: Adrian Reber <areber@redhat.com>