### PR TITLE
EPEL repo is required in the chroot for nagios plugins, fping and qstat (xCAT recipe).

### DIFF
--- a/docs/recipes/install/common/add_to_compute_chroot_xcat_intro.tex
+++ b/docs/recipes/install/common/add_to_compute_chroot_xcat_intro.tex
@@ -12,6 +12,7 @@ the chroot.
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true]
 [sms](*\#*) yum-config-manager --installroot=$CHROOT --enable base
 [sms](*\#*) cp /etc/yum.repos.d/OpenHPC.repo $CHROOT/etc/yum.repos.d
+[sms](*\#*) cp /etc/yum.repos.d/epel.repo $CHROOT/etc/yum.repos.d
 \end{lstlisting}
 % end_ohpc_run
 


### PR DESCRIPTION
I'm adding the epel repo to the chroot. At least nagios needs it to fulfill the qstat and fping package dependencies. There may be other optional packages that require this as well which is why I'm not putting it into the nagios area only.