### PR TITLE
Update the install guide for Aarch64

### DIFF
--- a/docs/recipes/install/centos7/aarch64/warewulf/slurm/manifest/admin.tex
+++ b/docs/recipes/install/centos7/aarch64/warewulf/slurm/manifest/admin.tex
@@ -8,6 +8,13 @@
 {\bf RPM Package Name} & {\bf Version} & {\bf Info/URL}  \\ 
 \midrule
 
+% <-- begin entry for clustershell-ohpc
+\multirow{2}{*}{clustershell-ohpc} & 
+\multirow{2}{*}{1.7.3} & 
+Python framework for efficient cluster administration. \newline { \color{logoblue} \url{http://clustershell.sourceforge.net}} 
+\\ \hline 
+% <-- end entry for clustershell-ohpc
+
 % <-- begin entry for conman-ohpc
 \multirow{2}{*}{conman-ohpc} & 
 \multirow{2}{*}{0.2.8} & 
@@ -43,12 +50,37 @@ Static cluster configuration database. \newline { \color{logoblue} \url{https://
 \\ \hline 
 % <-- end entry for genders-ohpc
 
+% <-- begin entry for lmod-defaults
+lmod-defaults-gnu-mpich-ohpc &
+\multirow{4}{*}{1.2} & 
+\multirow{12}{\linewidth}{OpenHPC default login environments. \newline {\color{logoblue} \url{https://github.com/openhpc/ohpc}}} \\ 
+& \\ 
+lmod-defaults-gnu-openmpi-ohpc &
+& \\ 
+\cline{1-2} lmod-defaults-gnu7-mpich-ohpc &\multirow{8}{*}{1.3.1}
+& \\ 
+lmod-defaults-gnu7-openmpi-ohpc &
+& \\ 
+lmod-defaults-intel-mpich-ohpc &
+& \\ 
+lmod-defaults-intel-openmpi-ohpc &
+& \\ 
+\hline
+% <-- end entry for lmod-defaults
+
 % <-- begin entry for lmod-ohpc
 \multirow{2}{*}{lmod-ohpc} & 
 \multirow{2}{*}{7.4.8} & 
 Lua based Modules (lmod). \newline { \color{logoblue} \url{https://github.com/TACC/Lmod}} 
 \\ \hline 
 % <-- end entry for lmod-ohpc
+
+% <-- begin entry for losf-ohpc
+\multirow{2}{*}{losf-ohpc} & 
+\multirow{2}{*}{0.54.0} & 
+A Linux operating system framework for managing HPC clusters.  { \color{logoblue} \url{https://github.com/hpcsi/losf}} 
+\\ \hline 
+% <-- end entry for losf-ohpc
 
 % <-- begin entry for mrsh-ohpc
 \multirow{2}{*}{mrsh-ohpc} & 
@@ -98,6 +130,20 @@ OpenHPC release files. \newline { \color{logoblue} \url{https://github.com/openh
 Parallel remote shell program. \newline { \color{logoblue} \url{http://sourceforge.net/projects/pdsh}} 
 \\ \hline 
 % <-- end entry for pdsh-ohpc
+
+% <-- begin entry for prun-ohpc
+\multirow{2}{*}{prun-ohpc} & 
+\multirow{2}{*}{1.1} & 
+Convenience utility for parallel job launch. \newline { \color{logoblue} \url{https://github.com/openhpc/ohpc}} 
+\\ \hline 
+% <-- end entry for prun-ohpc
+
+% <-- begin entry for test-suite-ohpc
+\multirow{2}{*}{test-suite-ohpc} & 
+\multirow{2}{*}{1.3.1} & 
+Integration test suite for OpenHPC. \newline { \color{logoblue} \url{https://github.com/openhpc/ohpc/tests}} 
+\\ \hline 
+% <-- end entry for test-suite-ohpc
 
 \bottomrule
 \end{tabularx}

--- a/docs/recipes/install/centos7/aarch64/warewulf/slurm/manifest/dev-tools.tex
+++ b/docs/recipes/install/centos7/aarch64/warewulf/slurm/manifest/dev-tools.tex
@@ -45,8 +45,8 @@ The GNU Portable Library Tool. \newline { \color{logoblue} \url{http://www.gnu.o
 
 % <-- begin entry for python-scipy
 python-scipy-gnu7-mpich-ohpc &
-\multirow{4}{*}{0.19.0} & 
-\multirow{4}{\linewidth}{Scientific Tools for Python. \newline {\color{logoblue} \url{http://www.scipy.org}}} \\ 
+\multirow{6}{*}{0.19.0} & 
+\multirow{6}{\linewidth}{Scientific Tools for Python. \newline {\color{logoblue} \url{http://www.scipy.org}}} \\ 
 python-scipy-gnu7-openmpi-ohpc &
 & \\ 
 python-scipy-gnu-mpich-ohpc &
@@ -59,11 +59,20 @@ python-scipy-gnu-openmpi-ohpc &
 % <-- begin entry for python-numpy
 python-numpy-gnu-ohpc &
 \multirow{1}{*}{1.11.1} & 
-\multirow{2}{\linewidth}{NumPy array processing for numbers, strings, records and objects.  {\color{logoblue} \url{http://sourceforge.net/projects/numpy}}} \\ 
-\cline{1-2} python-numpy-gnu7-ohpc &\multirow{1}{*}{1.12.1}
+\multirow{3}{\linewidth}{NumPy array processing for numbers, strings, records and objects. \newline {\color{logoblue} \url{http://sourceforge.net/projects/numpy}}} \\ 
+\cline{1-2} python-numpy-gnu7-ohpc &\multirow{2}{*}{1.12.1}
+& \\ 
+python-numpy-intel-ohpc &
 & \\ 
 \hline
 % <-- end entry for python-numpy
+
+% <-- begin entry for spack-ohpc
+\multirow{2}{*}{spack-ohpc} & 
+\multirow{2}{*}{0.10.0} & 
+HPC software package management. \newline { \color{logoblue} \url{https://github.com/LLNL/spack}} 
+\\ \hline 
+% <-- end entry for spack-ohpc
 
 % <-- begin entry for valgrind-ohpc
 \multirow{2}{*}{valgrind-ohpc} & 

--- a/docs/recipes/install/centos7/aarch64/warewulf/slurm/manifest/patterns.tex
+++ b/docs/recipes/install/centos7/aarch64/warewulf/slurm/manifest/patterns.tex
@@ -7,19 +7,36 @@
 \midrule
 
 ohpc-autotools & Collection of GNU autotools packages. \\ 
-ohpc-base & OpenHPC base packages. \\ 
+\hline
+ohpc-base & Collection of base packages. \\ 
+\hline
+ohpc-base-compute & Collection of compute node base packages. \\ 
+\hline
 ohpc-ganglia & Collection of Ganglia monitoring and metrics packages. \\ 
-ohpc-io-libs-gnu & OpenHPC IO library builds for use with GNU compiler toolchain. \\ 
+\hline
+ohpc-gnu7-io-libs & Collection of IO library builds for use with GNU compiler toolchain. \\ 
+\hline
+ohpc-gnu7-mpich-parallel-libs & Collection of parallel library builds for use with GNU compiler toolchain and the MPICH runtime. \\ 
+\hline
+ohpc-gnu7-openmpi-parallel-libs & Collection of parallel library builds for use with GNU compiler toolchain and the OpenMPI runtime. \\ 
+\hline
+ohpc-gnu7-parallel-libs & Collection of parallel library builds for use with GNU compiler toolchain. \\ 
+\hline
+ohpc-gnu7-perf-tools & Collection of performance tool builds for use with GNU compiler toolchain. \\ 
+\hline
+ohpc-gnu7-python-libs & Collection of python related library builds for use with GNU compiler toolchain. \\ 
+\hline
+ohpc-gnu7-runtimes & Collection of runtimes for use with GNU compiler toolchain. \\ 
+\hline
+ohpc-gnu7-serial-libs & Collection of serial library builds for use with GNU compiler toolchain. \\ 
+\hline
 ohpc-nagios & Collection of Nagios monitoring and metrics packages. \\ 
-ohpc-parallel-libs-gnu-mpich & OpenHPC parallel library builds for use with GNU compiler toolchain and the MPICH runtime. \\ 
-ohpc-parallel-libs-gnu-openmpi & OpenHPC parallel library builds for use with GNU compiler toolchain and the OpenMPI runtime. \\ 
-ohpc-perf-tools-gnu & OpenHPC performance tool builds for use with GNU compiler toolchain. \\ 
-ohpc-python-libs-gnu & OpenHPC python related library builds for use with GNU compiler toolchain. \\ 
-ohpc-runtimes-gnu & OpenHPC runtimes for use with GNU compiler toolchain. \\ 
-ohpc-serial-libs-gnu & OpenHPC serial library builds for use with GNU compiler toolchain. \\ 
-ohpc-slurm-server & OpenHPC server packages for SLURM. \\ 
+\hline
+ohpc-slurm-client & Collection of client packages for SLURM. \\ 
+\hline
+ohpc-slurm-server & Collection of server packages for SLURM. \\ 
+\hline
 ohpc-warewulf & Collection of base packages for Warewulf provisioning. \\ 
-ohpc-parallel-libs-gnu & OpenHPC parallel library builds for use with GNU compiler toolchain. \\ 
-ohpc-slurm-client & OpenHPC client packages for SLURM. \\ 
+\hline
 \bottomrule
 \end{tabularx}

--- a/docs/recipes/install/centos7/aarch64/warewulf/slurm/manifest/rms.tex
+++ b/docs/recipes/install/centos7/aarch64/warewulf/slurm/manifest/rms.tex
@@ -15,6 +15,27 @@ MUNGE authentication service. \newline { \color{logoblue} \url{http://dun.github
 \\ \hline 
 % <-- end entry for munge-ohpc
 
+% <-- begin entry for pbspro-execution-ohpc
+\multirow{2}{*}{pbspro-execution-ohpc} & 
+\multirow{2}{*}{14.1.0} & 
+PBS Professional for an execution host. \newline { \color{logoblue} \url{https://github.com/pbspro/pbspro}} 
+\\ \hline 
+% <-- end entry for pbspro-execution-ohpc
+
+% <-- begin entry for pbspro-client-ohpc
+\multirow{2}{*}{pbspro-client-ohpc} & 
+\multirow{2}{*}{14.1.0} & 
+PBS Professional for a client host. \newline { \color{logoblue} \url{https://github.com/pbspro/pbspro}} 
+\\ \hline 
+% <-- end entry for pbspro-client-ohpc
+
+% <-- begin entry for pbspro-server-ohpc
+\multirow{2}{*}{pbspro-server-ohpc} & 
+\multirow{2}{*}{14.1.0} & 
+PBS Professional for a server host. \newline { \color{logoblue} \url{https://github.com/pbspro/pbspro}} 
+\\ \hline 
+% <-- end entry for pbspro-server-ohpc
+
 % <-- begin entry for slurm-devel-ohpc
 \multirow{2}{*}{slurm-devel-ohpc} & 
 \multirow{2}{*}{16.05.10} & 

--- a/docs/recipes/install/centos7/aarch64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/centos7/aarch64/warewulf/slurm/steps.tex
@@ -190,6 +190,10 @@ links below:
 \vspace*{0.5cm}
 \input{common/lustre-client-post}
 
+\clearpage
+\paragraph{Enable forwarding of system logs} \label{sec:add_syslog}
+\input{common/syslog}
+
 \paragraph{Add \Nagios{} monitoring}
 \input{common/nagios}
 
@@ -209,10 +213,6 @@ links below:
 
 \paragraph{Add \conman{}} \label{sec:add_conman}
 \input{common/conman}
-
-\clearpage
-\paragraph{Enable forwarding of system logs} \label{sec:add_syslog}
-\input{common/syslog}
 
 \subsubsection{Import files} \label{sec:file_import}
 \input{common/import_ww_files}

--- a/docs/recipes/install/centos7/aarch64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/centos7/aarch64/warewulf/slurm/steps.tex
@@ -184,6 +184,9 @@ links below:
 \paragraph{Enable ssh control via resource manager} 
 \input{common/slurm_pam}
 
+\paragraph{Add \beegfs{}} \label{sec:add_beegfs}
+\input{common/install_beegfs_client_centos}
+
 \paragraph{Add \Lustre{} client} \label{sec:lustre_client}
 \input{common/lustre-client}
 \input{common/lustre-client-centos}

--- a/docs/recipes/install/sles12/aarch64/warewulf/slurm/manifest/admin.tex
+++ b/docs/recipes/install/sles12/aarch64/warewulf/slurm/manifest/admin.tex
@@ -8,6 +8,13 @@
 {\bf RPM Package Name} & {\bf Version} & {\bf Info/URL}  \\ 
 \midrule
 
+% <-- begin entry for clustershell-ohpc
+\multirow{2}{*}{clustershell-ohpc} & 
+\multirow{2}{*}{1.7.3} & 
+Python framework for efficient cluster administration. \newline { \color{logoblue} \url{http://clustershell.sourceforge.net}} 
+\\ \hline 
+% <-- end entry for clustershell-ohpc
+
 % <-- begin entry for conman-ohpc
 \multirow{2}{*}{conman-ohpc} & 
 \multirow{2}{*}{0.2.8} & 
@@ -43,12 +50,37 @@ Static cluster configuration database. \newline { \color{logoblue} \url{https://
 \\ \hline 
 % <-- end entry for genders-ohpc
 
+% <-- begin entry for lmod-defaults
+lmod-defaults-gnu-mpich-ohpc &
+\multirow{4}{*}{1.2} & 
+\multirow{12}{\linewidth}{OpenHPC default login environments. \newline {\color{logoblue} \url{https://github.com/openhpc/ohpc}}} \\ 
+& \\ 
+lmod-defaults-gnu-openmpi-ohpc &
+& \\ 
+\cline{1-2} lmod-defaults-gnu7-mpich-ohpc &\multirow{8}{*}{1.3.1}
+& \\ 
+lmod-defaults-gnu7-openmpi-ohpc &
+& \\ 
+lmod-defaults-intel-mpich-ohpc &
+& \\ 
+lmod-defaults-intel-openmpi-ohpc &
+& \\ 
+\hline
+% <-- end entry for lmod-defaults
+
 % <-- begin entry for lmod-ohpc
 \multirow{2}{*}{lmod-ohpc} & 
 \multirow{2}{*}{7.4.8} & 
 Lua based Modules (lmod). \newline { \color{logoblue} \url{https://github.com/TACC/Lmod}} 
 \\ \hline 
 % <-- end entry for lmod-ohpc
+
+% <-- begin entry for losf-ohpc
+\multirow{2}{*}{losf-ohpc} & 
+\multirow{2}{*}{0.54.0} & 
+A Linux operating system framework for managing HPC clusters.  { \color{logoblue} \url{https://github.com/hpcsi/losf}} 
+\\ \hline 
+% <-- end entry for losf-ohpc
 
 % <-- begin entry for mrsh-ohpc
 \multirow{2}{*}{mrsh-ohpc} & 
@@ -98,6 +130,20 @@ OpenHPC release files. \newline { \color{logoblue} \url{https://github.com/openh
 Parallel remote shell program. \newline { \color{logoblue} \url{http://sourceforge.net/projects/pdsh}} 
 \\ \hline 
 % <-- end entry for pdsh-ohpc
+
+% <-- begin entry for prun-ohpc
+\multirow{2}{*}{prun-ohpc} & 
+\multirow{2}{*}{1.1} & 
+Convenience utility for parallel job launch. \newline { \color{logoblue} \url{https://github.com/openhpc/ohpc}} 
+\\ \hline 
+% <-- end entry for prun-ohpc
+
+% <-- begin entry for test-suite-ohpc
+\multirow{2}{*}{test-suite-ohpc} & 
+\multirow{2}{*}{1.3.1} & 
+Integration test suite for OpenHPC. \newline { \color{logoblue} \url{https://github.com/openhpc/ohpc/tests}} 
+\\ \hline 
+% <-- end entry for test-suite-ohpc
 
 \bottomrule
 \end{tabularx}

--- a/docs/recipes/install/sles12/aarch64/warewulf/slurm/manifest/dev-tools.tex
+++ b/docs/recipes/install/sles12/aarch64/warewulf/slurm/manifest/dev-tools.tex
@@ -45,8 +45,8 @@ The GNU Portable Library Tool. \newline { \color{logoblue} \url{http://www.gnu.o
 
 % <-- begin entry for python-scipy
 python-scipy-gnu7-mpich-ohpc &
-\multirow{4}{*}{0.19.0} & 
-\multirow{4}{\linewidth}{Scientific Tools for Python. \newline {\color{logoblue} \url{http://www.scipy.org}}} \\ 
+\multirow{6}{*}{0.19.0} & 
+\multirow{6}{\linewidth}{Scientific Tools for Python. \newline {\color{logoblue} \url{http://www.scipy.org}}} \\ 
 python-scipy-gnu7-openmpi-ohpc &
 & \\ 
 python-scipy-gnu-mpich-ohpc &
@@ -59,11 +59,20 @@ python-scipy-gnu-openmpi-ohpc &
 % <-- begin entry for python-numpy
 python-numpy-gnu-ohpc &
 \multirow{1}{*}{1.11.1} & 
-\multirow{2}{\linewidth}{NumPy array processing for numbers, strings, records and objects.  {\color{logoblue} \url{http://sourceforge.net/projects/numpy}}} \\ 
-\cline{1-2} python-numpy-gnu7-ohpc &\multirow{1}{*}{1.12.1}
+\multirow{3}{\linewidth}{NumPy array processing for numbers, strings, records and objects. \newline {\color{logoblue} \url{http://sourceforge.net/projects/numpy}}} \\ 
+\cline{1-2} python-numpy-gnu7-ohpc &\multirow{2}{*}{1.12.1}
+& \\ 
+python-numpy-intel-ohpc &
 & \\ 
 \hline
 % <-- end entry for python-numpy
+
+% <-- begin entry for spack-ohpc
+\multirow{2}{*}{spack-ohpc} & 
+\multirow{2}{*}{0.10.0} & 
+HPC software package management. \newline { \color{logoblue} \url{https://github.com/LLNL/spack}} 
+\\ \hline 
+% <-- end entry for spack-ohpc
 
 % <-- begin entry for valgrind-ohpc
 \multirow{2}{*}{valgrind-ohpc} & 

--- a/docs/recipes/install/sles12/aarch64/warewulf/slurm/manifest/rms.tex
+++ b/docs/recipes/install/sles12/aarch64/warewulf/slurm/manifest/rms.tex
@@ -15,6 +15,27 @@ MUNGE authentication service. \newline { \color{logoblue} \url{http://dun.github
 \\ \hline 
 % <-- end entry for munge-ohpc
 
+% <-- begin entry for pbspro-execution-ohpc
+\multirow{2}{*}{pbspro-execution-ohpc} & 
+\multirow{2}{*}{14.1.0} & 
+PBS Professional for an execution host. \newline { \color{logoblue} \url{https://github.com/pbspro/pbspro}} 
+\\ \hline 
+% <-- end entry for pbspro-execution-ohpc
+
+% <-- begin entry for pbspro-client-ohpc
+\multirow{2}{*}{pbspro-client-ohpc} & 
+\multirow{2}{*}{14.1.0} & 
+PBS Professional for a client host. \newline { \color{logoblue} \url{https://github.com/pbspro/pbspro}} 
+\\ \hline 
+% <-- end entry for pbspro-client-ohpc
+
+% <-- begin entry for pbspro-server-ohpc
+\multirow{2}{*}{pbspro-server-ohpc} & 
+\multirow{2}{*}{14.1.0} & 
+PBS Professional for a server host. \newline { \color{logoblue} \url{https://github.com/pbspro/pbspro}} 
+\\ \hline 
+% <-- end entry for pbspro-server-ohpc
+
 % <-- begin entry for slurm-devel-ohpc
 \multirow{2}{*}{slurm-devel-ohpc} & 
 \multirow{2}{*}{16.05.10} & 

--- a/docs/recipes/install/sles12/aarch64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/sles12/aarch64/warewulf/slurm/steps.tex
@@ -180,6 +180,9 @@
 \paragraph{Enable ssh control via resource manager} 
 \input{common/slurm_pam}
 
+\paragraph{Add \beegfs{}} \label{sec:add_beegfs}
+\input{common/install_beegfs_client_centos}
+
 \paragraph{Add \Lustre{} client} \label{sec:lustre_client}
 \input{common/lustre-client}
 \input{common/lustre-client}

--- a/docs/recipes/install/sles12/aarch64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/sles12/aarch64/warewulf/slurm/steps.tex
@@ -187,6 +187,10 @@
 \input{common/lustre-client-post}
 
 \clearpage
+\paragraph{Enable forwarding of system logs} \label{sec:add_syslog}
+\input{common/syslog}
+
+\clearpage
 \paragraph{Add \Nagios{} monitoring}
 \input{common/nagios}
 
@@ -206,10 +210,6 @@
 
 \paragraph{Add \conman{}} \label{sec:add_conman}
 \input{common/conman}
-
-\clearpage
-\paragraph{Enable forwarding of system logs} \label{sec:add_syslog}
-\input{common/syslog}
 
 \subsubsection{Import files} \label{sec:file_import}
 \input{common/import_ww_files}


### PR DESCRIPTION
I was browsing the Aarch64 install guide and noticed a few differences compared to x86:

1) The "Enable forwarding of system logs" section was in a different place.

2) The beegfs section was missing. It's possible this was intentional, however the rest of the aarch64 doc does reference beegfs throughout.

3) Some of the tables in the appendix "Package Manifest" were out of date. This was only for the tables without gnu7 references in them.

The document is also incorrect for 1.3.1 and 1.3 in the same ways, but it's probably too late to update now.
