### PR TITLE
misc/build_order: fix build_order scripts

### DIFF
--- a/misc/build_order.py
+++ b/misc/build_order.py
@@ -62,6 +62,9 @@ for line in open(sys.argv[1]):
     # Ignore non ohpc (Build)Requires
     if line[2] == 'NA':
         continue
+    # Ignore kernel modules
+    if line[2].startswith('kmod'):
+        continue
     # Ignore the nagios_plugins
     if ((line[2].startswith('nagios-plugins')) and
             (not line[2].startswith('nagios-plugins-ohpc'))):


### PR DESCRIPTION
The build_order scripts are now skipping packages starting with
'kmod' and the RPM defines are now correct when running on Fedora.

Signed-off-by: Adrian Reber <areber@redhat.com>