### PR TITLE
lua-filesystem: clean up spec file

### DIFF
--- a/components/distro-packages/lua-filesystem/SPECS/lua-filesystem.spec
+++ b/components/distro-packages/lua-filesystem/SPECS/lua-filesystem.spec
@@ -11,41 +11,22 @@
 %global ohpc_bootstrap 1
 
 %include %{_sourcedir}/OHPC_macros
-%{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
-%define pname lua-filesystem
+%global pname lua-filesystem
 
-#
-# spec file for package luafilesystem
-# Copyright (c) 2009 florian.leparoux@gmail.com
-# Copyright (c) 2012 Togan Muftuoglu toganm@opensuse.org
-#
-# All modifications and additions to the file contributed by third parties
-# remain the property of their copyright owners, unless otherwise agreed
-# upon. The license for this file, and modifications and additions to the
-# file, is the same license as for the pristine package itself (unless the
-# license for the pristine package is not an Open Source License, in which
-# case the license is the MIT License). An "Open Source License" is a
-# license that conforms to the Open Source Definition (Version 1.9)
-# published by the Open Source Initiative.
-
-#
-# Please submit bugfixes or comments via http://bugs.opensuse.org/
-#
 %if 0%{?suse_version} <= 1220
-%define luaver 5.1
+%global luaver 5.1
 %else
-%define luaver 5.2
+%global luaver 5.2
 %endif
-%define lualibdir %{_libdir}/lua/%{luaver}
-%define luapkgdir %{_datadir}/lua/%{luaver}
-%define debug_package %{nil}
+%global lualibdir %{_libdir}/lua/%{luaver}
+%global luapkgdir %{_datadir}/lua/%{luaver}
 
-%define version_exp 1_6_3
+%global version_exp 1_6_3
 
 Name:           %{pname}%{PROJ_DELIM}
 Version:        1.6.3
-Release:        0
+Release:        0%{?dist}
 License:        MIT
 Summary:        Lua library to Access Directories and Files
 Url:            http://keplerproject.github.com/luafilesystem
@@ -57,7 +38,6 @@ Patch1:         luafilesystem-%{luaver}-optflags.patch
 # PATCH-FIX-UPSTREAM -- toganm@opensuse.org fixes Makefile for DESTDIR
 Patch2:         luafilesystem-%{version}-destdir.patch
 BuildRequires:  lua-devel
-BuildRoot:      %{_tmppath}/%{pname}-%{version}-build
 
 %description
 LuaFileSystem is a Lua library developed to complement the set of functions
@@ -70,25 +50,24 @@ structure and file attributes.
 %patch1
 %patch2 -p1
 
-sed -i 's|@@LIBDIR@@|%{_libdir}|g;s|@@INCLUDEDIR@@|%{_includedir}|g;' $(perl -ne 'print $1,"\n" if /^\+{3}\s+(.+?)\s+/' "%{PATCH1}")
+sed -i 's|@@LIBDIR@@|%{_libdir}|g;s|@@INCLUDEDIR@@|%{_includedir}|g;' config
 
 %build
-
-make %{?_smp_mflags} \
-    PREFIX=%{_prefix} \
-    LUA_LIBDIR=%{lualibdir} \
-    CFLAGS="%{optflags} -fPIC"
+make %{?_smp_mflags} LUA_LIBDIR=%{lualibdir} CFLAGS="%{optflags} -fPIC"
 
 %install
-%make_install \
-    DESTDIR=%buildroot \
-    PREFIX="%{_prefix}" \
-    LUA_LIBDIR="%{lualibdir}"
-
+%make_install LUA_LIBDIR="%{lualibdir}"
 
 %files
-%defattr(-,root,root,-)
 %dir %{_libdir}/lua
 %dir %{lualibdir}
 %{lualibdir}/lfs*
 
+%changelog
+* Tue Oct 17 2017 Adrian Reber <areber@redhat.com> - 1.6.3-0
+- removed setting PROJ_DELIM; this is done by OHPC_macros
+- replaced 'define' with 'global' to avoid scope problems and warnings
+- removed BuildRoot (not necessary) and debug_package (OHPC_macros)
+- removed implicit build dependency on perl
+- removed setting unused variables
+- removed opensuse comments; it is an OpenHPC spec file now


### PR DESCRIPTION
 - removed setting PROJ_DELIM; this is done by OHPC_macros
 - replaced 'define' with 'global' to avoid scope problems and warnings
 - removed BuildRoot (not necessary) and debug_package (OHPC_macros)
 - removed implicit build dependency on perl
 - removed setting unused variables
 - removed opensuse comments; it is an OpenHPC spec file now

Signed-off-by: Adrian Reber <areber@redhat.com>