### PR TITLE
perf-tools/papi: bump version to v5.6.0 (#668)

### DIFF
--- a/components/perf-tools/papi/SPECS/papi.spec
+++ b/components/perf-tools/papi/SPECS/papi.spec
@@ -16,7 +16,7 @@
 
 Summary:   Performance Application Programming Interface
 Name:      %{pname}%{PROJ_DELIM}
-Version:   5.5.1
+Version:   5.6.0
 Release:   1%{?dist}
 License:   BSD
 Group:     %{PROJ_NAME}/perf-tools


### PR DESCRIPTION
Signed-off-by: Karl W. Schulz <karl@ices.utexas.edu>