### PR TITLE
build_order: resolve and print out the correct build order

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,9 @@ SLES 12 SP2 | 587     | 363      | 60
 A detailed list of all available components is available in
 the "Package Manifest" appendix located in each of the companion install
 guide documents, and a list of updated packages can be found in the
-[release notes](https://github.com/openhpc/ohpc/releases/tag/v1.3.1.GA). 
-
-#### \*\* Important note for	those upgrading	from versions prior to 1.3
-
-There are significant changes included in the `warewulf-httpd.conf file` that ships with the warewulf-provision-server-ohpc package. If upgrading from a previously installed version, the updated config file will be saved as `/etc/httpd/conf.d/warewulf-httpd.conf.rpmnew` locally. You will need to copy this new version to the production file and restart the web server to ensure correct provisioning behavior. As an example for CentOS:
-
-```
-[sms]# cp /etc/httpd/conf.d/warewulf-httpd.conf.rpmnew /etc/httpd/conf.d/warewulf-httpd.conf
-[sms]# systemctl restart httpd
-```
+[release notes](https://github.com/openhpc/ohpc/releases/tag/v1.3.1.GA). The
+release notes also contain important information for those upgrading from previous
+versions of OpenHPC.
 
 #### Getting started
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Note that ARM-based builds in this release are being provided as a **Technology 
 ###### [CentOS 7.3]
 * [ohpc-release-1.3-1.el7.aarch64.rpm](https://github.com/openhpc/ohpc/releases/download/v1.3.GA/ohpc-release-1.3-1.el7.aarch64.rpm) (md5sum=16ad76e74b591a3b6dcc3cb8597d3f7d)
 * [Install Guide (with Warewulf + Slurm)](https://github.com/openhpc/ohpc/releases/download/v1.3.1.GA/Install_guide-CentOS7-Warewulf-SLURM-1.3.1-aarch64.pdf)
-* [Tar Archive](http://build.openhpc.community/dist/1.3.1/OpenHPC-1.3.1.CentOS_7_aarch64.tar) mirror of yum repository (md5sum=0c9602f1ac898569b56a6cd4f6505881)
+* [Tar Archive](http://build.openhpc.community/dist/1.3.1/OpenHPC-1.3.1.CentOS_7.aarch64.tar) mirror of yum repository (md5sum=0c9602f1ac898569b56a6cd4f6505881)
 
 ###### [SLES 12 SP2]
 * [ohpc-release-1.3-1.sle12.aarch64.rpm](https://github.com/openhpc/ohpc/releases/download/v1.3.GA/ohpc-release-1.3-1.sle12.aarch64.rpm) (md5sum=706a42f7785952f8b543c501eeec05da)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ the downloads section of the latest
 * [ohpc-release-1.3-1.el7.x86_64.rpm](https://github.com/openhpc/ohpc/releases/download/v1.3.GA/ohpc-release-1.3-1.el7.x86_64.rpm) (md5sum=d5139cf3aa83d095e6851628e8a684fa)
 * [Install Guide (with Warewulf + PBS Professional)](https://github.com/openhpc/ohpc/releases/download/v1.3.1.GA/Install_guide-CentOS7-Warewulf-PBSPro-1.3.1-x86_64.pdf)
 * [Install Guide (with Warewulf + Slurm)](https://github.com/openhpc/ohpc/releases/download/v1.3.1.GA/Install_guide-CentOS7-Warewulf-SLURM-1.3.1-x86_64.pdf)
-* [Install Guide (with xCAT & Slurm)](https://github.com/openhpc/ohpc/releases/download/v1.3.1.GA/Install_guide-CentOS7-xCAT-SLURM-1.3.1-x86_64.pdf)
+* [Install Guide (with xCAT + Slurm)](https://github.com/openhpc/ohpc/releases/download/v1.3.1.GA/Install_guide-CentOS7-xCAT-SLURM-1.3.1-x86_64.pdf)
 * [Tar Archive](http://build.openhpc.community/dist/1.3.1/OpenHPC-1.3.1.CentOS_7.x86_64.tar) mirror of yum repository (md5sum=e53ad41d09fed7b2ee763cfec6c2fcb1)
 
 ###### [SLES 12 SP2]

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Note that ARM-based builds in this release are being provided as a **Technology 
 ###### [CentOS 7.3]
 * [ohpc-release-1.3-1.el7.aarch64.rpm](https://github.com/openhpc/ohpc/releases/download/v1.3.GA/ohpc-release-1.3-1.el7.aarch64.rpm) (md5sum=16ad76e74b591a3b6dcc3cb8597d3f7d)
 * [Install Guide (with Warewulf + Slurm)](https://github.com/openhpc/ohpc/releases/download/v1.3.1.GA/Install_guide-CentOS7-Warewulf-SLURM-1.3.1-aarch64.pdf)
-* [Tar Archive](http://build.openhpc.community/dist/1.3.1/OpenHPC-1.3.CentOS_7_aarch64.tar) mirror of yum repository (md5sum=0c9602f1ac898569b56a6cd4f6505881)
+* [Tar Archive](http://build.openhpc.community/dist/1.3.1/OpenHPC-1.3.1.CentOS_7_aarch64.tar) mirror of yum repository (md5sum=0c9602f1ac898569b56a6cd4f6505881)
 
 ###### [SLES 12 SP2]
 * [ohpc-release-1.3-1.sle12.aarch64.rpm](https://github.com/openhpc/ohpc/releases/download/v1.3.GA/ohpc-release-1.3-1.sle12.aarch64.rpm) (md5sum=706a42f7785952f8b543c501eeec05da)

--- a/components/rms/slurm/SOURCES/rpmmacros
+++ b/components/rms/slurm/SOURCES/rpmmacros
@@ -1,1 +1,0 @@
-%define _with_mysql  1

--- a/components/rms/slurm/SPECS/slurm.spec
+++ b/components/rms/slurm/SPECS/slurm.spec
@@ -9,7 +9,7 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%include %{_sourcedir}/rpmmacros
+%global _with_mysql  1
 
 %define pname slurm
 
@@ -113,11 +113,7 @@ Summary:   Slurm Workload Manager
 License:   GPL
 Group:     %{PROJ_NAME}/rms
 Source:    https://github.com/SchedMD/slurm/archive/%{pname}-%{ver_exp}.tar.gz
-#Source:    http://www.schedmd.com/download/archive/%{pname}-%{version}.tar.bz2
 Source1:   OHPC_macros
-Source2:   rpmmacros
-BuildRoot: %{_tmppath}/%{pname}-%{version}-%{release}
-DocDir:    %{OHPC_PUB}/doc/contrib
 URL:       http://slurm.schedmd.com/
 
 # 8/15/14 karl.w.schulz@intel.com - include prereq
@@ -502,7 +498,6 @@ Gives the ability for Slurm to use Berkeley Lab Checkpoint/Restart
 %__make %{?_smp_mflags}
 
 %install
-rm -rf "$RPM_BUILD_ROOT"
 DESTDIR="$RPM_BUILD_ROOT" %__make install
 DESTDIR="$RPM_BUILD_ROOT" %__make install-contrib
 
@@ -834,10 +829,6 @@ touch $LIST
 %endif
 
 mkdir -p $RPM_BUILD_ROOT/%{_docdir}
-#############################################################################
-
-%clean
-rm -rf $RPM_BUILD_ROOT
 #############################################################################
 
 %files -f slurm.files

--- a/misc/build_order.py
+++ b/misc/build_order.py
@@ -1,0 +1,101 @@
+#!/bin/python3
+
+# To be able to use this script with python2 and python3 the following
+# is needed (just for the last line: print('%s' % i, end=' '))
+from __future__ import print_function
+
+import sys
+
+
+def topological_sort(source):
+    # https://stackoverflow.com/questions/11557241/python-sorting-a-dependency-list
+    """perform topo sort on elements.
+
+    :arg source: list of ``(name, [list of dependancies])`` pairs
+    :returns: list of names, with dependancies listed first
+    """
+    # copy deps so we can modify set in-place
+    pending = [(name, set(deps)) for name, deps in source]
+    emitted = []
+    while pending:
+        next_pending = []
+        next_emitted = []
+        for entry in pending:
+            name, deps = entry
+            # remove deps we emitted last pass
+            deps.difference_update(emitted)
+            if deps:
+                # still has deps? recheck during next pass
+                next_pending.append(entry)
+            else:
+                # no more deps? time to emit
+                yield name
+                # <-- not required, but helps preserve original ordering
+                emitted.append(name)
+                # remember what we emitted for difference_update() in next pass
+                next_emitted.append(name)
+        if not next_emitted:
+            # all entries have unmet deps, one of two things is wrong...
+            raise ValueError(
+                "cyclic or missing dependancy detected: %r" %
+                (next_pending,))
+        pending = next_pending
+        emitted = next_emitted
+
+
+spec_dict = {}
+dependency = {}
+
+if len(sys.argv) != 2:
+    print("Need dependency file as input")
+    sys.exit(1)
+
+
+for line in open(sys.argv[1]):
+    line = line.rstrip().split(':')
+    # The spec_dict is later used to translate
+    # package names into spec files
+    spec_dict[line[1]] = line[0]
+    # Ignore the meta_packages
+    if line[1] == 'meta-packages':
+        continue
+    # Ignore non ohpc (Build)Requires
+    if line[2] == 'NA':
+        continue
+    # Ignore the nagios_plugins
+    if ((line[2].startswith('nagios-plugins')) and
+            (not line[2].startswith('nagios-plugins-ohpc'))):
+        continue
+    # This tries to filter out versions with a "."
+    if "." in line[2]:
+        continue
+    if line[0] in dependency:
+        if line[2] not in dependency[line[0]]:
+            dependency[line[0]].append(line[2])
+    else:
+        dependency[line[0]] = [line[2]]
+
+additional = {}
+
+# Add entries to the dict which have no dependencies
+for v in dependency.values():
+    for value in v:
+        if spec_dict[value] not in dependency.keys():
+            additional[spec_dict[value]] = []
+
+dependency.update(additional)
+
+# Translate everything to spec file-names
+for k, v in dependency.items():
+    for i in range(len(v)):
+        v[i] = spec_dict[v[i]]
+    # remove cylic dependencies
+    dependency[k] = [x for x in v if x != k]
+
+
+# make a list of the dict
+dep_list = [(k, set(v)) for (k, v) in dependency.items()]
+
+# Sort and print
+for i in topological_sort(dep_list):
+    print('%s' % i, end=' ')

--- a/misc/build_order.sh
+++ b/misc/build_order.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+if [ ! -e components/OHPC_macros ]; then
+	echo -n "This script expects to be started in the top-level OpenHPC git"
+	echo " checkout directory."
+	echo -n "Checking for 'components/OHPC_macros' failed and"
+	echo " therefore exiting."
+	exit 1
+fi
+
+SOURCEDIR=`rpm --eval '%{_sourcedir}'`
+
+if [ ! -e ${SOURCEDIR}/OHPC_macros ]; then
+	echo "${SOURCEDIR}/OHPC_macros not found."
+	echo "Please 'cp components/OHPC_macros ${SOURCEDIR}/OHPC_macros'"
+	exit 1
+fi
+
+DEPLIST=`mktemp`
+
+trap "rm -f ${DEPLIST}" EXIT QUIT HUP KILL TERM
+
+for i in `find . -name *.spec`; do
+	SPEC=`basename ${i}`
+	SOURCES="`dirname ${i}`/../SOURCES"
+	NAMES=`rpmspec -q ${i} --queryformat '%{name}:' 2> /dev/null`
+	# Let's hope the first name is the right one
+	NAME=`echo ${NAMES} | cut -d: -f1`
+	REQ=`rpmspec -q ${i} --requires 2> /dev/null`
+	BR=`rpmspec -q ${i} --buildrequires 2> /dev/null`
+	for j in ${REQ} ${BR}; do
+		if [[ ${j} != *"ohpc"* ]] || [[ ${j} == *"buildroot"* ]]; then
+			OIFS=${IFS}
+			IFS=':'
+			for x in ${NAMES}; do
+				# Does not have dependency on an OpenHPC package.
+				# Still necessary to track as it could be a
+				# dependency itself.
+				echo "${SPEC}:${x}:NA" >> ${DEPLIST}
+			done
+			IFS=${OIFS}
+			continue
+		fi
+		# This is a real dependency on an OpenHPC package.
+		echo "${SPEC}:${NAME}:${j}" >> ${DEPLIST}
+	done
+done
+
+# Dependencies are resolved in python
+python misc/build_order.py ${DEPLIST}


### PR DESCRIPTION
Building the OpenHPC packages outside of OBS in clean environment requires each time to manually decide in which order to build the packages. These scripts extract (Build)Requires of all spec files and try to resolve to correct order in which the OpenHPC packages should be built.

$ misc/build_order.sh
lua-filesystem.spec lua-bitop.spec sigar.spec luaposix.spec lmod.spec ohpc-filesystem.spec munge.spec [...]