### PR TITLE
[docs] Add simple checks to base install commands

### DIFF
--- a/docs/recipes/install/centos7/aarch64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/centos7/aarch64/warewulf/slurm/steps.tex
@@ -82,8 +82,10 @@
 % ohpc_validation_newline
 % ohpc_validation_comment Disable firewall 
 \begin{lstlisting}[language=bash,keywords={}]
-[sms](*\#*) systemctl disable firewalld
-[sms](*\#*) systemctl stop firewalld
+[sms](*\#*) if systemctl status firewalld; then
+              systemctl disable firewalld
+              systemctl stop firewalld
+            fi
 \end{lstlisting}
 % end_ohpc_run
 

--- a/docs/recipes/install/common/bos.tex
+++ b/docs/recipes/install/common/bos.tex
@@ -13,7 +13,9 @@ installed the BOS, there may be an adequate entry already defined
 in \path{/etc/hosts}. If not, the following addition can be used to identify
 your SMS host.
 \begin{lstlisting}[language=bash,keywords={}]
-[sms](*\#*) echo ${sms_ip} ${sms_name} >> /etc/hosts
+[sms](*\#*) if ! grep -q ${sms_name} /etc/hosts; then
+              echo ${sms_ip} ${sms_name} >> /etc/hosts
+            fi
 \end{lstlisting}
 
 While it is theoretically possible to enable SELinux on a cluster provisioned


### PR DESCRIPTION
This is a first attempt at improving the command lines in the documents. 

Most of them just allow safe copy and paste across by checking already updated files, thus avoiding duplicated commands. The bulk is, therefore, uncontroversial, as long as we're happy to have the checks on most places. If this is the case, and this patch is accepted, I'll create a pull request to all others.

The more complicated changes will be submitted after the initial cleanup.

Reference repo: https://git.linaro.org/leg/hpc/ohpc-scripts.git/

This change: https://git.linaro.org/leg/hpc/ohpc-scripts.git/tree/centos7/00_base_install.sh