### PR TITLE
Use distributed compiler version for Intel MPI

### DIFF
--- a/components/mpi-families/impi-devel/SPECS/intel-mpi.spec
+++ b/components/mpi-families/impi-devel/SPECS/intel-mpi.spec
@@ -26,7 +26,7 @@ BuildArch: x86_64
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 AutoReq:   no
 
-BuildRequires:-post-build-checks
+BuildRequires: -post-build-checks
 
 Requires: prun%{PROJ_DELIM}
 Requires: intel-mpi-doc >= %{year}
@@ -65,10 +65,19 @@ if [ -d ${topDir} ];then
 
     for dir in ${versions}; do
 	if [ -e ${topDir}/${dir}/linux/mpi/intel64/bin/mpiicc ];then
-	    version=`grep "^MPIVERSION=" ${topDir}/${dir}/linux/mpi/intel64/bin/mpiicc | cut -d '"' -f2 | sed 's| Update |\.|'`
+	    version=`grep "^MPIVERSION=" ${topDir}/${dir}/linux/mpi/intel64/bin/mpiicc | cut -d '"' -f2`
 	    if [ -z "${version}" ];then
 		echo "Error: unable to determine MPI version"
 		exit 1
+            elif [ "${version:0:2}" = "20" -a -e ${topDir}/${dir}/linux/bin/intel64/icc ];then
+                # Starting with 2017, the MPI versions distributed with
+                # Parallel Studio are versioned to match the compiler
+                # version they're shipped with.  Rather than extracting a
+                # version string from mpiicc that would be similar to, but not
+                # the same as the compiler version, we just use the actual
+                # compiler version that it's shipped with.  This is extracted
+                # using the same logic as the compiler modules
+                version=`${topDir}/${dir}/linux/bin/intel64/icc -V 2>&1 | grep Version | awk -F 'Version' '{print $2}' | awk '{print $1}'`
 	    fi
 	    
 	    echo "--> Installing OpenHPC-style modulefile for MPI version=${version}"


### PR DESCRIPTION
This creates a consistent versioning for Intel MPI when the version string extracted from mpiicc has oddball modifiers like "2017 Update 2" or "2018 Beta Update 1".

The only issue I see this change could cause is that it creates new modules for all the intel-mpi installations since a new versioning scheme is used to be consistent with the compiler versions.  This won't invalidate any existing module using the old scheme (i.e. 2017.2 for 2017 Update 2) but it will create duplicate modules for those already present.  If this change were to be accepted, then perhaps it could be modified with a warning during the post-install step for the user to purge previous modules that are versioned differently?

Or if the re-versioning is too disruptive I can easily rebase it for 1.4