### PR TITLE
admin/ohpc-filesystem: update rpm dependency config to provide defaul…

### DIFF
--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -91,6 +91,7 @@ Requires:      llvm-compilers%{PROJ_DELIM}
 
 %endif
 
+# Disable RPM symlink analysis on files in %{OHPC_HOME}. 
 %global __libsymlink_exclude_path  %{OHPC_HOME}/.*$
 
 # MPI dependencies

--- a/components/admin/ohpc-filesystem/SOURCES/ohpc-find-requires
+++ b/components/admin/ohpc-filesystem/SOURCES/ohpc-find-requires
@@ -24,8 +24,14 @@ if [ ! -d "$buildroot" ]; then
     exit 1
 fi
 
-# Second argument is top-level search path
+# Second argument is default search path; if provided, 3rd argument is
+# path from %{OHPC_HOME} which overrides default (although it is the
+# same path for canonical ohpc builds).
 searchPath="$2"
+if [ $numArgs -gt 2 ];then
+    searchPath="$3"
+fi
+
 if [ -z "$searchPath" ];then
     >&2echo "Required search path argument not provided"
     exit 1

--- a/components/admin/ohpc-filesystem/SOURCES/ohpc.attr
+++ b/components/admin/ohpc-filesystem/SOURCES/ohpc.attr
@@ -1,7 +1,7 @@
 %__ohpc_provides	/usr/lib/rpm/ohpc-find-provides
-%__ohpc_requires 	/usr/lib/rpm/ohpc-find-requires %{buildroot} %{OHPC_HOME}
-%__ohpc_path            ^%{OHPC_HOME}
-%__elf_exclude_path 	^%{OHPC_HOME}
+%__ohpc_requires 	/usr/lib/rpm/ohpc-find-requires %{buildroot} /opt/ohpc %{?OHPC_HOME}
+%__ohpc_path            ^%{!?OHPC_HOME:/opt/ohpc}
+%__elf_exclude_path 	^%{!?OHPC_HOME:/opt/ohpc}
 
 %__ohpc_magic    	^ELF (32|64)-bit.*$
 %__ohpc_flags    	magic_and_path


### PR DESCRIPTION
…t ohpc

path in cases where OHPC_HOME macro is not defined.

Signed-off-by: Karl W. Schulz <karl.w.schulz@intel.com>