### PR TITLE
initial import of python34-build-patch

### DIFF
--- a/components/dev-tools/python34-build-patch/SOURCES/unixccompiler.patch
+++ b/components/dev-tools/python34-build-patch/SOURCES/unixccompiler.patch
@@ -1,0 +1,19 @@
+--- unixccompiler.py    2018-02-20 11:19:24.339194396 -0600
++++ unixccompiler.py~   2018-02-20 12:23:32.927930210 -0600
+@@ -80,16 +80,6 @@
+     if sys.platform == "cygwin":
+         exe_extension = ".exe"
+ 
+-    def _fix_lib_args(self, libraries, library_dirs, runtime_library_dirs):
+-        """Remove standard library path from rpath"""
+-        libraries, library_dirs, runtime_library_dirs = super(
+-            self.__class__, self)._fix_lib_args(libraries, library_dirs,
+-            runtime_library_dirs)
+-        libdir = sysconfig.get_config_var('LIBDIR')
+-        if runtime_library_dirs and (libdir in runtime_library_dirs):
+-            runtime_library_dirs.remove(libdir)
+-        return libraries, library_dirs, runtime_library_dirs
+-
+     def preprocess(self, source, output_file=None, macros=None,
+                    include_dirs=None, extra_preargs=None, extra_postargs=None):
+         fixed_args = self._fix_compile_args(None, macros, include_dirs)

--- a/components/dev-tools/python34-build-patch/SPECS/python34-build-patch.spec
+++ b/components/dev-tools/python34-build-patch/SPECS/python34-build-patch.spec
@@ -1,0 +1,80 @@
+#----------------------------------------------------------------------------bh-
+# This RPM .spec file is part of the OpenHPC project.
+#
+# It may have been modified from the default version supplied by the underlying
+# release package (if available) in order to apply patches, perform customized
+# build/install configurations, and supply additional files to support
+# desired integration conventions.
+#
+#----------------------------------------------------------------------------eh-
+
+%include %{_sourcedir}/OHPC_macros
+
+%global python_lib_path /usr/lib64/python3.4
+%global file_to_patch %{python_lib_path}/distutils/unixccompiler.py
+
+%define pname python34-build-patch
+
+Summary:   OpenHPC build package for python34 modules
+Name:      %{pname}%{PROJ_DELIM}
+Version:   0.1
+Release:   1
+License:   Apache-2.0
+URL:       https://github.com/openhpc/ohpc
+Group:     %{PROJ_NAME}/dev-tools
+BuildArch: x86_64
+Source1:   OHPC_macros
+Source2:   unixccompiler.patch
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+
+#!BuildIgnore: brp-check-suse
+#!BuildIgnore: post-build-checks
+
+Requires: patch
+
+Provides: %{pname}%{PROJ_DELIM}
+
+%description
+
+Reverts the patch https://src.fedoraproject.org/rpms/python3/blob/master/f/00001-rpath.patch
+to allow builds of numpy with Intel PSXE on RHEL-like systems.
+
+%prep
+
+%build
+
+%install
+
+install -D -m644 %{SOURCE2}  $RPM_BUILD_ROOT%{OHPC_ADMIN}/compat/python34-distutils-unixccompiler.patch
+
+%post
+
+if [ -f %{file_to_patch} ];then
+    echo "Patching %{file_to_patch}"
+    pushd %{python_lib_path}/distutils
+    patch -p0 < %{OHPC_ADMIN}/compat/python34-distutils-unixccompiler.patch
+    popd
+    exit 0
+else
+    echo "Unable to find %{file_to_patch}"
+    exit 1
+fi
+
+%preun
+
+if [ -f %{file_to_patch} ];then
+    echo "Reversing patch %{file_to_patch}"
+    pushd %{python_lib_path}
+    patch -R -p0 < %{OHPC_ADMIN}/compat/python34-distutils-unixccompiler.patch
+    popd
+    exit 0
+else
+    echo "Unable to find %{file_to_patch}"
+    exit 1
+fi
+
+
+%files
+%{OHPC_ADMIN}/compat/python34-distutils-unixccompiler.patch
+
+%changelog


### PR DESCRIPTION
A patch in the EPEL distribution of python3 (https://src.fedoraproject.org/rpms/python3/blob/master/f/00001-rpath.patch) causes numpy to fail at build time when using the Intel PSXE compilers on RHEL-like systems. This package contains a patch to revert that EPEL patch. Making this package a build requirement of numpy-intel-ohpc allows builds to complete successfully. 

Signed-off-by: Reese Baird <reese.baird@intel.com>