### PR TITLE
Opafm variable in input.local

### DIFF
--- a/docs/recipes/install/centos7/input.local.template
+++ b/docs/recipes/install/centos7/input.local.template
@@ -43,6 +43,7 @@ eth_provision="${eth_provision:-eth0}"
 # Flags for optional installation/configuration
 enable_ib="${enable_ib:-0}"
 enable_opa="${enable_opa:-0}"
+enable_opafm="${enable_opafm:-0}"
 enable_mpi_defaults="${enable_mpi_defaults:-1}"
 enable_ipoib="${enable_ipoib:-0}"
 

--- a/docs/recipes/install/sles12/input.local.template
+++ b/docs/recipes/install/sles12/input.local.template
@@ -37,6 +37,7 @@ provision_wait="${provision_wait:-180}"
 # Flags for optional installation/configuration
 enable_ib="${enable_ib:-0}"
 enable_opa="${enable_opa:-0}"
+enable_opafm="${enable_opafm:-0}"
 enable_mpi_defaults="${enable_mpi_defaults:-1}"
 enable_ipoib="${enable_ipoib:-0}"
 


### PR DESCRIPTION
The input.local files were missing the opafm variable being defined. The recipe.sh script checks for these variables in order to install the opafm package and enable the service. Adding the variable to the input.local file will allow a user to select that parameter now for use.