### PR TITLE
get_source.sh: script which tries to download sources

### DIFF
--- a/misc/get_source.sh
+++ b/misc/get_source.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+if [ $# -ne 1 ]; then
+	echo "${0} requires the name of the spec file as parameter."
+	exit 1
+fi
+
+PATTERN=${1}
+
+IFS=$'\n'
+
+for i in `find . -name "${PATTERN}"`; do
+
+	if [ ! -f ${i} ]; then
+		echo "${i} is not a file. Skipping."
+		continue
+	fi
+
+	echo ${i}
+
+	pushd `dirname ${i}` > /dev/null
+	BASE=`basename ${i}`
+
+	SOURCES=`rpmspec --parse --define '_sourcedir ../SOURCES' --define 'rhel 7' ${BASE} | grep Source`
+	for u in ${SOURCES}; do
+		echo ${u}
+		if [[ "${u}" != *"http"* ]]; then
+			continue
+		fi
+		u=`awk '{ print $2 }' <<< ${u}`
+		echo "Trying to get ${u}"
+		# Try to download only if newer
+		WGET=`wget -N -nv -P ../SOURCES ${u}x 2>&1`
+		# Handling for github URLs with #/ or #$/
+		if grep -E "#[$]?/" <<< ${u}; then
+			URL=`echo ${u} | cut -d# -f1`
+			mv `echo ${WGET} | cut -d\  -f13 | sed -e 's/^"//' -e 's/"$//'` ../SOURCES/`basename ${u}`
+		fi
+	done
+
+	popd > /dev/null
+done


### PR DESCRIPTION
If building outside of OBS an automated way of getting all the
source tarballs is missing. Instead of manually downloading all
the required source archives this script tries to be clever
and downloads the source archives in the components SOURCES directory.

It only tries to download 'SourceX' lines with 'http' in them
and it also tries to handle URLs with '#[?]/' where the downloaded
source archive has another name then what rpmbuild is looking for.

It works like this:

$ misc/get_source.sh lmod.spec
./components/admin/lmod/SPECS/lmod.spec
Source0:   https://github.com/TACC/Lmod/archive/7.7.1.tar.gz#$/lmod-7.7.1.tar.gz
Trying to get https://github.com/TACC/Lmod/archive/7.7.1.tar.gz#$/lmod-7.7.1.tar.gz
https://github.com/TACC/Lmod/archive/7.7.1.tar.gz#$/lmod-7.7.1.tar.gz
Source1:   OHPC_macros

Signed-off-by: Adrian Reber <areber@redhat.com>