### PR TITLE
admin/ohpc-filesystem: modified approach for creation of ohpc.attr fi…

### DIFF
--- a/components/admin/ohpc-filesystem/SOURCES/ohpc-find-requires
+++ b/components/admin/ohpc-filesystem/SOURCES/ohpc-find-requires
@@ -24,13 +24,8 @@ if [ ! -d "$buildroot" ]; then
     exit 1
 fi
 
-# Second argument is default search path; if provided, 3rd argument is
-# path from %{OHPC_HOME} which overrides default (although it is the
-# same path for canonical ohpc builds).
+# Second argument is default search path.
 searchPath="$2"
-if [ $numArgs -gt 2 ];then
-    searchPath="$3"
-fi
 
 if [ -z "$searchPath" ];then
     >&2echo "Required search path argument not provided"

--- a/components/admin/ohpc-filesystem/SOURCES/ohpc.attr
+++ b/components/admin/ohpc-filesystem/SOURCES/ohpc.attr
@@ -1,7 +1,0 @@
-%__ohpc_provides	/usr/lib/rpm/ohpc-find-provides
-%__ohpc_requires 	/usr/lib/rpm/ohpc-find-requires %{buildroot} /opt/ohpc %{?OHPC_HOME}
-%__ohpc_path            ^%{!?OHPC_HOME:/opt/ohpc}
-%__elf_exclude_path 	^%{!?OHPC_HOME:/opt/ohpc}
-
-%__ohpc_magic    	^ELF (32|64)-bit.*$
-%__ohpc_flags    	magic_and_path

--- a/components/admin/ohpc-filesystem/SPECS/ohpc-filesystem.spec
+++ b/components/admin/ohpc-filesystem/SPECS/ohpc-filesystem.spec
@@ -21,6 +21,7 @@ Source0: OHPC_setup_compiler
 Source1: OHPC_setup_mpi
 Source2: ohpc-find-requires
 Source3: ohpc-find-provides
+Source4: OHPC_macros
 
 BuildArch: noarch
 

--- a/components/admin/ohpc-filesystem/SPECS/ohpc-filesystem.spec
+++ b/components/admin/ohpc-filesystem/SPECS/ohpc-filesystem.spec
@@ -1,3 +1,15 @@
+#----------------------------------------------------------------------------bh-
+# This RPM .spec file is part of the OpenHPC project.
+#
+# It may have been modified from the default version supplied by the underlying
+# release package (if available) in order to apply patches, perform customized
+# build/install configurations, and supply additional files to support
+# desired integration conventions.
+#
+#----------------------------------------------------------------------------eh-
+
+%include %{_sourcedir}/OHPC_macros
+
 Name: ohpc-filesystem
 Version: 1.3
 Release: 1.ohpc
@@ -7,9 +19,8 @@ Group: ohpc/admin
 License: ASL 2.0
 Source0: OHPC_setup_compiler
 Source1: OHPC_setup_mpi
-Source2: ohpc.attr
-Source3: ohpc-find-requires
-Source4: ohpc-find-provides
+Source2: ohpc-find-requires
+Source3: ohpc-find-provides
 
 BuildArch: noarch
 
@@ -40,9 +51,20 @@ install -p -m 644 %{SOURCE0} $RPM_BUILD_ROOT/opt/ohpc/admin/ohpc
 install -p -m 644 %{SOURCE1} $RPM_BUILD_ROOT/opt/ohpc/admin/ohpc
 
 # rpm dependency plugins
-install -p -m 755 %{SOURCE2} $RPM_BUILD_ROOT/usr/lib/rpm/fileattrs
+install -p -m 755 %{SOURCE2} $RPM_BUILD_ROOT/usr/lib/rpm
 install -p -m 755 %{SOURCE3} $RPM_BUILD_ROOT/usr/lib/rpm
-install -p -m 755 %{SOURCE4} $RPM_BUILD_ROOT/usr/lib/rpm
+
+%{__mkdir_p} %{buildroot}/usr/lib/rpm/fileattrs/
+%{__cat} <<EOF > %{buildroot}//usr/lib/rpm/fileattrs/ohpc.attr
+%%__ohpc_provides        /usr/lib/rpm/ohpc-find-provides
+%%__ohpc_requires        /usr/lib/rpm/ohpc-find-requires %%{buildroot} %{OHPC_HOME}
+%%__ohpc_path            ^%{OHPC_HOME}
+%%__elf_exclude_path     ^%{OHPC_HOME}
+
+%%__ohpc_magic           ^ELF (32|64)-bit.*$
+%%__ohpc_flags           magic_and_path
+EOF
+
 
 %files
 %dir /opt/ohpc/


### PR DESCRIPTION
…le. Leverage OHPC_HOME macro at build time in ohpc-filesystem as opposed to using potentially undefined macros in .attr file. Follow up to #645.

Signed-off-by: Karl W. Schulz <karl.w.schulz@intel.com>