### PR TITLE
Specific uid and gid for slurm system user

### DIFF
--- a/components/rms/munge/SPECS/munge.spec
+++ b/components/rms/munge/SPECS/munge.spec
@@ -146,10 +146,10 @@ rm -rf "$RPM_BUILD_ROOT"
 # karl.w.schulz@intel.com (9/10/18) - provide specific uid/gid to deal with 
 # possibility of getting alternate ownership within Warewulf
 /usr/bin/getent group munge >/dev/null 2>&1 || \
-  /usr/sbin/groupadd -r munge -g 200
+  /usr/sbin/groupadd -r munge -g 201
 /usr/bin/getent passwd munge >/dev/null 2>&1 || \
   /usr/sbin/useradd -c "MUNGE authentication service" \
-  -d "%{_sysconfdir}/munge" -g munge -s /bin/false -r munge -u 200
+  -d "%{_sysconfdir}/munge" -g munge -s /bin/false -r munge -u 201
 
 %post
 if [ ! -e %{_sysconfdir}/munge/munge.key -a -c /dev/urandom ]; then

--- a/components/rms/slurm/SPECS/slurm.spec
+++ b/components/rms/slurm/SPECS/slurm.spec
@@ -1085,10 +1085,10 @@ mkdir -p $RPM_BUILD_ROOT/%{_docdir}
 
 # provide specific uid/gid to ensure that it is the same across the cluster
 /usr/bin/getent group slurm >/dev/null 2>&1 || \
-  /usr/sbin/groupadd -r slurm -g 201
+  /usr/sbin/groupadd -r slurm -g 202
 /usr/bin/getent passwd slurm >/dev/null 2>&1 || \
   /usr/sbin/useradd -c "SLURM resource manager" \
-  -d %{_sysconfdir} -g slurm -s /bin/nologin -r slurm -u 201
+  -d %{_sysconfdir} -g slurm -s /bin/nologin -r slurm -u 202
   
 exit 0
 

--- a/components/rms/slurm/SPECS/slurm.spec
+++ b/components/rms/slurm/SPECS/slurm.spec
@@ -1083,9 +1083,13 @@ mkdir -p $RPM_BUILD_ROOT/%{_docdir}
 #    fi
 #fi
 
-getent passwd slurm >/dev/null || \
-    /usr/sbin/useradd -U -c "SLURM resource manager" \
-    -s /sbin/nologin -r -d %{_sysconfdir} slurm
+# provide specific uid/gid to ensure that it is the same across the cluster
+/usr/bin/getent group slurm >/dev/null 2>&1 || \
+  /usr/sbin/groupadd -r slurm -g 201
+/usr/bin/getent passwd slurm >/dev/null 2>&1 || \
+  /usr/sbin/useradd -c "SLURM resource manager" \
+  -d %{_sysconfdir} -g slurm -s /bin/nologin -r slurm -u 201
+  
 exit 0
 
 %post


### PR DESCRIPTION
Slurm requires that uid/gid are the same across the cluster, this patch follows the example of munge spec file (which uses uid/gid 200) and sets uid and gid to 201.

Differing ids are a problem for stateful xCAT install, where ids end up being different - stateful xCAT image installs different packages than default install on the SMS.
 Regardless, given that this is a requirement ( https://slurm.schedmd.com/accounting.html) it is a good practice to enforce this.