### PR TITLE
add script to quickly build a SRPM

### DIFF
--- a/misc/build_order.sh
+++ b/misc/build_order.sh
@@ -32,7 +32,7 @@ trap "rm -f ${DEPLIST}" EXIT QUIT HUP KILL TERM
 DISTRO=`rpm --eval '0%{?fedora}'`
 
 if [ "${DISTRO}" != "0" ]; then
-	FLAGS="--undefine fedora --define 'rhel 7'"
+	FLAGS=(--undefine fedora --define "rhel 7")
 fi
 
 for i in `find . -name *.spec`; do
@@ -41,8 +41,8 @@ for i in `find . -name *.spec`; do
 	NAMES=`rpmspec -q ${i} --queryformat '%{name}:' 2> /dev/null`
 	# Let's hope the first name is the right one
 	NAME=`echo ${NAMES} | cut -d: -f1`
-	REQ=`rpmspec -q ${i} ${FLAGS} --requires 2> /dev/null`
-	BR=`rpmspec -q ${i} ${FLAGS} --buildrequires 2> /dev/null`
+	REQ=`rpmspec -q ${i} "${FLAGS[@]}" --requires 2> /dev/null`
+	BR=`rpmspec -q ${i} "${FLAGS[@]}" --buildrequires 2> /dev/null`
 	for j in ${REQ} ${BR}; do
 		if [[ ${j} != *"ohpc"* ]] || [[ ${j} == *"buildroot"* ]]; then
 			OIFS=${IFS}

--- a/misc/build_srpm.sh
+++ b/misc/build_srpm.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#  Copyright 2017 Adrian Reber
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+PATTERN=$1
+
+MACROS=components/OHPC_macros
+
+if [ ! -e ${MACROS} ]; then
+	echo -n "This script expects to be started in the top-level OpenHPC git"
+	echo " checkout directory."
+	echo -n "Checking for '${MACROS}' failed and"
+	echo " therefore exiting."
+	exit 1
+fi
+
+. misc/shell-functions
+
+ROOT=`pwd`
+
+for i in `find . -name "*${PATTERN}*spec"`; do
+	BASE=`basename $i`
+	DIR=`dirname $i`
+	echo "Building SRPM for ${i}"
+
+	prepare_git_tree ${DIR}
+
+	# Try to build the SRPM
+	SRPM=`build_srpm ${i}`
+	RESULT=$?
+	if [ "$RESULT" == "1" ]; then
+		echo "Building the SRPM for ${BASE} failed."
+		echo "Trying to fetch Source0"
+		${ROOT}/misc/get_source.sh ${BASE}
+	fi
+
+	# Let's hope fetching the sources worked and retry building the SRPM
+	SRPM=`build_srpm ${i}`
+	RESULT=$?
+
+	if [ "$RESULT" == "1" ]; then
+		echo "Still got an error building SRPM for ${BASE}"
+		echo "Giving up, this needs to be fixed manually"
+		continue
+	fi
+
+	echo ${SRPM}
+done

--- a/misc/get_source.sh
+++ b/misc/get_source.sh
@@ -30,7 +30,7 @@ for i in `find . -name "${PATTERN}"`; do
 		u=`awk '{ print $2 }' <<< ${u}`
 		echo "Trying to get ${u}"
 		# Try to download only if newer
-		WGET=`wget -N -nv -P ../SOURCES ${u}x 2>&1`
+		WGET=`wget -N -nv -P ../SOURCES ${u} 2>&1`
 		# Handling for github URLs with #/ or #$/
 		if grep -E "#[$]?/" <<< ${u}; then
 			URL=`echo ${u} | cut -d# -f1`

--- a/misc/shell-functions
+++ b/misc/shell-functions
@@ -1,0 +1,21 @@
+
+prepare_git_tree() {
+
+	local DIR=${1}
+
+        if [ ! -e ${DIR}/../SOURCES ]; then
+                # empty SOURCES directory are not created by git
+                mkdir ${DIR}/../SOURCES
+        fi
+
+        # for builds outside of OBS OHPC_macros needs to exist
+        if [ ! -e ${DIR}/../SOURCES/OHPC_macros ]; then
+                pushd ${DIR}/../SOURCES > /dev/null
+                if [ -e ../../../OHPC_macros ]; then
+                        ln -s ../../../OHPC_macros
+                elif [ -e ../../../../OHPC_macros ]; then
+                        ln -s ../../../../OHPC_macros
+                fi
+                popd > /dev/null
+        fi
+}

--- a/misc/shell-functions
+++ b/misc/shell-functions
@@ -19,3 +19,15 @@ prepare_git_tree() {
                 popd > /dev/null
         fi
 }
+
+build_srpm() {
+	local SPEC=${1}
+	local DIR=`dirname ${1}`
+
+	SRPM=`rpmbuild -bs --nodeps --define "_sourcedir ${DIR}/../SOURCES" --define 'rhel 7' --undefine 'fedora' ${SPEC}`
+	RESULT=$?
+
+	echo ${SRPM} | tail -1 | awk -F\  '{ print $2 }'
+
+	return ${RESULT}
+}


### PR DESCRIPTION
The script build_srpm.sh builds a SRPM for specified packages. It
creates the necessary files in the SOURCES directory by either
downloading those files or creating symbolic links.

```
 $ misc/build_srpm.sh lua
 Building SRPM for ./components/distro-packages/lua-filesystem/SPECS/lua-filesystem.spec
 /home/adrian/rpmbuild/SRPMS/lua-filesystem-ohpc-1.6.3-0.src.rpm
 Building SRPM for ./components/distro-packages/lua-posix/SPECS/luaposix.spec
 /home/adrian/rpmbuild/SRPMS/lua-posix-ohpc-33.2.1-1.ohpc.src.rpm
 Building SRPM for ./components/distro-packages/lua-bit/SPECS/lua-bitop.spec
 /home/adrian/rpmbuild/SRPMS/lua-bit-ohpc-1.0.2-1.ohpc.src.rpm
```

In combination with the build_order.sh script this can be used to create the OpenHPC SRPMs and rebuild them locally in the correct order.