### PR TITLE
Consistent UIDs/GIDs for slurm and munge

### DIFF
--- a/components/rms/munge/SPECS/munge.spec
+++ b/components/rms/munge/SPECS/munge.spec
@@ -146,10 +146,10 @@ rm -rf "$RPM_BUILD_ROOT"
 # karl.w.schulz@intel.com (9/10/18) - provide specific uid/gid to deal with 
 # possibility of getting alternate ownership within Warewulf
 /usr/bin/getent group munge >/dev/null 2>&1 || \
-  /usr/sbin/groupadd -r munge -g 200
+  /usr/sbin/groupadd -r munge -g 201
 /usr/bin/getent passwd munge >/dev/null 2>&1 || \
   /usr/sbin/useradd -c "MUNGE authentication service" \
-  -d "%{_sysconfdir}/munge" -g munge -s /bin/false -r munge -u 200
+  -d "%{_sysconfdir}/munge" -g munge -s /bin/false -r munge -u 201
 
 %post
 if [ ! -e %{_sysconfdir}/munge/munge.key -a -c /dev/urandom ]; then

--- a/components/rms/slurm/SPECS/slurm.spec
+++ b/components/rms/slurm/SPECS/slurm.spec
@@ -1083,9 +1083,13 @@ mkdir -p $RPM_BUILD_ROOT/%{_docdir}
 #    fi
 #fi
 
-getent passwd slurm >/dev/null || \
-    /usr/sbin/useradd -U -c "SLURM resource manager" \
-    -s /sbin/nologin -r -d %{_sysconfdir} slurm
+# provide specific uid/gid to ensure that it is the same across the cluster
+/usr/bin/getent group slurm >/dev/null 2>&1 || \
+  /usr/sbin/groupadd -r slurm -g 202
+/usr/bin/getent passwd slurm >/dev/null 2>&1 || \
+  /usr/sbin/useradd -c "SLURM resource manager" \
+  -d %{_sysconfdir} -g slurm -s /bin/nologin -r slurm -u 202
+  
 exit 0
 
 %post


### PR DESCRIPTION
Resubmission of #642, see that discussion for additional information. 

Slurm and munge UID/GUIDs need to be consistent across the cluster. Munge already sets uid/guid of 200. This patch changes that to 201 (CentOS SYS_UID_MIN is 201) and sets slurm's to 202. 

xCAT stateful install has problems without this patch, because nodes and SMS end up with slurm ids being off by one, but this issue can come up in other contexts.

Signed-off-by: mhodak <mhodak@lenovo.com>