### PR TITLE
Introduce ppc64le build-related options in .spec files

### DIFF
--- a/components/admin/pdsh/SPECS/pdsh.spec
+++ b/components/admin/pdsh/SPECS/pdsh.spec
@@ -316,7 +316,7 @@ from an allocated Torque job.
 %build
 
 # work around old config.guess on aarch64 systems
-%ifarch aarch64
+%ifarch aarch64 || ppc64le
 cp /usr/lib/rpm/config.guess config
 %endif
 

--- a/components/compiler-families/llvm-compilers/SPECS/llvm-compilers.spec
+++ b/components/compiler-families/llvm-compilers/SPECS/llvm-compilers.spec
@@ -79,6 +79,7 @@ cd llvm-%{version}.src/projects
 ln -s ../../compiler-rt-%{version}.src compiler-rt
 cd ../..
 
+%ifnarch ppc64le
 cd llvm-%{version}.src/projects
 ln -s ../../libcxx-%{version}.src libcxx
 cd ../..
@@ -90,6 +91,7 @@ cd ../..
 cd llvm-%{version}.src/projects
 ln -s ../../libunwind-%{version}.src libunwind
 cd ../..
+%endif
 
 cd llvm-%{version}.src/projects
 ln -s ../../openmp-%{version}.src openmp

--- a/components/dev-tools/autoconf/SPECS/autoconf.spec
+++ b/components/dev-tools/autoconf/SPECS/autoconf.spec
@@ -56,6 +56,10 @@ their use.
 %setup -n autoconf-%{version}
 
 %build
+%ifarch ppc64le
+cp /usr/lib/rpm/config.guess build-aux
+%endif
+
 ./configure --prefix=%{install_path}
 
 %install

--- a/components/io-libs/adios/SPECS/adios.spec
+++ b/components/io-libs/adios/SPECS/adios.spec
@@ -112,7 +112,7 @@ export CFLAGS="-fp-model strict $CFLAGS"
 %endif
 
 # work around old config.guess on aarch64 systems
-%ifarch aarch64
+%ifarch aarch64 || ppc64le
 cp /usr/lib/rpm/config.guess config
 %endif
 

--- a/components/io-libs/hdf5/SPECS/hdf5.spec
+++ b/components/io-libs/hdf5/SPECS/hdf5.spec
@@ -68,7 +68,7 @@ grids. You can also mix and match them in HDF5 files according to your needs.
 %build
 
 # override with newer config.guess for aarch64
-%ifarch aarch64
+%ifarch aarch64 || ppc64le
 cp /usr/lib/rpm/config.guess bin
 %endif
 

--- a/components/io-libs/phdf5/SPECS/hdf5.spec
+++ b/components/io-libs/phdf5/SPECS/hdf5.spec
@@ -68,7 +68,7 @@ grids. You can also mix and match them in HDF5 files according to your needs.
 %build
 
 # override with newer config.guess for aarch64
-%ifarch aarch64
+%ifarch aarch64 || ppc64le
 cp /usr/lib/rpm/config.guess bin
 %endif
 

--- a/components/io-libs/pnetcdf/SPECS/pnetcdf.spec
+++ b/components/io-libs/pnetcdf/SPECS/pnetcdf.spec
@@ -49,7 +49,7 @@ attributes, and variables (> 2B array elements).
 %build
 
 # override with newer config.guess for aarch64
-%ifarch aarch64
+%ifarch aarch64 || ppc64le
 cp /usr/lib/rpm/config.guess scripts
 %endif
 

--- a/components/mpi-families/openmpi/SPECS/openmpi.spec
+++ b/components/mpi-families/openmpi/SPECS/openmpi.spec
@@ -17,7 +17,7 @@
 %define pname openmpi3
 %define with_openib 1
 
-%ifarch aarch64
+%ifarch aarch64 || ppc64le
 %define with_psm 0
 %define with_psm2 0
 %else

--- a/components/parallel-libs/hypre/SPECS/hypre.spec
+++ b/components/parallel-libs/hypre/SPECS/hypre.spec
@@ -84,7 +84,7 @@ phenomena in the defense, environmental, energy, and biological sciences.
 
 %build
 
-%ifarch aarch64
+%ifarch aarch64 || ppc64le
 cp /usr/lib/rpm/config.guess src/config
 %endif
 

--- a/components/perf-tools/mpiP/SPECS/mpiP.spec
+++ b/components/perf-tools/mpiP/SPECS/mpiP.spec
@@ -60,7 +60,7 @@ file.
 %build
 
 # override with newer config.guess for aarch64
-%ifarch aarch64
+%ifarch aarch64 || ppc64le
 cp /usr/lib/rpm/config.guess bin
 %endif
 

--- a/components/perf-tools/pdtoolkit/SPECS/pdtoolkit.spec
+++ b/components/perf-tools/pdtoolkit/SPECS/pdtoolkit.spec
@@ -84,8 +84,12 @@ rm -f %buildroot%{install_path}/.last_config
 
 %ifarch aarch64
 %define arch_dir arm64_linux
-%else
+%endif
+%ifarch x86_64
 %define arch_dir x86_64
+%endif
+%ifarch ppc64le
+%define arch_dir ibm64linux
 %endif
 
 pushd %buildroot%{install_path}/%{arch_dir}/lib
@@ -102,17 +106,17 @@ ln -s ../../contrib/rose/roseparse/upcparse edg33-upcparse
 sed -i 's|%buildroot||g' ../../contrib/rose/roseparse/upcparse
 %endif
 rm -f edg44-c-roseparse
-%ifnarch aarch64
+%ifnarch aarch64 || ppc64le
 ln -s  ../../contrib/rose/edg44/%{arch_dir}/roseparse/edg44-c-roseparse
 sed -i 's|%buildroot||g' ../../contrib/rose/edg44/%{arch_dir}/roseparse/edg44-c-roseparse
 %endif
 rm -f edg44-cxx-roseparse
-%ifnarch aarch64
+%ifnarch aarch64 || ppc64le
 ln -s  ../../contrib/rose/edg44/%{arch_dir}/roseparse/edg44-cxx-roseparse
 sed -i 's|%buildroot||g' ../../contrib/rose/edg44/%{arch_dir}/roseparse/edg44-cxx-roseparse
 %endif
 rm -f edg44-upcparse
-%ifnarch aarch64
+%ifnarch aarch64 || ppc64le
 ln -s  ../../contrib/rose/edg44/%{arch_dir}/roseparse/edg44-upcparse
 sed -i 's|%buildroot||g' ../../contrib/rose/edg44/%{arch_dir}/roseparse/edg44-upcparse
 %endif

--- a/components/perf-tools/tau/SPECS/tau.spec
+++ b/components/perf-tools/tau/SPECS/tau.spec
@@ -109,7 +109,7 @@ export FFLAGS="$FFLAGS -I$MPI_INCLUDE_DIR"
 export TAUROOT=`pwd`
 
 # override with newer config.guess for aarch64
-%ifarch aarch64
+%ifarch aarch64 || ppc64le
 cp /usr/lib/rpm/config.guess utils/opari2/build-config/.
 cp /usr/lib/rpm/config.sub utils/opari2/build-config/.
 %endif

--- a/components/provisioning/warewulf-provision/SOURCES/warewulf-provision-ppc64le.patch
+++ b/components/provisioning/warewulf-provision/SOURCES/warewulf-provision-ppc64le.patch
@@ -1,0 +1,43 @@
+--- a/provision/initramfs/Makefile.in.orig	2017-03-10 10:18:39.101375078 -0500
++++ b/provision/initramfs/Makefile.in	2017-03-10 10:19:33.921378704 -0500
+@@ -282,6 +282,14 @@
+ MAINTAINERCLEANFILES = Makefile.in
+ all: all-recursive
+ 
++ARCH := $(shell uname -m)
++
++ifeq ($(ARCH),ppc64le)
++	LOADER :=ld64
++else
++	LOADER :=ld-linux
++endif
++
+ .SUFFIXES:
+ $(srcdir)/Makefile.in:  $(srcdir)/Makefile.am  $(am__configure_deps)
+ 	@for dep in $?; do \
+--- warewulf3-3.7pre/provision/initramfs/Makefile.in.orig	2017-03-13 11:43:02.946811424 -0400
++++ warewulf3-3.7pre/provision/initramfs/Makefile.in	2017-03-13 11:48:46.216827808 -0400
+@@ -642,6 +642,12 @@
+ 	fi
+ 	@ if [ ! -f "_work/$(LIBARCHIVE_DIR)/" ]; then \
+ 		echo "Building libarchive" ;\
++		if [ -f "/usr/lib/rpm/config.guess" ]; then \
++			cp /usr/lib/rpm/config.guess _work/$(LIBARCHIVE_DIR)/build/autoconf;\
++		fi; \
++		if [ -f "/usr/lib/rpm/config.sub" ]; then \
++			cp /usr/lib/rpm/config.sub _work/$(LIBARCHIVE_DIR)/build/autoconf;\
++		fi; \
+ 		(cd _work/$(LIBARCHIVE_DIR)/; ./configure $(LIBARCHIVE_CONFIGARGS)) ;\
+ 		$(MAKE) -C _work/$(LIBARCHIVE_DIR);\
+ 	fi
+@@ -683,8 +683,8 @@
+ 	ln -s mkfs.ext4 rootfs/sbin/mkfs.ext3
+ 	cp -a _work/$(LIBARCHIVE_DIR)/bsdtar rootfs/bin/bsdtar
+ 	$(MAKE) -C _work/$(PARTED_DIR)/ DESTDIR=`pwd`/rootfs install
+-	cp -L --parents /lib*/ld-linux* rootfs/
+-	find rootfs -type f -perm -o+x -print | grep -v ld-linux | xargs ldd | grep "=>" | awk '{print $$3}' | grep "^/" | sort | uniq | while read i; do cp -L --parents $$i rootfs/ && chmod 755 rootfs/$$i; done
++	cp -L --parents /lib*/$(LOADER)* rootfs/
++	find rootfs -type f -perm -o+x -print | grep -v $(LOADER) | xargs ldd | grep "=>" | awk '{print $$3}' | grep "^/" | sort | uniq | while read i; do cp -L --parents $$i rootfs/ && chmod 755 rootfs/$$i; done
+ 	rm -f rootfs/linuxrc rootfs/lib64/*.la rootfs/lib/*.la rootfs/usr/lib64/*.la rootfs/usr/lib/*.la
+ 	rm -rf rootfs/usr/share rootfs/usr/include rootfs/usr/lib/pkgconfig
+ 	find -type d \! -perm -u=w -exec chmod u+w {} \;

--- a/components/provisioning/warewulf-provision/SPECS/warewulf-provision.spec
+++ b/components/provisioning/warewulf-provision/SPECS/warewulf-provision.spec
@@ -63,6 +63,7 @@ Patch5: warewulf-provision.bin-file.patch
 Patch6: warewulf-provision.sles_tftpboot.patch
 Patch7: warewulf-provision.ipxe-kargs.patch
 Patch8: warewulf-provision.parted_libdir.patch
+Patch9: warewulf-provision-ppc64le.patch
 
 %description
 Warewulf >= 3 is a set of utilities designed to better enable
@@ -138,6 +139,7 @@ fi
 %patch6 -p1
 %patch7 -p1
 %patch8 -p1
+%patch9 -p2
 
 %build
 cd %{dname}
@@ -228,7 +230,9 @@ rm -rf $RPM_BUILD_ROOT
 %endif
 
 %{_bindir}/*
+%ifnarch ppc64le
 %{_datadir}/warewulf/ipxe/*
+%endif
 %{perl_vendorlib}/Warewulf/Event/Bootstrap.pm
 %{perl_vendorlib}/Warewulf/Event/Dhcp.pm
 %{perl_vendorlib}/Warewulf/Event/Pxe.pm

--- a/components/serial-libs/openblas/SPECS/openblas.spec
+++ b/components/serial-libs/openblas/SPECS/openblas.spec
@@ -58,7 +58,7 @@ Patch5:         1262.patch
 Patch6:         1236.patch
 # PATCH for https://github.com/xianyi/OpenBLAS/pull/1247
 Patch7:         1247.patch
-ExclusiveArch:  %ix86 ia64 ppc ppc64 x86_64 aarch64
+ExclusiveArch:  %ix86 ia64 ppc ppc64 ppc64le x86_64 aarch64
 
 %description
 OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version.


### PR DESCRIPTION
With this all spec files have been adapted to also build on ppc64le.
Right now only llvm-compilers.spec does not build on ppc64le with:

 llvm5-compilers-ohpc-5.0.0/llvm/projects/libunwind/include/__libunwind_config.h:55:4: error: #error "Unsupported architecture."

As this seems to be part of the actual source code and not packaging
related, and as nothing depends yet on llvm-compilers, llvm-compilers
has been ignored for the ppc64le effort.

This is also only compile tested but a first step towards ppc64le
support.

Test build results available at:

 https://copr.fedorainfracloud.org/coprs/adrian/ohpc-ppc64le/packages/

Signed-off-by: Adrian Reber <areber@redhat.com>