### PR TITLE
Fix URL of SOURCE.

### DIFF
--- a/components/distro-packages/python-Cython/SPECS/python-Cython.spec
+++ b/components/distro-packages/python-Cython/SPECS/python-Cython.spec
@@ -33,7 +33,7 @@ Url:            http://www.cython.org
 Summary:        The Cython compiler for writing C extensions for the Python language
 License:        Apache-2.0
 Group:          Development/Languages/Python
-Source:         http://pypi.python.org/packages/source/C/Cython/Cython-%{version}.tar.gz
+Source:         https://pypi.python.org/packages/b3/89/e8dddc86bf4f144407962e04c4018f53dfe4d6ae5010d34573d8521e810e/Cython-%{version}.tar.gz
 Source1:        python-Cython-rpmlintrc
 Patch1:         python-Cython-c++11.patch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
As I mentioned on issue #589 , I found that the URL in the spec file of python-Cython.
Apparently, the download URL format of python-Cython might change after the spec file was created.