### PR TITLE
Various cleanups and build fixes

### DIFF
--- a/components/dev-tools/scipy/SPECS/python-scipy.spec
+++ b/components/dev-tools/scipy/SPECS/python-scipy.spec
@@ -69,7 +69,7 @@ Summary:        Scientific Tools for Python
 License:        BSD-3-Clause
 Group:          %{PROJ_NAME}/dev-tools
 Url:            http://www.scipy.org
-Source0:        https://github.com/scipy/scipy/archive/v%{version}.tar.gz#$/%{pname}-%{version}.tar.gz
+Source0:        https://github.com/scipy/scipy/archive/v%{version}.tar.gz#/%{pname}-%{version}.tar.gz
 Source1:        OHPC_macros
 %if 0%{?sles_version} || 0%{?suse_version}
 BuildRequires:  fdupes

--- a/components/perf-tools/imb/SOURCES/imb.cc.patch
+++ b/components/perf-tools/imb/SOURCES/imb.cc.patch
@@ -6,5 +6,5 @@
 -CC          = mpiicc 
 +CC          = mpicc 
  ifeq (,$(shell which ${CC}))
- $(error ${CC} is not defined through the PATH environment variable setting. Please try sourcing an Intel(r) Cluster Tools script file such as "mpivars.[c]sh" or "ictvars.[c]sh")
+ $(error ${CC} is not defined through the PATH environment variable setting. Please try sourcing an Intel(R) Cluster Tools script file such as "mpivars.[c]sh" or "ictvars.[c]sh")
  endif

--- a/components/perf-tools/imb/SPECS/imb.spec
+++ b/components/perf-tools/imb/SPECS/imb.spec
@@ -39,7 +39,7 @@ measurements for point-to-point and global communication operations for
 a range of message sizes.
 
 %prep
-%setup -n imb
+%setup -n mpi-benchmarks-%{version}
 
 # OpenHPC patches
 %patch1 -p0
@@ -108,7 +108,8 @@ EOF
 
 %files
 %defattr(-,root,root,-)
-%{OHPC_PUB}
+%{install_path}
+%{OHPC_MODULEDEPS}/%{compiler_family}-%{mpi_family}/%{pname}
 %doc license/license.txt license/use-of-trademark-license.txt ReadMe_IMB.txt
 
 

--- a/components/serial-libs/scotch/SPECS/scotch.spec
+++ b/components/serial-libs/scotch/SPECS/scotch.spec
@@ -25,9 +25,8 @@ URL:		http://www.labri.fr/perso/pelegrin/%{pname}/
 Source0:	http://gforge.inria.fr/frs/download.php/file/34618/%{pname}_%{version}.tar.gz
 Source1:	%{pname}-Makefile.%{compiler_family}.inc.in
 Source2:	%{pname}-rpmlintrc
+Source3:	OHPC_macros
 Patch0:         %{pname}-%{version}-destdir.patch
-BuildRoot:	%{_tmppath}/%{pname}-%{version}-%{release}-root
-DocDir:         %{OHPC_PUB}/doc/contrib
 
 BuildRequires:	flex bison
 %if 0%{?suse_version} >= 1100
@@ -46,7 +45,6 @@ BuildRequires:  zlib-devel
 %endif
 %endif
 
-%define debug_package %{nil}
 %define install_path %{OHPC_LIBS}/%{compiler_family}/%{pname}/%version
 
 %description
@@ -69,7 +67,6 @@ popd
 %install
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
-rm -rf %{buildroot}
 
 pushd src
 make prefix=%{buildroot}%{install_path} install
@@ -127,13 +124,10 @@ setenv          %{PNAME}_INC        %{install_path}/include
 
 EOF
 
-%clean
-rm -rf ${RPM_BUILD_ROOT}
-
 %files
 %defattr(-,root,root)
 %doc README.txt ./doc/*
-%{OHPC_PUB}
+%{install_path}
+%{OHPC_MODULEDEPS}/%{compiler_family}/%{pname}
 
 %changelog
-


### PR DESCRIPTION
This fixes a few broken builds on the 1.3.3 branch and does some minor
cleanups. Especially implicit defined or already defined parts from
OHPC_macros have been removed.

Signed-off-by: Adrian Reber <areber@redhat.com>