### PR TITLE
environment modules based dependencies

### DIFF
--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -34,6 +34,8 @@
 
 DocDir:    %{OHPC_PUB}/doc/contrib
 
+%global lmod_version 7.6.1
+
 %if 0%{?rhel} == 7
 	# OBS define's rhel_version to 700 for RHEL, in case we are
 	# not running in OBS
@@ -44,6 +46,15 @@ DocDir:    %{OHPC_PUB}/doc/contrib
 # installation path layout
 %if 0%{?ohpc_bootstrap} == 0
 Requires: ohpc-filesystem
+%{!?ohpc_dependencies: %global ohpc_dependencies 1}
+%endif
+
+# Setting 'ohpc_dependencies' to '0' disable the special ohpc
+# dependency generator and uses the one from RPM
+%if 0%{?ohpc_dependencies} != 0
+%global _use_internal_dependency_generator 0
+%global __find_provides %{OHPC_ADMIN}/ohpc/find-provides.ohpc %{PROJ_NAME} %{lmod_version}
+%global __find_requires %{OHPC_ADMIN}/ohpc/find-requires.ohpc %{PROJ_NAME} %{lmod_version}
 %endif
 
 # OpenHPC packages also require ohpc-buildroot to access macros used to define
@@ -64,8 +75,7 @@ BuildRequires: ohpc-buildroot
 %if 0%{?ohpc_compiler_dependent} == 1
 
 %if "%{compiler_family}" == "gnu7"
-BuildRequires: gnu7-compilers%{PROJ_DELIM} >= 7.2.0
-Requires:      gnu7-compilers%{PROJ_DELIM} >= 7.2.0
+%global ohpc_compiler_module gnu7/7.2.0
 %endif
 %if "%{compiler_family}" == "intel"
 BuildRequires: gcc-c++ intel-compilers-devel%{PROJ_DELIM}
@@ -97,24 +107,32 @@ Requires:      llvm-compilers%{PROJ_DELIM}
 BuildRequires: intel-mpi-devel%{PROJ_DELIM}
 Requires:      intel-mpi-devel%{PROJ_DELIM}
 %global __requires_exclude ^libmpi\\.so.*$|^libmpifort\\.so.*$|^libmpicxx\\.so.*$
-%endif
-%if "%{mpi_family}" == "mpich"
-BuildRequires: mpich-%{compiler_family}%{PROJ_DELIM}
-Requires:      mpich-%{compiler_family}%{PROJ_DELIM}
-%endif
-%if "%{mpi_family}" == "mvapich2"
-BuildRequires: mvapich2-%{compiler_family}%{PROJ_DELIM}
-Requires:      mvapich2-%{compiler_family}%{PROJ_DELIM}
-%endif
-%if "%{mpi_family}" == "openmpi3"
-BuildRequires: openmpi3-%{compiler_family}%{PROJ_DELIM}
-Requires:      openmpi3-%{compiler_family}%{PROJ_DELIM}
+%else
+# First the compiler, then the MPI
+%global ohpc_internal_modules %{expand:%%{?ohpc_compiler_module:%%{ohpc_compiler_module}}} %{mpi_family}
+BuildRequires: %{mpi_family}-%{compiler_family}%{PROJ_DELIM}
 %endif
 %endif
 
-%global ohpc_setup_compiler %{expand:\
-	. %{OHPC_ADMIN}/ohpc/OHPC_setup_compiler %{compiler_family} \
-	%if 0%{?ohpc_mpi_dependent} == 1 \
-		. %{OHPC_ADMIN}/ohpc/OHPC_setup_mpi %{mpi_family} \
-	%endif \
-}
+# The following lines make sure that it works if only one
+# of those variables is defined
+
+%{!?ohpc_compiler_module: %global ohpc_compiler_module %{nil}}
+
+%{!?ohpc_internal_modules: %global ohpc_internal_modules %{expand:%%{?ohpc_compiler_module:%%{ohpc_compiler_module}}}}
+
+%{?ohpc_required_modules: %global ohpc_internal_modules %{expand:%%{?ohpc_internal_modules:%%{ohpc_internal_modules}}} %{expand:%%{?ohpc_required_modules:%%{ohpc_required_modules}}}}
+
+# This creates the necessary BuildRequires:
+
+%{?ohpc_internal_modules:%{lua:
+	mods = rpm.expand("%{ohpc_internal_modules}")
+	delim = rpm.expand("%{PROJ_NAME}")
+	for i in mods:gmatch("%S+") do
+		print('BuildRequires: ')
+		print(delim)
+		print('-module(')
+		print(i)
+		print(')\n')
+	end
+}}

--- a/components/admin/ohpc-filesystem/SOURCES/find-provides.ohpc
+++ b/components/admin/ohpc-filesystem/SOURCES/find-provides.ohpc
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# parameter 1: project name like ohpc
+# parameter 2: minimum lmod version
+
+PROJECT=$1
+LMOD_VERSION=$2
+
+# This script tries to detect installed modules and creates the
+# corresponding provides
+# ${PROJECT}-module(name)
+# ${PROJECT}-module(name/version)
+# ${PROJECT}-module(dependency/name/version)
+
+# rpmbuild gives us a list of all installed files through a pipe
+
+filelist=`sed "s/[]['\"*?{}]/\\\\\&/g"`
+
+for file in ${filelist}; do
+	# Search for modules under modulefiles and moduledeps
+	# But ignore .version files
+	if [[ "${file}" == *"modulefiles"*".version"* ]]; then
+		continue
+	fi
+	if [[ "${file}" == *"moduledeps"*".version"* ]]; then
+		continue
+	fi
+	if [[ "${file}" == *"modulefiles"* ]]; then
+		# ignore directories
+		if [[ -d ${file} ]]; then
+			continue
+		fi
+		# modules defined in modulefiles are usually
+		# name/version
+		# let's create two provides
+		# a generic 'name' and a 'name/version'
+		dep=`awk -Fmodulefiles/ '{ print $2 }' <<<  ${file}`
+		# the result of this should be at least 3 characters long
+		deplen=${#dep}
+		if [[ ${deplen} -lt 3 ]]; then
+			continue
+		fi
+		echo "${PROJECT}-module(${dep})"
+		echo "${PROJECT}-module(`dirname ${dep}`)"
+		# Check if this module extends the MODULEPATH, which means
+		# that it provides its service under an additional name.
+		dep=`grep -E "prepend-path(\s)*MODULEPATH(.)*moduledeps" ${file}`
+		if [[ $? -ne 0 ]]; then
+			continue
+		fi
+		dep=`awk -Fmoduledeps/ '{ print $2 }' <<< ${dep}`
+		echo "${PROJECT}-module(${dep})"
+	fi
+	if [[ "${file}" == *"moduledeps"* ]]; then
+		# ignore directories
+		if [[ -d ${file} ]]; then
+			continue
+		fi
+		dep=`awk -Fmoduledeps/ '{ print $2 }' <<< ${file}`
+		# First the full 'requires' with compiler-mpi
+		echo "${PROJECT}-module(${dep})"
+		echo "${PROJECT}-module(`dirname ${dep}`)"
+		# Remove the first directory level to also provide
+		# not just gnu/plasma but also plasma
+		dep=${dep#*/}
+		echo "${PROJECT}-module(${dep})"
+		echo "${PROJECT}-module(`dirname ${dep}`)"
+		# Check if this module extends the MODULEPATH, which means
+		# that it provides its service under an additional name.
+		dep=`grep -E "prepend-path(\s)*MODULEPATH(.)*moduledeps" ${file}`
+		if [[ $? -ne 0 ]]; then
+			continue
+		fi
+		dep=`awk -Fmoduledeps/ '{ print $2 }' <<< ${dep}`
+		echo "${PROJECT}-module(${dep})"
+	fi
+done

--- a/components/admin/ohpc-filesystem/SOURCES/find-requires.ohpc
+++ b/components/admin/ohpc-filesystem/SOURCES/find-requires.ohpc
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# parameter 1: project name like ohpc
+# parameter 2: minimum lmod version
+
+PROJECT=$1
+LMOD_VERSION=$2
+
+# This script tries to detect required modules and creates the
+# corresponding requires
+# ${PROJECT}-module(name) # in most cases compiler or compiler-mpi
+
+# rpmbuild gives us a list of all installed files through a pipe
+
+filelist=`sed "s/[]['\"*?{}]/\\\\\&/g"`
+
+for file in ${filelist}; do
+	# Detect required modules by looking at the directory
+	# name after 'moduledeps'
+	if [[ "${file}" == *"moduledeps"* ]]; then
+		ADD_LMOD_DEPENDENCY=1
+		# only look at directories
+		if [[ ! -d ${file} ]]; then
+			continue
+		fi
+		dep=`awk -Fmoduledeps/ '{ print $2 }' <<< ${file}`
+		# the result of this should be at least 2 characters long
+		deplen=${#dep}
+		if [[ ${deplen} -lt 2 ]]; then
+			continue
+		fi
+		# Get the first field
+		dep=`cut -d/ -f1 <<< ${dep}`
+		echo "${PROJECT}-module(${dep})"
+	fi
+done
+
+# If any module file is found in modulefiles or moduledeps
+# lmod should probably be installed
+ADD_LMOD_DEPENDENCY=0
+
+# If a 'depends-on' is found we need to add a mimimum lmod version
+ADD_LMOD_VERSION_DEPENDENCY=0
+
+# Change IFS for looping over depends-on lines
+IFS=$'\n'
+
+# Try to find depends-on statements
+for file in ${filelist}; do
+	# skip directories
+	if [[ -d ${file} ]]; then
+		continue
+	fi
+	if [[ "${file}" == *"modulefiles"* || "${file}" == *"moduledeps"* ]]; then
+		ADD_LMOD_DEPENDENCY=1
+		deps=`grep depends-on ${file} 2>&1`
+		if [[ $? -ne 0 ]]; then
+			continue
+		fi
+		for dep in ${deps}; do
+			# trim leading whitespace
+			dep=`sed -e 's/^[[:space:]]*//' <<< ${dep}`
+			dep=`cut -d\  -f2 <<< ${dep}`
+			deplen=${#dep}
+			if [[ ${deplen} -lt 2 ]]; then
+				continue
+			fi
+			echo "${PROJECT}-module(${dep})"
+		done
+		ADD_LMOD_VERSION_DEPENDENCY=1
+	fi
+done
+
+if [[ ${ADD_LMOD_VERSION_DEPENDENCY} -eq 1 ]]; then
+	echo "lmod-${PROJECT} >= ${LMOD_VERSION}"
+elif [[ ${ADD_LMOD_DEPENDENCY} -eq 1 ]]; then
+	echo "lmod-${PROJECT}"
+fi
+
+exit 0

--- a/components/admin/ohpc-filesystem/SOURCES/macros.ohpc
+++ b/components/admin/ohpc-filesystem/SOURCES/macros.ohpc
@@ -1,0 +1,41 @@
+#  Copyright 2017 Adrian Reber
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# This file depends on definitions in OHPC_macros
+
+%ohpc_setup_compiler() \
+	%if 0%{?ohpc_compiler_dependent} == 1 \
+		. %{OHPC_ADMIN}/ohpc/OHPC_setup_compiler %{compiler_family} \
+	%endif \
+	%{nil}
+
+
+# This macro loads the necessary modules. Modules need to be defined in
+# %%ohpc_required_modules
+%ohpc_load_modules() \
+	%ohpc_setup_compiler \
+        for i in %{?ohpc_internal_modules:%ohpc_internal_modules} \\\
+		%{?ohpc_required_modules:%ohpc_required_modules}; do \
+		if [[ x"${i}" == x"%{compiler_family}"* ]]; then \
+			# If the module name starts with the compiler_family \
+			# remove the first part. \
+			if [[ x"${i}" != x"%{ohpc_compiler_module}" ]]; then \
+				# But only if it is not the actual compiler \
+				# module we want to load. \
+				i=${i#*/} \
+			fi \
+		fi \
+		module load ${i}; \
+        done \
+	%{nil}

--- a/components/admin/ohpc-filesystem/SPECS/ohpc-filesystem.spec
+++ b/components/admin/ohpc-filesystem/SPECS/ohpc-filesystem.spec
@@ -1,5 +1,5 @@
 Name: ohpc-filesystem
-Version: 1.3
+Version: 1.4
 Release: 1.ohpc
 Summary: Common top-level OpenHPC directories
 
@@ -7,6 +7,9 @@ Group: ohpc/admin
 License: ASL 2.0
 Source0: OHPC_setup_compiler
 Source1: OHPC_setup_mpi
+Source2: macros.ohpc
+Source3: find-provides.ohpc
+Source4: find-requires.ohpc
 
 BuildArch: noarch
 
@@ -30,6 +33,10 @@ mkdir -p $RPM_BUILD_ROOT/opt/ohpc/pub/{apps,doc,compiler,libs,moduledeps,modulef
 mkdir -p $RPM_BUILD_ROOT/opt/ohpc/admin/ohpc
 install -p -m 644 %{SOURCE0} $RPM_BUILD_ROOT/opt/ohpc/admin/ohpc
 install -p -m 644 %{SOURCE1} $RPM_BUILD_ROOT/opt/ohpc/admin/ohpc
+install -p -m 755 %{SOURCE3} $RPM_BUILD_ROOT/opt/ohpc/admin/ohpc
+install -p -m 755 %{SOURCE4} $RPM_BUILD_ROOT/opt/ohpc/admin/ohpc
+mkdir -p $RPM_BUILD_ROOT/usr/lib/rpm/macros.d
+install -p -m 644 %{SOURCE2} $RPM_BUILD_ROOT/usr/lib/rpm/macros.d
 
 %files
 %dir /opt/ohpc/
@@ -47,8 +54,14 @@ install -p -m 644 %{SOURCE1} $RPM_BUILD_ROOT/opt/ohpc/admin/ohpc
 %dir /opt/ohpc/admin/ohpc/
 /opt/ohpc/admin/ohpc/OHPC_setup_compiler
 /opt/ohpc/admin/ohpc/OHPC_setup_mpi
+/opt/ohpc/admin/ohpc/find-provides.ohpc
+/opt/ohpc/admin/ohpc/find-requires.ohpc
+/usr/lib/rpm/macros.d/macros.ohpc
 
 %changelog
+* Wed Nov 08 2017 Adrian Reber <areber@redhat.com> - 1.4
+- added scripts to find provides/requires based on modules
+
 * Mon May  8 2017 Karl W Schulz <karl.w.schulz@intel.com> - 1.3
 - minor description updates
 

--- a/components/compiler-families/llvm-compilers/SPECS/llvm-compilers.spec
+++ b/components/compiler-families/llvm-compilers/SPECS/llvm-compilers.spec
@@ -8,7 +8,9 @@
 #
 #----------------------------------------------------------------------------eh-
 
-%define compiler_family gnu7
+%global compiler_family gnu7
+%global ohpc_compiler_dependent 1
+%global ohpc_required_modules cmake
 %include %{_sourcedir}/OHPC_macros
 
 # Remember to drop this gnu-compilers dependency in the future,
@@ -38,8 +40,6 @@ Source6:   http://releases.llvm.org/%{version}/libunwind-%{version}.src.tar.xz
 Source7:   http://releases.llvm.org/%{version}/lld-%{version}.src.tar.xz
 Source8:   http://releases.llvm.org/%{version}/openmp-%{version}.src.tar.xz
 Source9:   OHPC_macros
-BuildRequires: gnu7-compilers%{PROJ_DELIM}
-BuildRequires: cmake%{PROJ_DELIM}
 BuildRequires: make
 BuildRequires: perl
 BuildRequires: python
@@ -48,7 +48,6 @@ BuildRequires: binutils-devel
 BuildRequires: libstdc++-devel
 Requires:      binutils
 Requires:      gcc-c++
-Requires:      gnu7-compilers%{PROJ_DELIM}
 %if 0%{?rhel_version} || 0%{?centos_version} || 0%{?rhel}
 BuildRequires: perl-Data-Dumper
 %endif
@@ -102,8 +101,7 @@ ln -s flang-%{flang_sha} flang
 %{__sed} -i -e 's/-Werror/-Wall/g' flang/CMakeLists.txt
 
 %install
-%ohpc_setup_compiler
-module load cmake
+%ohpc_load_modules
 
 mkdir build-clang
 cd build-clang

--- a/components/dev-tools/autoconf/SPECS/autoconf.spec
+++ b/components/dev-tools/autoconf/SPECS/autoconf.spec
@@ -24,7 +24,7 @@ Source0:   https://ftp.gnu.org/gnu/autoconf/autoconf-%{version}.tar.gz
 Source1:   OHPC_macros
 BuildRoot: %{_tmppath}/%{pname}-%{version}-%{release}-root
 
-Requires: m4
+Requires: m4 perl(Data::Dumper)
 
 %if 0%{?rhel_version} || 0%{?centos_version} || 0%{?rhel}
 BuildRequires: m4

--- a/components/dev-tools/cmake/SPECS/cmake.spec
+++ b/components/dev-tools/cmake/SPECS/cmake.spec
@@ -35,7 +35,13 @@ BuildRequires:  pkgconfig
 %if 0%{!?sles_version} && 0%{!?suse_version}
 BuildRequires:  bzip2-devel
 BuildRequires:  expat-devel
+Requires:       expat
+Requires:       bzip2
 %endif
+Requires:       libarchive
+Requires:       libcurl
+Requires:       ncurses-libs
+Requires:       zlib
 
 %define install_path %{OHPC_UTILS}/%{pname}/%version
 

--- a/components/dev-tools/easybuild/SPECS/easybuild.spec
+++ b/components/dev-tools/easybuild/SPECS/easybuild.spec
@@ -32,27 +32,18 @@ Source3:   https://pypi.io/packages/source/v/vsc-base/vsc-base-%{vsc_base_ver}.t
 Source4:   https://pypi.io/packages/source/v/vsc-install/vsc-install-%{vsc_install_ver}.tar.gz
 Source5:   bootstrap_eb.py
 Source6:   OHPC_macros
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildRequires: python
 BuildRequires: python-setuptools
 Requires: python-setuptools
 Requires: python
 #!BuildIgnore: post-build-checks
 
-# Lmod dependency (note that lmod is pre-populated in the OpenHPC OBS build
-# environment; if building outside, lmod remains a formal build dependency).
-%if !0%{?OHPC_BUILD}
-BuildRequires: lmod%{PROJ_DELIM}
-%endif
-
-%define debug_package %{nil}
-
 # Default library install path
 %define install_path %{OHPC_LIBS}/%{pname}/%version
 
 %description
-EasyBuild is a software build and installation framework that allows 
-you to manage (scientific) software on High Performance Computing (HPC) 
+EasyBuild is a software build and installation framework that allows
+you to manage (scientific) software on High Performance Computing (HPC)
 systems in an efficient way.
 
 %prep

--- a/components/dev-tools/libtool/SPECS/libtool.spec
+++ b/components/dev-tools/libtool/SPECS/libtool.spec
@@ -25,7 +25,6 @@ Source1:   OHPC_macros
 BuildRoot: %{_tmppath}/%{pname}-%{version}-%{release}-root
 
 #!BuildIgnore: post-build-checks rpmlint-Factory
-%global __provides_exclude ^libltdl\\.so.*$
 
 %define debug_package %{nil}
 %define install_path %{OHPC_UTILS}/autotools

--- a/components/dev-tools/mpi4py/SPECS/python-mpi4py.spec
+++ b/components/dev-tools/mpi4py/SPECS/python-mpi4py.spec
@@ -33,8 +33,6 @@ Source0:        https://bitbucket.org/mpi4py/mpi4py/downloads/%{pname}-%{version
 Source1:        OHPC_macros
 BuildRequires:  python-devel
 BuildRequires:  python-setuptools
-#BuildRequires:  python-Cython
-Requires:       lmod%{PROJ_DELIM} >= 7.6.1
 Requires:       python
 
 # Default library install path
@@ -52,15 +50,12 @@ exposes an API which grounds on the standard MPI-2 C++ bindings.
 find . -type f -name "*.py" -exec sed -i "s|#!/usr/bin/env python||" {} \;
 
 %build
-
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 python setup.py build
 
 %install
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 python setup.py install --prefix=%{install_path} --root=%{buildroot}
 

--- a/components/dev-tools/numpy/SPECS/python-numpy.spec
+++ b/components/dev-tools/numpy/SPECS/python-numpy.spec
@@ -33,7 +33,6 @@ Source1:        OHPC_macros
 Patch1:         numpy-buildfix.patch
 Patch2:         numpy-intelccomp.patch
 Patch3:         numpy-intelfcomp.patch
-Requires:       lmod%{PROJ_DELIM} >= 7.6.1
 BuildRequires:  python-devel python-setuptools
 Requires:       python
 Provides:       numpy = %{version}
@@ -129,10 +128,9 @@ module-whatis "URL %{url}"
 
 set     version             %{version}
 
-# Require openblas for gnu compiler families
-if { ![is-loaded intel] } {
+%if "%{compiler_family}" != "intel"
     depends-on openblas
-}
+%endif
 
 prepend-path    PATH                %{install_path}/bin
 prepend-path    PYTHONPATH          %{install_path}/lib64/python2.7/site-packages

--- a/components/dev-tools/scipy/SPECS/python-scipy.spec
+++ b/components/dev-tools/scipy/SPECS/python-scipy.spec
@@ -26,8 +26,9 @@
 #
 
 # scipy build that is dependent on compiler toolchain
-%define ohpc_compiler_dependent 1
-%define ohpc_mpi_dependent 1
+%global ohpc_compiler_dependent 1
+%global ohpc_mpi_dependent 1
+%global ohpc_required_modules %{compiler_family}/numpy %{compiler_family}-%{mpi_family}/fftw
 %include %{_sourcedir}/OHPC_macros
 
 %global gnu_family gnu7
@@ -53,14 +54,10 @@ Source1:        OHPC_macros
 %if 0%{?sles_version} || 0%{?suse_version}
 BuildRequires:  fdupes
 %endif
-BuildRequires:  fftw-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 BuildRequires:  python-devel
 BuildRequires:  python-setuptools
 BuildRequires:  python-Cython%{PROJ_DELIM}
-BuildRequires:  python-numpy-%{compiler_family}%{PROJ_DELIM}
 BuildRequires:  swig
-Requires:       lmod%{PROJ_DELIM} >= 7.6.1
-Requires:       python-numpy-%{compiler_family}%{PROJ_DELIM}
 
 # Default library install path
 %define install_path %{OHPC_LIBS}/%{compiler_family}/%{mpi_family}/%{pname}/%version
@@ -83,15 +80,12 @@ leading scientists and engineers.
 find . -type f -name "*.py" -exec sed -i "s|#!/usr/bin/env python||" {} \;
 
 %build
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 %if "%{compiler_family}" != "intel"
 module load openblas
-module load fftw
 %endif
 
-module load numpy
 
 %if %{compiler_family} == intel
 cat > site.cfg << EOF
@@ -119,14 +113,12 @@ python setup.py config_fc --fcompiler=gnu95 --noarch build
 %endif
 
 %install
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 %if "%{compiler_family}" == "%{gnu_family}"
 module load openblas
 %endif
 
-module load numpy
 python setup.py install --prefix=%{install_path} --root=%{buildroot}
 find %{buildroot}%{install_path}/lib64/python2.7/site-packages/scipy -type d -name tests | xargs rm -rf # Don't ship tests
 # Don't ship weave examples, they're marked as documentation:

--- a/components/io-libs/adios/SPECS/adios.spec
+++ b/components/io-libs/adios/SPECS/adios.spec
@@ -9,8 +9,9 @@
 #----------------------------------------------------------------------------eh-
 
 # Build that is dependent on compiler/mpi toolchains
-%define ohpc_compiler_dependent 1
-%define ohpc_mpi_dependent 1
+%global ohpc_compiler_dependent 1
+%global ohpc_mpi_dependent 1
+%global ohpc_required_modules autotools %{compiler_family}-%{mpi_family}/phdf5 %{compiler_family}-%{mpi_family}/netcdf %{compiler_family}/numpy
 %include %{_sourcedir}/OHPC_macros
 
 %{!?with_lustre: %global with_lustre 0}
@@ -31,18 +32,11 @@ Source1: OHPC_macros
 AutoReq: no
 
 BuildRequires: zlib-devel glib2-devel
-Requires:      zlib
+Requires:      zlib glib2
 
 # libm.a from CMakeLists
 BuildRequires: glibc-static
 
-BuildRequires: libtool%{PROJ_DELIM}
-Requires:      lmod%{PROJ_DELIM} >= 7.6.1
-BuildRequires: phdf5-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-Requires:      phdf5-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-
-BuildRequires: netcdf-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-Requires:      netcdf-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 BuildRequires: python-devel
 
 %if 0%{with_lustre}
@@ -51,7 +45,6 @@ BuildRequires: python-devel
 BuildRequires: lustre-lite
 Requires: lustre-client%{PROJ_DELIM}
 %endif
-BuildRequires: python-numpy-%{compiler_family}%{PROJ_DELIM}
 
 
 %if 0%{?sles_version} || 0%{?suse_version}
@@ -82,12 +75,7 @@ LIBSUFF=64
 sed -i "s|@64@|$LIBSUFF|" wrappers/numpy/setup*
 
 # OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
-
-module load autotools
-module load phdf5
-module load netcdf
-module load numpy
+%ohpc_load_modules
 
 TOPDIR=$PWD
 
@@ -149,7 +137,7 @@ chmod +x adios_config
 
 %install
 # OpenHPC compiler designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 export NO_BRP_CHECK_RPATH=true
 
 make DESTDIR=$RPM_BUILD_ROOT install
@@ -158,10 +146,6 @@ make DESTDIR=$RPM_BUILD_ROOT install
 export PPATH="/lib64/python2.7/site-packages"
 export PATH=$(pwd):$PATH
 
-%if "%{compiler_family}" != "intel"
-module load openblas
-%endif
-module load numpy
 export CFLAGS="-I$NUMPY_DIR$PPATH/numpy/core/include -I$(pwd)/src/public -L$(pwd)/src"
 pushd wrappers/numpy
 make MPI=y python

--- a/components/io-libs/hdf5/SPECS/hdf5.spec
+++ b/components/io-libs/hdf5/SPECS/hdf5.spec
@@ -72,8 +72,7 @@ grids. You can also mix and match them in HDF5 files according to your needs.
 cp /usr/lib/rpm/config.guess bin
 %endif
 
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 ./configure --prefix=%{install_path} \
 	    --enable-fortran         \
@@ -85,9 +84,7 @@ cp /usr/lib/rpm/config.guess bin
 make %{?_smp_mflags}
 
 %install
-
-# OpenHPC compiler designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 export NO_BRP_CHECK_RPATH=true
 

--- a/components/io-libs/netcdf-CXX/SPECS/netcdf-cxx4.spec
+++ b/components/io-libs/netcdf-CXX/SPECS/netcdf-cxx4.spec
@@ -25,8 +25,9 @@
 #-------------------------------------------------------------------------------
 
 # Build that is dependent on compiler/mpi toolchains
-%define ohpc_compiler_dependent 1
-%define ohpc_mpi_dependent 1
+%global ohpc_compiler_dependent 1
+%global ohpc_mpi_dependent 1
+%global ohpc_required_modules %{compiler_family}-%{mpi_family}/phdf5 %{compiler_family}-%{mpi_family}/netcdf
 %include %{_sourcedir}/OHPC_macros
 
 # Base package name
@@ -45,11 +46,6 @@ Source0:	https://github.com/Unidata/netcdf-cxx4/archive/v%{version}.tar.gz
 Source101:	OHPC_macros
 
 BuildRequires:  zlib-devel >= 1.2.5
-Requires:       lmod%{PROJ_DELIM} >= 7.6.1
-BuildRequires:  phdf5-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-BuildRequires:  netcdf-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-Requires:       netcdf-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-
 
 #!BuildIgnore: post-build-checks rpmlint-Factory
 
@@ -92,11 +88,7 @@ NetCDF data is:
 %setup -q -n %{pname}4-%{version}
 
 %build
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
-
-module load phdf5
-module load netcdf
+%ohpc_load_modules
 
 export CPPFLAGS="-I$HDF5_INC -I$NETCDF_INC"
 export LDFLAGS="-L$HDF5_LIB -L$NETCDF_LIB"
@@ -113,11 +105,7 @@ export LDFLAGS="-L$HDF5_LIB -L$NETCDF_LIB"
 make %{?_smp_mflags}
 
 %install
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
-
-module load phdf5
-module load netcdf
+%ohpc_load_modules
 
 make %{?_smp_mflags} DESTDIR=$RPM_BUILD_ROOT install
 

--- a/components/io-libs/netcdf-Fortran/SPECS/netcdf-fortran.spec
+++ b/components/io-libs/netcdf-Fortran/SPECS/netcdf-fortran.spec
@@ -25,8 +25,9 @@
 #-------------------------------------------------------------------------------
 
 # Build that is dependent on compiler/mpi toolchains
-%define ohpc_compiler_dependent 1
-%define ohpc_mpi_dependent 1
+%global ohpc_compiler_dependent 1
+%global ohpc_mpi_dependent 1
+%global ohpc_required_modules %{compiler_family}-%{mpi_family}/phdf5 %{compiler_family}-%{mpi_family}/netcdf
 %include %{_sourcedir}/OHPC_macros
 
 # Base package name
@@ -45,10 +46,6 @@ Source0:	https://github.com/Unidata/netcdf-fortran/archive/v%{version}.tar.gz
 Source101:	OHPC_macros
 
 BuildRequires:  zlib-devel >= 1.2.5
-BuildRequires:  phdf5-%{compiler_family}-%{mpi_family}%{PROJ_DELIM} >= 1.8.8
-BuildRequires:  netcdf-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-Requires:       netcdf-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-Requires:       lmod%{PROJ_DELIM} >= 7.6.1
 
 #!BuildIgnore: post-build-checks rpmlint-Factory
 
@@ -91,11 +88,7 @@ NetCDF data is:
 %setup -q -n %{pname}-%{version}
 
 %build
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
-
-module load phdf5
-module load netcdf
+%ohpc_load_modules
 
 
 export CFLAGS="-L$HDF5_LIB -I$HDF5_INC -L$NETCDF_LIB -I$NETCDF_INC"
@@ -116,11 +109,8 @@ export LDFLAGS="-L$HDF5_LIB -L$NETCDF_LIB"
 make %{?_smp_mflags}
 
 %install
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
-module load phdf5
-module load netcdf
 
 make %{?_smp_mflags} DESTDIR=$RPM_BUILD_ROOT install
 

--- a/components/io-libs/netcdf/SPECS/netcdf.spec
+++ b/components/io-libs/netcdf/SPECS/netcdf.spec
@@ -26,8 +26,9 @@
 #
 
 # Build that is dependent on compiler/mpi toolchains
-%define ohpc_compiler_dependent 1
-%define ohpc_mpi_dependent 1
+%global ohpc_compiler_dependent 1
+%global ohpc_mpi_dependent 1
+%global ohpc_required_modules %{compiler_family}-%{mpi_family}/phdf5
 %include %{_sourcedir}/OHPC_macros
 
 # Base package name
@@ -49,9 +50,6 @@ Source101:	OHPC_macros
 
 BuildRequires:  zlib-devel >= 1.2.5
 BuildRequires:  m4
-Requires:       lmod%{PROJ_DELIM} >= 7.6.1
-BuildRequires:  phdf5-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-Requires:       phdf5-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 
 #!BuildIgnore: post-build-checks rpmlint-Factory
 
@@ -94,10 +92,8 @@ NetCDF data is:
 %setup -q -n %{pname}-c-%{version}
 
 %build
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
-module load phdf5
 export CPPFLAGS="-I$HDF5_INC"
 export LDFLAGS="-L$HDF5_LIB"
 export CFLAGS="-L$HDF5_LIB -I$HDF5_INC"
@@ -115,8 +111,7 @@ export CC=mpicc
 make %{?_smp_mflags}
 
 %install
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 module load phdf5
 export CFLAGS="-L$HDF5_LIB -I$HDF5_INC"

--- a/components/io-libs/phdf5/SPECS/hdf5.spec
+++ b/components/io-libs/phdf5/SPECS/hdf5.spec
@@ -73,7 +73,7 @@ cp /usr/lib/rpm/config.guess bin
 %endif
 
 # OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 export CC=mpicc
 export CXX=mpicxx
@@ -93,7 +93,7 @@ export MPICXX=mpicxx
 %install
 
 # OpenHPC compiler designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 export NO_BRP_CHECK_RPATH=true
 

--- a/components/io-libs/pnetcdf/SPECS/pnetcdf.spec
+++ b/components/io-libs/pnetcdf/SPECS/pnetcdf.spec
@@ -54,7 +54,7 @@ cp /usr/lib/rpm/config.guess scripts
 %endif
 
 # OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 CC=mpicc \
 CXX=mpicxx \
@@ -70,8 +70,7 @@ CFLAGS="-fPIC -DPIC" CXXFLAGS="-fPIC -DPIC" FCFLAGS="-fPIC" FFLAGS="-fPIC" \
 %{__make}
 
 %install
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 %{__make} DESTDIR=$RPM_BUILD_ROOT install
 

--- a/components/io-libs/sionlib/SPECS/sionlib.spec
+++ b/components/io-libs/sionlib/SPECS/sionlib.spec
@@ -44,9 +44,7 @@ This is the %{compiler_family}-%{mpi_family} version.
 %patch0 -p0
 
 %build
-
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 %if %{compiler_family} == intel
 CONFIGURE_OPTIONS="--compiler=intel --disable-parutils "
@@ -84,9 +82,7 @@ sed -i 's|-g|-g -fpic|g' build-*/Makefile.defs
 %endif
 
 %install
-
-# OpenHPC compiler designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 make DESTDIR=$RPM_BUILD_ROOT install
 

--- a/components/mpi-families/mpich/SPECS/mpich.spec
+++ b/components/mpi-families/mpich/SPECS/mpich.spec
@@ -10,20 +10,18 @@
 
 # MPICH MPI stack that is dependent on compiler toolchain
 %define ohpc_compiler_dependent 1
+
+%{!?with_pmix: %global with_pmix 0}
+%if 0%{with_pmix}
+%global ohpc_required_modules pmix
+%endif
+
 %include %{_sourcedir}/OHPC_macros
 %{!?RMS_DELIM: %global RMS_DELIM %{nil}}
 
-%define with_slurm 0
-%{!?with_slurm: %define with_slurm 0}
-%if 0%{with_slurm}
-BuildRequires: slurm-devel%{PROJ_DELIM} slurm%{PROJ_DELIM}
-%endif
+%global with_slurm 0
+%{!?with_slurm: %global with_slurm 0}
 
-%{!?with_pmix: %define with_pmix 0}
-%if 0%{with_pmix}
-BuildRequires:  pmix%{PROJ_DELIM}
-BuildRequires: libevent-devel
-%endif
 
 # Base package name
 %define pname mpich
@@ -41,6 +39,13 @@ Patch0:    config.pmix.patch
 
 Requires: prun%{PROJ_DELIM} >= 1.2
 Requires: perl
+
+%if 0%{with_pmix}
+BuildRequires: libevent-devel
+%endif
+%if 0%{with_slurm}
+BuildRequires: slurm-devel%{PROJ_DELIM} slurm%{PROJ_DELIM}
+%endif
 
 %if "%{RMS_DELIM}" != "%{nil}"
 Provides: %{pname}-%{compiler_family}%{PROJ_DELIM}

--- a/components/mpi-families/mvapich2/SPECS/mvapich2.spec
+++ b/components/mpi-families/mvapich2/SPECS/mvapich2.spec
@@ -87,7 +87,7 @@ across multiple networks.
 %patch1 -p0
 
 %build
-%ohpc_setup_compiler
+%ohpc_load_modules
 ./configure --prefix=%{install_path} \
 	    --enable-cxx \
 	    --enable-g=dbg \
@@ -103,7 +103,7 @@ across multiple networks.
 make %{?_smp_mflags}
 
 %install
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 make %{?_smp_mflags} DESTDIR=$RPM_BUILD_ROOT install
 

--- a/components/parallel-libs/boost/SPECS/boost.spec
+++ b/components/parallel-libs/boost/SPECS/boost.spec
@@ -99,8 +99,7 @@ see the boost-doc package.
 %setup -q -n %{pname}_%{version_exp}
 
 %build
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 %if %build_mpi
 export CC=mpicc
@@ -127,8 +126,7 @@ EOF
 
 
 %install
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 %if %build_mpi
 export CC=mpicc

--- a/components/parallel-libs/fftw/SPECS/fftw.spec
+++ b/components/parallel-libs/fftw/SPECS/fftw.spec
@@ -50,8 +50,7 @@ data, and of arbitrary input size.
 %setup -q -n %{pname}-%{version}-pl2
 
 %build
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 BASEFLAGS="--enable-shared --disable-dependency-tracking --enable-threads"
 %if %{openmp}
@@ -66,8 +65,7 @@ BASEFLAGS="$BASEFLAGS --enable-mpi"
 make
 
 %install
-# OpenHPC compiler designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 make DESTDIR=$RPM_BUILD_ROOT install
 

--- a/components/parallel-libs/hypre/SPECS/hypre.spec
+++ b/components/parallel-libs/hypre/SPECS/hypre.spec
@@ -26,8 +26,9 @@
 #
 
 # Build that is is dependent on compiler toolchain and MPI
-%define ohpc_compiler_dependent 1
-%define ohpc_mpi_dependent 1
+%global ohpc_compiler_dependent 1
+%global ohpc_mpi_dependent 1
+%global ohpc_required_modules %{compiler_family}/superlu %{compiler_family}/numpy
 %include %{_sourcedir}/OHPC_macros
 
 %if "%{compiler_family}" != "intel"
@@ -54,12 +55,7 @@ Source1:        OHPC_macros
 # TODO : add babel
 #BuildRequires:  babel-devel
 #BuildRequires:  libltdl-devel
-BuildRequires:  superlu-%{compiler_family}%{PROJ_DELIM}
-Requires:       superlu-%{compiler_family}%{PROJ_DELIM}
 BuildRequires:  libxml2-devel
-Requires:       lmod%{PROJ_DELIM} >= 7.6.1
-BuildRequires:  python-devel
-BuildRequires:  python-numpy-%{compiler_family}%{PROJ_DELIM}
 %if 0%{?suse_version}
 BuildRequires:  python-xml
 %else
@@ -88,9 +84,7 @@ phenomena in the defense, environmental, energy, and biological sciences.
 cp /usr/lib/rpm/config.guess src/config
 %endif
 
-%ohpc_setup_compiler
-
-module load superlu
+%ohpc_load_modules
 
 %if "%{compiler_family}" != "intel"
 module load openblas
@@ -134,9 +128,7 @@ make %{?_smp_mflags} all CC="mpicc $FLAGS" \
 cd ..
 
 %install
-%ohpc_setup_compiler
-
-module load superlu
+%ohpc_load_modules
 
 %if "%{compiler_family}" != "intel"
 module load openblas
@@ -205,11 +197,10 @@ module-whatis "%{url}"
 
 set     version                     %{version}
 
-# Require superlu (and openblas for gnu compiler families)
 depends-on superlu
-if { ![is-loaded intel] } {
+%if "%{compiler_family}" != "intel"
     depends-on openblas
-}
+%endif
 
 prepend-path    PATH                %{install_path}/bin
 prepend-path    INCLUDE             %{install_path}/include

--- a/components/parallel-libs/mumps/SPECS/mumps.spec
+++ b/components/parallel-libs/mumps/SPECS/mumps.spec
@@ -52,7 +52,6 @@ Source5:        OHPC_macros
 Patch0:         mumps-5.0.1-shared-mumps.patch
 Patch1:         mumps-5.0.0-shared-pord.patch
 Patch2:         mumps-5.0.2-psxe2017.patch
-Requires:       lmod%{PROJ_DELIM} >= 7.6.1
 
 %if 0%{?suse_version}
 BuildRequires: libgomp1
@@ -83,7 +82,7 @@ C interfaces, and can interface with ordering tools such as Scotch.
 %endif
 
 %build
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 # Enable scalapack linkage for blas/lapack with gnu builds
 %if "%{compiler_family}" != "intel"
@@ -187,9 +186,9 @@ module-whatis "%{url}"
 
 set     version                     %{version}
 
-if { ![is-loaded intel] } {
+%if "%{compiler_family}" != "intel"
     depends-on scalapack
-}
+%endif
 
 prepend-path    PATH                %{install_path}/bin
 prepend-path    INCLUDE             %{install_path}/include

--- a/components/parallel-libs/petsc/SPECS/petsc.spec
+++ b/components/parallel-libs/petsc/SPECS/petsc.spec
@@ -9,8 +9,9 @@
 #----------------------------------------------------------------------------eh-
 
 # PETSc library that is is dependent on compiler toolchain and MPI
-%define ohpc_compiler_dependent 1
-%define ohpc_mpi_dependent 1
+%global ohpc_compiler_dependent 1
+%global ohpc_mpi_dependent 1
+%global ohpc_required_modules %{compiler_family}-%{mpi_family}/phdf5
 %include %{_sourcedir}/OHPC_macros
 
 %if "%{compiler_family}" != "intel"
@@ -32,9 +33,6 @@ Source0:        http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-%{versi
 Source1:        OHPC_macros
 Patch1:         petsc.rpath.patch
 Url:            http://www.mcs.anl.gov/petsc/
-Requires:       lmod%{PROJ_DELIM} >= 7.6.1
-BuildRequires:  phdf5-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-Requires:       phdf5-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 BuildRequires:  python
 BuildRequires:  valgrind%{PROJ_DELIM}
 BuildRequires:  xz
@@ -56,10 +54,8 @@ differential equations.
 
 
 %build
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
-module load phdf5
 
 # Enable scalapack linkage for blas/lapack with gnu builds
 %if "%{compiler_family}" != "intel"
@@ -137,9 +133,9 @@ set     version                     %{version}
 
 # Require phdf5 (and scalapack for gnu compiler families)
 depends-on phdf5
-if { ![is-loaded intel] } {
+%if "%{compiler_family}" != "intel"
     depends-on scalapack
-}
+%endif
 
 prepend-path    PATH                %{install_path}/bin
 prepend-path    INCLUDE             %{install_path}/include

--- a/components/parallel-libs/scalapack/SPECS/scalapack.spec
+++ b/components/parallel-libs/scalapack/SPECS/scalapack.spec
@@ -32,7 +32,6 @@
 
 %if "%{compiler_family}" != "intel"
 BuildRequires: openblas-%{compiler_family}%{PROJ_DELIM}
-Requires:      openblas-%{compiler_family}%{PROJ_DELIM}
 %endif
 
 # Base package name
@@ -51,7 +50,6 @@ Source0:        http://www.netlib.org/scalapack/scalapack-%{version}.tgz
 Source1:        baselibs.conf
 Source2:        OHPC_macros
 Patch0:         scalapack-2.0.2-shared-lib.patch
-Requires:       lmod%{PROJ_DELIM} >= 7.6.1
 
 %description
 The ScaLAPACK (or Scalable LAPACK) library includes a subset
@@ -88,7 +86,7 @@ routines resemble their LAPACK equivalents as much as possible.
 cp SLmake.inc.example SLmake.inc
 
 %build
-%ohpc_setup_compiler
+%ohpc_load_modules
 %if "%{compiler_family}" != "intel"
 module load openblas
 %endif
@@ -130,9 +128,9 @@ module-whatis "%{url}"
 
 set     version                     %{version}
 
-if { ![is-loaded intel]  } {
+%if "%{compiler_family}" != "intel"
     depends-on openblas
-}
+%endif
 
 prepend-path    LD_LIBRARY_PATH     %{install_path}/lib
 

--- a/components/parallel-libs/scotch/SPECS/ptscotch.spec
+++ b/components/parallel-libs/scotch/SPECS/ptscotch.spec
@@ -30,8 +30,6 @@ Source1: scotch-Makefile.%{compiler_family}.inc.in
 Source2: scotch-rpmlintrc
 Source3: OHPC_macros
 Patch0:  scotch-%{version}-destdir.patch
-BuildRoot: %{_tmppath}/%{pname}-%{version}-%{release}-root
-DocDir:    %{OHPC_PUB}/doc/contrib
 
 BuildRequires:	flex bison
 %if 0%{?suse_version} >= 1100
@@ -50,11 +48,6 @@ BuildRequires:  zlib-devel
 %endif
 %endif
 
-# Requires:	
-
-#Disable debug packages
-%define debug_package %{nil}
-
 # Default library install path
 %define install_path %{OHPC_LIBS}/%{compiler_family}/%{mpi_family}/%{pname}/%{version}
 
@@ -68,15 +61,14 @@ sparse matrix ordering.
 sed s/@RPMFLAGS@/'%{optflags} -fPIC'/ < %SOURCE1 > src/Makefile.inc
 
 %build
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 pushd src
 make %{?_smp_mflags} %{pname}
 popd
 
 %install
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 pushd src
 make prefix=%{buildroot}%{install_path} install
@@ -134,9 +126,6 @@ setenv          %{PNAME}_LIB        %{install_path}/lib
 setenv          %{PNAME}_INC        %{install_path}/include
 
 EOF
-
-%clean
-rm -rf ${RPM_BUILD_ROOT}
 
 %files
 %defattr(-,root,root)

--- a/components/parallel-libs/slepc/SPECS/slepc.spec
+++ b/components/parallel-libs/slepc/SPECS/slepc.spec
@@ -13,8 +13,9 @@
 #
 
 # Build that is is dependent on compiler toolchain and MPI
-%define ohpc_compiler_dependent 1
-%define ohpc_mpi_dependent 1
+%global ohpc_compiler_dependent 1
+%global ohpc_mpi_dependent 1
+%global ohpc_required_modules %{compiler_family}-%{mpi_family}/petsc
 %include %{_sourcedir}/OHPC_macros
 
 
@@ -32,11 +33,6 @@ Group:          %{PROJ_NAME}/parallel-libs
 Url:            http://slepc.upv.es
 Source0:        http://slepc.upv.es/download/distrib/%{pname}-%{version}.tar.gz
 Source1:        OHPC_macros
-BuildRoot:      %{_tmppath}/%{pname}-%{version}-%{release}-root
-DocDir:         %{OHPC_PUB}/doc/contrib
-BuildRequires:  petsc-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-Requires:       petsc-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-Requires:       lmod%{PROJ_DELIM} >= 7.6.1
 
 # A configure script in slepc is made by python
 BuildRequires: python
@@ -46,8 +42,6 @@ BuildRequires: openblas-%{compiler_family}%{PROJ_DELIM}
 Requires:      openblas-%{compiler_family}%{PROJ_DELIM}
 %endif
 
-# Disable debug packages
-%define debug_package %{nil}
 # Default library install path
 %define install_path %{OHPC_LIBS}/%{compiler_family}/%{mpi_family}/%{pname}/%version
 
@@ -65,20 +59,18 @@ quadratic eigenvalue problems.
 set -- *
 
 %build
-%ohpc_setup_compiler
+%ohpc_load_modules
 %if "%{compiler_family}" != "intel"
 module load openblas
 %endif
-module load petsc
 ./configure --prefix=/tmp%{install_path}
-make 
+make
 
 %install
-%ohpc_setup_compiler
+%ohpc_load_modules
 %if "%{compiler_family}" != "intel"
 module load openblas
 %endif
-module load petsc
 make install
 
 # move from tmp install dir to %install_path
@@ -128,10 +120,7 @@ setenv          %{PNAME}_INC        %{install_path}/include
 setenv          %{PNAME}_ARCH       ""
 EOF
 
-%clean
-rm -rf ${RPM_BUILD_ROOT}
-
-%files 
+%files
 %defattr(-,root,root,-)
 %{OHPC_PUB}
 %doc COPYING COPYING.LESSER README docs/slepc.pdf

--- a/components/parallel-libs/superlu_dist/SPECS/superlu_dist.spec
+++ b/components/parallel-libs/superlu_dist/SPECS/superlu_dist.spec
@@ -26,8 +26,9 @@
 #
 
 # Build that is is dependent on compiler toolchain and MPI
-%define ohpc_compiler_dependent 1
-%define ohpc_mpi_dependent 1
+%global ohpc_compiler_dependent 1
+%global ohpc_mpi_dependent 1
+%global ohpc_required_modules %{compiler_family}/metis
 %include %{_sourcedir}/OHPC_macros
 
 %if "%{compiler_family}" != "intel"
@@ -55,9 +56,6 @@ Patch0:         superlu_dist-4.1-sequence-point.patch
 Patch1:         superlu_dist-4.2-make.patch
 Patch2:         superlu_dist-4.1-example-no-return-in-non-void.patch
 Patch3:         superlu_dist-4.1-parmetis.patch
-Requires:       lmod%{PROJ_DELIM} >= 7.6.1
-BuildRequires:  metis-%{compiler_family}%{PROJ_DELIM}
-Requires:       metis-%{compiler_family}%{PROJ_DELIM}
 
 #!BuildIgnore: post-build-checks
 
@@ -87,10 +85,7 @@ solutions.
 %patch3 -p1
 
 %build
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
-
-module load metis
+%ohpc_load_modules
 
 %if "%{compiler_family}" != "intel"
 module load scalapack

--- a/components/parallel-libs/trilinos/SPECS/trilinos.spec
+++ b/components/parallel-libs/trilinos/SPECS/trilinos.spec
@@ -9,8 +9,9 @@
 #----------------------------------------------------------------------------eh-
 
 # Build that is is dependent on compiler toolchain and MPI
-%define ohpc_compiler_dependent 1
-%define ohpc_mpi_dependent 1
+%global ohpc_compiler_dependent 1
+%global ohpc_mpi_dependent 1
+%global ohpc_required_modules cmake %{compiler_family}-%{mpi_family}/boost %{compiler_family}-%{mpi_family}/phdf5 %{compiler_family}-%{mpi_family}/netcdf
 %include %{_sourcedir}/OHPC_macros
 
 # Base package name
@@ -29,12 +30,10 @@ Source0:        https://github.com/trilinos/Trilinos/archive/trilinos-release-%{
 Source1:        OHPC_macros
 Patch0:         trilinos-11.14.3-no-return-in-non-void.patch
 Patch1:         Trilinos-trilinos-aarch64.patch
-BuildRequires:  cmake%{PROJ_DELIM}
 BuildRequires:  doxygen
 BuildRequires:  expat
 BuildRequires:  graphviz
 BuildRequires:  libxml2-devel
-Requires:       lmod%{PROJ_DELIM} >= 7.6.1
 BuildRequires:  perl
 %if 0%{?rhel_version} || 0%{?centos_version} || 0%{?rhel}
 BuildRequires:  qt-devel
@@ -44,9 +43,6 @@ BuildRequires:  libqt4-devel
 BuildRequires:  swig > 2.0.0
 BuildRequires:  xz
 BuildRequires:  zlib-devel
-BuildRequires:  boost-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-BuildRequires:  phdf5-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-BuildRequires:  netcdf-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 %if "%{compiler_family}" != intel
 BuildRequires:  openblas-%{compiler_family}%{PROJ_DELIM}
 %endif
@@ -72,13 +68,7 @@ Trilinos top layer providing a common look-and-feel and infrastructure.
 %patch1 -p1
 
 %build
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
-
-module load cmake
-module load boost
-module load netcdf
-module load phdf5
+%ohpc_load_modules
 
 %if "%{compiler_family}" != "intel"
 module load openblas
@@ -167,7 +157,7 @@ make %{?_smp_mflags} VERBOSE=1
 cd ..
 
 %install
-%ohpc_setup_compiler
+%ohpc_load_modules
 cd tmp
 make %{?_smp_mflags} DESTDIR=%{buildroot} install INSTALL='install -p'
 cd ..
@@ -203,9 +193,9 @@ setenv          %{PNAME}_INC        %{install_path}/include
 setenv          %{PNAME}_LIB        %{install_path}/lib
 
 # Autoload openblas for gnu builds
-if { ![is-loaded intel] } {
+%if "%{compiler_family}" != "intel"
     depends-on openblas
-}
+%endif
 
 EOF
 

--- a/components/perf-tools/imb/SPECS/imb.spec
+++ b/components/perf-tools/imb/SPECS/imb.spec
@@ -9,8 +9,8 @@
 #----------------------------------------------------------------------------eh-
 
 # Build that is dependent on compiler/mpi toolchains
-%define ohpc_compiler_dependent 1
-%define ohpc_mpi_dependent 1
+%global ohpc_compiler_dependent 1
+%global ohpc_mpi_dependent 1
 %include %{_sourcedir}/OHPC_macros
 
 # Base package name
@@ -45,18 +45,14 @@ a range of message sizes.
 %patch1 -p0
 
 %build
-
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 cd src
 make all
 cd -
 
 %install
-
-# OpenHPC compiler designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 %{__mkdir} -p %{buildroot}%{install_path}/bin
 cd src

--- a/components/perf-tools/mpiP/SPECS/mpiP.spec
+++ b/components/perf-tools/mpiP/SPECS/mpiP.spec
@@ -68,8 +68,8 @@ cp /usr/lib/rpm/config.guess bin
 
 # note: in order to support call-site demangling, we compile mpiP with gnu
 # see above where compiler_family is changed
-%define compiler_family gnu7
-%ohpc_setup_compiler
+%global compiler_family gnu7
+%ohpc_load_modules
 
 CC=mpicc
 CXX=mpicxx
@@ -87,8 +87,8 @@ FC=mpif90
 
 # note: in order to support call-site demangling, we compile mpiP with gnu
 # see above where compiler_family is changed
-%define compiler_family gnu7
-%ohpc_setup_compiler
+%global compiler_family gnu7
+%ohpc_load_modules
 
 make %{?_smp_mflags} shared
 make DESTDIR=$RPM_BUILD_ROOT install

--- a/components/perf-tools/pdtoolkit/SPECS/pdtoolkit.spec
+++ b/components/perf-tools/pdtoolkit/SPECS/pdtoolkit.spec
@@ -44,8 +44,7 @@ Program Database Toolkit (PDT) is a framework for analyzing source code written 
 
 
 %build
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 ./configure -prefix=%buildroot%{install_path} \
         -useropt=-fPIC \
@@ -59,7 +58,7 @@ export DONT_STRIP=1
 make %{?_smp_mflags}
 
 %install
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 ./configure -prefix=%buildroot%{install_path} \
 %if "%{compiler_family}" == "intel"

--- a/components/perf-tools/scalasca/SPECS/scalasca.spec
+++ b/components/perf-tools/scalasca/SPECS/scalasca.spec
@@ -9,8 +9,9 @@
 #----------------------------------------------------------------------------eh-
 
 # Build that is dependent on compiler/mpi toolchains
-%define ohpc_compiler_dependent 1
-%define ohpc_mpi_dependent 1
+%global ohpc_compiler_dependent 1
+%global ohpc_mpi_dependent 1
+%global ohpc_required_modules %{compiler_family}-%{mpi_family}/scorep
 %include %{_sourcedir}/OHPC_macros
 
 # Base package name
@@ -26,11 +27,8 @@ Group:     %{PROJ_NAME}/perf-tools
 URL:       http://www.scalasca.org
 Source0:   http://apps.fz-juelich.de/scalasca/releases/scalasca/2.3/dist/scalasca-%{version}.tar.gz
 Source1:   OHPC_macros
-Requires:  lmod%{PROJ_DELIM} >= 7.6.1
-BuildRequires: scorep-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-BuildRequires: scorep-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-Requires:  scorep-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 BuildRequires: zlib-devel
+Requires:  zlib
 
 # Default library install path
 %define install_path %{OHPC_LIBS}/%{compiler_family}/%{mpi_family}/%{pname}/%version
@@ -56,11 +54,7 @@ This is the %{compiler_family}-%{mpi_family} version.
 %setup -q -n %{pname}-%{version}
 
 %build
-
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
-
-module load scorep
+%ohpc_load_modules
 
 %if %{compiler_family} == intel
 CONFIGURE_OPTIONS="--with-nocross-compiler-suite=intel "
@@ -91,7 +85,7 @@ CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --with-mpi=openmpi "
 %install
 
 # OpenHPC compiler designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 module load scorep
 

--- a/components/perf-tools/scorep/SPECS/scorep.spec
+++ b/components/perf-tools/scorep/SPECS/scorep.spec
@@ -9,8 +9,9 @@
 #----------------------------------------------------------------------------eh-
 
 # Build that is dependent on compiler/mpi toolchains
-%define ohpc_compiler_dependent 1
-%define ohpc_mpi_dependent 1
+%global ohpc_compiler_dependent 1
+%global ohpc_mpi_dependent 1
+%global ohpc_required_modules pdtoolkit sionlib
 %include %{_sourcedir}/OHPC_macros
 
 # Base package name
@@ -36,16 +37,11 @@ BuildRequires: binutils-devel
 Requires     : binutils-devel
 BuildRequires: libunwind-devel
 Requires     : libunwind-devel
-Requires     : lmod%{PROJ_DELIM} >= 7.6.1
 BuildRequires: zlib-devel
 %ifarch x86_64
 BuildRequires: papi%{PROJ_DELIM}
 Requires     : papi%{PROJ_DELIM}
 %endif
-BuildRequires: pdtoolkit-%{compiler_family}%{PROJ_DELIM}
-Requires     : pdtoolkit-%{compiler_family}%{PROJ_DELIM}
-BuildRequires: sionlib-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-Requires     : sionlib-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 
 # Default library install path
 %define install_path %{OHPC_LIBS}/%{compiler_family}/%{mpi_family}/%{pname}/%version
@@ -64,15 +60,11 @@ This is the %{compiler_family}-%{mpi_family} version.
 %patch0 -p1
 
 %build
-
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 %ifarch x86_64
 module load papi
 %endif
-module load pdtoolkit
-module load sionlib
 
 %if %{compiler_family} == intel
 CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --with-nocross-compiler-suite=intel "
@@ -101,11 +93,9 @@ CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --with-mpi=openmpi "
 ./configure --prefix=%{install_path} --disable-static --enable-shared $CONFIGURE_OPTIONS
 
 %install
+%ohpc_load_modules
 
 export NO_BRP_CHECK_RPATH=true
-
-# OpenHPC compiler designation
-%ohpc_setup_compiler
 
 %ifarch x86_64
 module load papi

--- a/components/perf-tools/tau/SPECS/tau.spec
+++ b/components/perf-tools/tau/SPECS/tau.spec
@@ -9,8 +9,9 @@
 #----------------------------------------------------------------------------eh-
 
 # Build that is dependent on compiler/mpi toolchains
-%define ohpc_compiler_dependent 1
-%define ohpc_mpi_dependent 1
+%global ohpc_compiler_dependent 1
+%global ohpc_mpi_dependent 1
+%global ohpc_required_modules %{compiler_family}/pdtoolkit
 %include %{_sourcedir}/OHPC_macros
 
 # Base package name
@@ -46,13 +47,10 @@ BuildRequires: curl
 BuildRequires: postgresql-devel binutils-devel
 Requires: binutils-devel
 BuildRequires: libotf-devel zlib-devel python-devel
-Requires:      lmod%{PROJ_DELIM} >= 7.6.1
-BuildRequires: pdtoolkit-%{compiler_family}%{PROJ_DELIM}
 %ifarch x86_64
 BuildRequires: papi%{PROJ_DELIM}
 Requires: papi%{PROJ_DELIM}
 %endif
-Requires: pdtoolkit-%{compiler_family}%{PROJ_DELIM}
 
 #!BuildIgnore: post-build-checks
 
@@ -82,12 +80,10 @@ sed -i -e 's/^BITS.*/BITS = 64/' src/Profile/Makefile.skel
 %endif
 
 %install
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 %ifarch x86_64
 module load papi
 %endif
-module load pdtoolkit
 
 %if "%{compiler_family}" == "intel"
 export fcomp=ifort

--- a/components/rms/pmix/SPECS/pmix.spec
+++ b/components/rms/pmix/SPECS/pmix.spec
@@ -8,6 +8,7 @@
 #
 #----------------------------------------------------------------------------eh-
 
+%global ohpc_required_modules autotools
 %include %{_sourcedir}/OHPC_macros
 %global pname pmix
 %global PNAME %(tr [a-z] [A-Z] <<< %{pname})
@@ -24,7 +25,8 @@ Source1: OHPC_macros
 Patch0: singleton.5391e43.patch
 
 BuildRequires: libevent-devel
-BuildRequires: lmod-ohpc libtool-ohpc
+
+Requires: libevent
 
 %global install_path %{OHPC_ADMIN}/%{pname}
 
@@ -50,8 +52,8 @@ This RPM contains all the tools necessary to compile and link against PMIx.
 %prep
 %setup -q -n %{pname}-%{version}
 %patch0 -p1
-module load autotools
-./autogen.sh 
+%ohpc_load_modules
+./autogen.sh
 
 %build
 CFLAGS="%{optflags}" ./configure --prefix=%{install_path}

--- a/components/rms/slurm/SPECS/slurm.spec
+++ b/components/rms/slurm/SPECS/slurm.spec
@@ -223,7 +223,7 @@ Requires(pre):  shadow-utils
 %endif
 
 #needed to enable jobcomp_elasticsearch plugin
-BuildRequires: curl-devel
+BuildRequires: curl-devel lua-devel
 
 %description
 Slurm is an open source, fault-tolerant, and highly

--- a/components/runtimes/ocr/SPECS/ocr.spec
+++ b/components/runtimes/ocr/SPECS/ocr.spec
@@ -77,9 +77,8 @@ This version is for clusters using MPI.
 %setup -q -n ocr-OCRv%{version}_ohpc
 
 %build
+%ohpc_load_modules
 cd ocr/build
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
 
 %if %{compiler_family} == intel
 export CFLAGS="-fp-model strict $CFLAGS"
@@ -94,9 +93,8 @@ OCR_TYPE=x86-mpi make %{?_smp_mflags} all
 %define install_path %{OHPC_LIBS}/%{compiler_family}/%{pname}/%version
 
 %install
+%ohpc_load_modules
 cd ocr/build
-# OpenHPC compiler designation
-%ohpc_setup_compiler
 
 mkdir -p $RPM_BUILD_ROOT/%{install_path}
 make OCR_TYPE=x86 OCR_INSTALL=$RPM_BUILD_ROOT/%{install_path} %{?_smp_mflags} install

--- a/components/serial-libs/R/SPECS/R.spec
+++ b/components/serial-libs/R/SPECS/R.spec
@@ -96,7 +96,6 @@ Requires:	libicu52_1
 BuildRequires:  libicu
 Requires:	libicu
 %endif
-Requires:       lmod%{PROJ_DELIM} >= 7.6.1
 
 Provides:       R = %{version}
 Provides:       R-KernSmooth = 2.23.14
@@ -219,9 +218,9 @@ setenv          %{PNAME}_BIN        %{install_path}/bin
 setenv          %{PNAME}_LIB        %{install_path}/lib64
 setenv          %{PNAME}_SHARE      %{install_path}/share
 
-if { ![is-loaded intel] } {
+%if "%{compiler_family}" != "intel"
     depends-on openblas
-}
+%endif
 
 EOF
 

--- a/components/serial-libs/gsl/SPECS/gsl.spec
+++ b/components/serial-libs/gsl/SPECS/gsl.spec
@@ -44,8 +44,7 @@ lends itself to being used in very high level languages (VHLLs).
 %setup -q -n %{pname}-%{version}
 
 %build
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 %if %{compiler_family} == intel
 export CFLAGS="-fp-model strict $CFLAGS"
@@ -55,8 +54,7 @@ export CFLAGS="-fp-model strict $CFLAGS"
 make %{?_smp_mflags}
 
 %install
-# OpenHPC compiler designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 make %{?_smp_mflags} DESTDIR=$RPM_BUILD_ROOT install
 
 # Remove static libraries

--- a/components/serial-libs/metis/SPECS/metis.spec
+++ b/components/serial-libs/metis/SPECS/metis.spec
@@ -67,15 +67,13 @@ shown to produce high quality results and scale to very large problems.
 %prep
 %setup -q -n %{pname}-%{version}
 %build
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 make config shared=1 prefix=%{install_path}
 make
 
 %install
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 make install DESTDIR=${RPM_BUILD_ROOT}
 

--- a/components/serial-libs/openblas/SPECS/openblas.spec
+++ b/components/serial-libs/openblas/SPECS/openblas.spec
@@ -80,8 +80,7 @@ OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version.
 #%patch7 -p1
 
 %build
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 # Only *86 CPUs support DYNAMIC_ARCH
 %ifarch %ix86 x86_64
@@ -96,8 +95,7 @@ make    %{?openblas_target} USE_THREAD=1 USE_OPENMP=1 \
         PREFIX=%{buildroot}%{install_path}
 
 %install
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 make   %{?openblas_target} PREFIX=%{buildroot}%{install_path} install
 

--- a/components/serial-libs/plasma/SPECS/plasma.spec
+++ b/components/serial-libs/plasma/SPECS/plasma.spec
@@ -37,14 +37,9 @@ Source2: http://www.netlib.org/lapack/lapack-3.7.0.tgz
 Source3: %{pname}-rpmlintrc
 Source4: OHPC_macros
 Patch1:  plasma-lapack_version.patch
-Requires: lmod%{PROJ_DELIM} >= 7.6.1
 
-BuildRoot: %{_tmppath}/%{pname}-%{version}-%{release}-root
-DocDir:    %{OHPC_PUB}/doc/contrib
 
 #!BuildIgnore: post-build-checks 
-# Disable debug packages
-%define debug_package %{nil}
 # Default library install path
 %define install_path %{OHPC_LIBS}/%{compiler_family}/%{pname}/%version
 
@@ -67,7 +62,7 @@ cp %{SOURCE0} build/download
 cp %{SOURCE2} build/download
 
 # OpenHPC compiler designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 %if "%{compiler_family}" != "intel"
 module load openblas
@@ -153,9 +148,9 @@ set     version			    %{version}
 
 
 # Require openblas for gnu compiler families
-if { ![is-loaded intel] } {
+%if "%{compiler_family}" != "intel"
     depends-on openblas
-}
+%endif
 
 prepend-path    PATH                %{install_path}/bin
 prepend-path    MANPATH             %{install_path}/share/man

--- a/components/serial-libs/scotch/SPECS/scotch.spec
+++ b/components/serial-libs/scotch/SPECS/scotch.spec
@@ -57,16 +57,14 @@ sparse matrix ordering.
 sed s/@RPMFLAGS@/'%{optflags} -fPIC'/ < %{SOURCE1} > src/Makefile.inc
 
 %build
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 pushd src
 make %{?_smp_mflags}
 popd
 
 %install
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 pushd src
 make prefix=%{buildroot}%{install_path} install

--- a/components/serial-libs/superlu/SPECS/superlu.spec
+++ b/components/serial-libs/superlu/SPECS/superlu.spec
@@ -53,7 +53,6 @@ Patch2:         superlu-4.3-dont-opt-away.diff
 # this routine in the library which, however, remains fully functionnal
 Patch3:         superlu-5.1-disable-hsl.patch
 Url:            http://crd.lbl.gov/~xiaoye/SuperLU/
-Requires:       lmod%{PROJ_DELIM} >= 7.6.1
 BuildRequires:  tcsh
 
 # Default library install path
@@ -74,7 +73,7 @@ Docu can be found on http://www.netlib.org.
 %patch3 -p1
 
 %build
-%ohpc_setup_compiler
+%ohpc_load_modules
 
 make lib
 
@@ -117,10 +116,9 @@ module-whatis "%{url}"
 
 set     version                     %{version}
 
-if { ![is-loaded intel] } {
+%if "%{compiler_family}" != "intel"
     depends-on openblas
-}
-
+%endif
 
 prepend-path    INCLUDE             %{install_path}/include
 prepend-path    LD_LIBRARY_PATH     %{install_path}/lib

--- a/misc/build_order.py
+++ b/misc/build_order.py
@@ -70,7 +70,7 @@ for line in open(sys.argv[1]):
             (not line[2].startswith('nagios-plugins-ohpc'))):
         continue
     # This tries to filter out versions with a "."
-    if "." in line[2]:
+    if "." in line[2] and not "/" in line[2]:
         continue
     if line[0] in dependency:
         if line[2] not in dependency[line[0]]:
@@ -94,7 +94,6 @@ for k, v in dependency.items():
         v[i] = spec_dict[v[i]]
     # remove cylic dependencies
     dependency[k] = [x for x in v if x != k]
-
 
 # make a list of the dict
 dep_list = [(k, set(v)) for (k, v) in dependency.items()]


### PR DESCRIPTION
In order to avoid base OS breakage due to duplicate or wrong
dependencies, this introduces a completely different dependency model
for OpenHPC.

The main problem with the automatically generated SO based dependencies
is that OpenHPC packages can have the same SO 'Requires' or 'Provides'
as packages installed by the base OS.
As the OpenHPC packages are installed outside of the dynamic loader's
scope the dependencies are correctly solved in the RPM database but not
in the running system.

To avoid those problems this patch disables the RPM internal dependency
generator and replaces it with a environment module based
implementation.

This new environment module based generator creates dependencies like:

 # repoquery --requires openblas-gnu7-ohpc
 lmod-ohpc
 ohpc-filesystem
 ohpc-module(gnu7)
 # repoquery --provides openblas-gnu7-ohpc
 ohpc-module(openblas)
 ohpc-module(openblas/0.2.20)
 openblas-gnu7-ohpc = 0.2.20-1.ohpc
 openblas-gnu7-ohpc(x86-64) = 0.2.20-1.ohpc
 # repoquery --requires tau-gnu7-openmpi3-ohpc
 lmod-ohpc >= 7.6.1
 ohpc-module(gnu7-openmpi3)
 ohpc-module(papi)
 ohpc-module(pdtoolkit)

The created dependencies can directly be used in the 'module load'
syntax.

The new dependency generators are looking for environment module files
in 'modulefiles/' and 'moduledeps/' and create the dependencies based
on paths, filenames, prepend-path and depends-on.

Besides the infrastructure changes in this commit, the following changes
in the RPM spec files can be made to simplify dependency handling.

If the variable 'ohpc_required_modules' is set to a valid environment
modules name the necessary 'BuildRequires:' and 'Requires:' statements
will be generated:

 llvm-compilers.spec: %global ohpc_required_modules cmake
 # rpm -qpR ~/rpmbuild/SRPMS/llvm5-compilers-ohpc-5.0.0-1.ohpc.src.rpm  | grep cmake
 ohpc-module(cmake)
 # repoquery --provides cmake-ohpc
 cmake-ohpc = 3.9.2-1.ohpc
 cmake-ohpc(x86-64) = 3.9.2-1.ohpc
 ohpc-module(cmake)
 ohpc-module(cmake/3.9.2)

And if using the macro '%ohpc_load_modules' in the '%build' and
'%install' section the previously defined required modules will
be automatically loaded.

The resulting binary RPM will only require 'ohpc-module(cmake)' if it is
mentioned in the environment modules file.

Right now this has only been compile tested and the results can be seen
here: https://copr.fedorainfracloud.org/coprs/adrian/ohpc-modules-final/

Signed-off-by: Adrian Reber <areber@redhat.com>