### PR TITLE
admin/ohpc-filesystem: include custom requires/provides plugin files for RPM dependency analysis

### DIFF
--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -91,6 +91,8 @@ Requires:      llvm-compilers%{PROJ_DELIM}
 
 %endif
 
+%global __libsymlink_exclude_path  %{OHPC_HOME}/.*$
+
 # MPI dependencies
 %if 0%{?ohpc_mpi_dependent} == 1
 %if "%{mpi_family}" == "impi"

--- a/components/admin/ohpc-filesystem/SOURCES/ohpc-find-provides
+++ b/components/admin/ohpc-filesystem/SOURCES/ohpc-find-provides
@@ -1,31 +1,28 @@
 #!/bin/bash
 #
 # ohpc-find-provides
+#-----------------------------------------------------------------------
+# Licensed under the Apache License, Version 2.0 (the "License"); you
+# may not use this file except in compliance with the License. You may
+# obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#-----------------------------------------------------------------------
 
 IFS=$'\n'
-TMPFILE=$(mktemp)
-appendString=""
-
-while getopts "r:" opt; do
-    case ${opt} in
-    	r )
-	    appendString=$OPTARG
-	    ;;
-    esac
-done
 
 # Get the list of files.
 filelist=`sed "s/[]['\"*?{}]/\\\\\&/g"`
 
-# Default mode - if the "-r" option is not enabled to provide a string
-# to append, we simply return to ignore .so's installed into OHPC path
+# Use standard elfdeps tool and append additional (ohpc) color delimiter
 
-if [ -z "$appendString" ];then
-    exit 0
-elif [ -x /usr/lib/rpm/elfdeps -a -n "$filelist" ];then
-    
-    # Otherwise, use elfdeps and append a string to detected Provides
-    # information
+if [ -x /usr/lib/rpm/elfdeps -a -n "$filelist" ];then
     
     provideList=$(echo $filelist | /usr/lib/rpm/elfdeps -P)
     for provide in $provideList; do

--- a/components/admin/ohpc-filesystem/SOURCES/ohpc-find-provides
+++ b/components/admin/ohpc-filesystem/SOURCES/ohpc-find-provides
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# ohpc-find-provides
+
+IFS=$'\n'
+TMPFILE=$(mktemp)
+appendString=""
+
+while getopts "r:" opt; do
+    case ${opt} in
+    	r )
+	    appendString=$OPTARG
+	    ;;
+    esac
+done
+
+# Get the list of files.
+filelist=`sed "s/[]['\"*?{}]/\\\\\&/g"`
+
+# Default mode - if the "-r" option is not enabled to provide a string
+# to append, we simply return to ignore .so's installed into OHPC path
+
+if [ -z "$appendString" ];then
+    exit 0
+elif [ -x /usr/lib/rpm/elfdeps -a -n "$filelist" ];then
+    
+    # Otherwise, use elfdeps and append a string to detected Provides
+    # information
+    
+    provideList=$(echo $filelist | /usr/lib/rpm/elfdeps -P)
+    for provide in $provideList; do
+	echo "$provide(ohpc)"
+    done
+fi

--- a/components/admin/ohpc-filesystem/SOURCES/ohpc-find-requires
+++ b/components/admin/ohpc-filesystem/SOURCES/ohpc-find-requires
@@ -1,10 +1,21 @@
 #!/bin/bash
 #
 # ohpc-find-requires
+#-----------------------------------------------------------------------
+# Licensed under the Apache License, Version 2.0 (the "License"); you
+# may not use this file except in compliance with the License. You may
+# obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#-----------------------------------------------------------------------
 
 IFS=$'\n'
-TMPFILE=$(mktemp)
-LOGFILE=/tmp/requires.log
 
 # First argument is buildroot
 buildroot="$1"
@@ -13,44 +24,51 @@ if [ ! -d "$buildroot" ]; then
     exit 1
 fi
 
+# Second argument is top-level search path
+searchPath="$2"
+if [ -z"$searchPath" ];then
+    >&2echo "Required search path argument not provided"
+    exit 1
+fi
+
+if [ ! -x /usr/lib/rpm/elfdeps ]; then
+    >&2 echo "Required /usr/lib/rpm/elfdeps binary not available locally"
+    exit 1
+fi
+
 # Get the list of files.
 filelist=`sed "s/[]['\"*?{}]/\\\\\&/g"`
 
 if [ -z "$filelist" ]; then exit 0; fi
 
-# Step 1: use standard rpmdeps analysis and cache results
-echo "$filelist" | /usr/lib/rpm/elfdeps -R >> $TMPFILE
 
-# Step 2: remove any .so's from requires list if they are not provides by base OS
+# Step 1: use standard elfdeps analysis and cache results
+requireList=$(echo ${filelist} | /usr/lib/rpm/elfdeps -R)
 
-for require in `cat $TMPFILE`; do
+# Step 2: append additional color delimiter for ohpc provided packages (that
+# install into $searchPath)
+	      
+for require in ${requireList}; do
 
     # Check if this is owned by ohpc pre-requisite
     package=$(rpm -q --queryformat '%{NAME}\n' --whatprovides "$require(ohpc)")
     if [ $? -eq 0 ];then
 	echo "$require(ohpc)"
-#	echo "--> package owner = $package" >> ${LOGFILE}
     else
-	# check if this requirement is housed in
-	# ${buildroot}/opt/ohpc. If so, we append an (ohpc)
-	# designation, otherwise we leave the requirement as is to be
-	# satisfied by packages outside of ohpc.
+
+	# check if this requirement is housed in ${buildroot}/opt/ohpc.
+	# If so, we append an (ohpc) color designation, otherwise we
+	# leave the requirement as is.
 	
-	# strip off () to get libname
-	
-	libname=${require%%(*}
-	match=$(find ${buildroot}/opt/ohpc -name ${libname})
+	libname=${require%%(*}  # strip off () to get libname
+	match=$(find ${buildroot}/${searchPath} -name ${libname})
 
 	if [ -n "${match}" ];then
-#	    echo "--> current ohpc build is package owner" >> ${LOGFILE}
 	    echo "$require(ohpc)"
 	else
-#	    echo "--> package assumed external to ohpc" >> ${LOGFILE}
 	    echo "$require"
 	fi
 	
      fi
 		  
  done
-
-rm -f $TMPFILE

--- a/components/admin/ohpc-filesystem/SOURCES/ohpc-find-requires
+++ b/components/admin/ohpc-filesystem/SOURCES/ohpc-find-requires
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# ohpc-find-requires
+
+IFS=$'\n'
+TMPFILE=$(mktemp)
+LOGFILE=/tmp/requires.log
+
+# First argument is buildroot
+buildroot="$1"
+if [ ! -d "$buildroot" ]; then
+    >&2 echo "Invalid buildroot"
+    exit 1
+fi
+
+# Get the list of files.
+filelist=`sed "s/[]['\"*?{}]/\\\\\&/g"`
+
+if [ -z "$filelist" ]; then exit 0; fi
+
+# Step 1: use standard rpmdeps analysis and cache results
+echo "$filelist" | /usr/lib/rpm/elfdeps -R >> $TMPFILE
+
+# Step 2: remove any .so's from requires list if they are not provides by base OS
+
+for require in `cat $TMPFILE`; do
+
+    # Check if this is owned by ohpc pre-requisite
+    package=$(rpm -q --queryformat '%{NAME}\n' --whatprovides "$require(ohpc)")
+    if [ $? -eq 0 ];then
+	echo "$require(ohpc)"
+#	echo "--> package owner = $package" >> ${LOGFILE}
+    else
+	# check if this requirement is housed in
+	# ${buildroot}/opt/ohpc. If so, we append an (ohpc)
+	# designation, otherwise we leave the requirement as is to be
+	# satisfied by packages outside of ohpc.
+	
+	# strip off () to get libname
+	
+	libname=${require%%(*}
+	match=$(find ${buildroot}/opt/ohpc -name ${libname})
+
+	if [ -n "${match}" ];then
+#	    echo "--> current ohpc build is package owner" >> ${LOGFILE}
+	    echo "$require(ohpc)"
+	else
+#	    echo "--> package assumed external to ohpc" >> ${LOGFILE}
+	    echo "$require"
+	fi
+	
+     fi
+		  
+ done
+
+rm -f $TMPFILE

--- a/components/admin/ohpc-filesystem/SOURCES/ohpc-find-requires
+++ b/components/admin/ohpc-filesystem/SOURCES/ohpc-find-requires
@@ -26,7 +26,7 @@ fi
 
 # Second argument is top-level search path
 searchPath="$2"
-if [ -z"$searchPath" ];then
+if [ -z "$searchPath" ];then
     >&2echo "Required search path argument not provided"
     exit 1
 fi

--- a/components/admin/ohpc-filesystem/SOURCES/ohpc.attr
+++ b/components/admin/ohpc-filesystem/SOURCES/ohpc.attr
@@ -1,5 +1,5 @@
-%__ohpc_provides	/usr/lib/rpm/ohpc-find-provides -r ohpc
-%__ohpc_requires 	/usr/lib/rpm/ohpc-find-requires %{buildroot}
+%__ohpc_provides	/usr/lib/rpm/ohpc-find-provides
+%__ohpc_requires 	/usr/lib/rpm/ohpc-find-requires %{buildroot} %{OHPC_HOME}
 %__ohpc_path            ^%{OHPC_HOME}
 %__elf_exclude_path 	^%{OHPC_HOME}
 

--- a/components/admin/ohpc-filesystem/SOURCES/ohpc.attr
+++ b/components/admin/ohpc-filesystem/SOURCES/ohpc.attr
@@ -1,0 +1,7 @@
+%__ohpc_provides	/usr/lib/rpm/ohpc-find-provides -r ohpc
+%__ohpc_requires 	/usr/lib/rpm/ohpc-find-requires %{buildroot}
+%__ohpc_path            ^%{OHPC_HOME}
+%__elf_exclude_path 	^%{OHPC_HOME}
+
+%__ohpc_magic    	^ELF (32|64)-bit.*$
+%__ohpc_flags    	magic_and_path

--- a/components/admin/ohpc-filesystem/SPECS/ohpc-filesystem.spec
+++ b/components/admin/ohpc-filesystem/SPECS/ohpc-filesystem.spec
@@ -7,12 +7,15 @@ Group: ohpc/admin
 License: ASL 2.0
 Source0: OHPC_setup_compiler
 Source1: OHPC_setup_mpi
+Source2: ohpc.attr
+Source3: ohpc-find-requires
+Source4: ohpc-find-provides
 
 BuildArch: noarch
 
 %description
 This administrative package is used to define top level OpenHPC installation
-directories and is utilized by most packages that do not install into system
+directories. It is utilized by most packages that do not install into system
 default paths.
 
 %package -n ohpc-buildroot
@@ -22,14 +25,24 @@ Requires: lmod-ohpc
 Requires: ohpc-filesystem
 
 %description -n ohpc-buildroot
-Common compiler and MPI family convenience scripts used during OpenHPC builds.
+
+This administrative package is used to provide RPM dependency analysis tools
+and common compiler and MPI family convenience scripts used during OpenHPC
+builds.
 
 %install
 # The ohpc-filesystems owns all the common directories
 mkdir -p $RPM_BUILD_ROOT/opt/ohpc/pub/{apps,doc,compiler,libs,moduledeps,modulefiles,mpi}
 mkdir -p $RPM_BUILD_ROOT/opt/ohpc/admin/ohpc
+mkdir -p $RPM_BUILD_ROOT/usr/lib/rpm/fileattrs
+
 install -p -m 644 %{SOURCE0} $RPM_BUILD_ROOT/opt/ohpc/admin/ohpc
 install -p -m 644 %{SOURCE1} $RPM_BUILD_ROOT/opt/ohpc/admin/ohpc
+
+# rpm dependency plugins
+install -p -m 755 %{SOURCE2} $RPM_BUILD_ROOT/usr/lib/rpm/fileattrs
+install -p -m 755 %{SOURCE3} $RPM_BUILD_ROOT/usr/lib/rpm
+install -p -m 755 %{SOURCE4} $RPM_BUILD_ROOT/usr/lib/rpm
 
 %files
 %dir /opt/ohpc/
@@ -45,8 +58,13 @@ install -p -m 644 %{SOURCE1} $RPM_BUILD_ROOT/opt/ohpc/admin/ohpc
 
 %files -n ohpc-buildroot
 %dir /opt/ohpc/admin/ohpc/
+%dir /usr/lib/rpm/
+%dir /usr/lib/rpm/fileattrs/
 /opt/ohpc/admin/ohpc/OHPC_setup_compiler
 /opt/ohpc/admin/ohpc/OHPC_setup_mpi
+/usr/lib/rpm/ohpc-find-provides
+/usr/lib/rpm/ohpc-find-requires
+/usr/lib/rpm/fileattrs/ohpc.attr
 
 %changelog
 * Mon May  8 2017 Karl W Schulz <karl.w.schulz@intel.com> - 1.3


### PR DESCRIPTION
This includes several new files that are housed in `/usr/lib/rpm` to trigger the rpm dependency analysis plugin to use ohpc-provided scripts for analyzing ELF dependencies. These only get triggered for files installed into the `%{OHPC_HOME}` path.  This is one potential approach intended to avoid namespace collision with library .so's of the same name that might come from the underlying OS or other package repos (the example discussed in TSC meetings was `openblas`). 

In this approach, an additional color of `(ohpc)` is appended to relevant Provides and Requires dependencies if the .so is housed within `%{OHPC_HOME}`.

