### PR TITLE
macros for OHPC-style builds of multiple python flavored packages from a single spec

### DIFF
--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -35,9 +35,9 @@
 DocDir:    %{OHPC_PUB}/doc/contrib
 
 %if 0%{?rhel} == 7
-	# OBS define's rhel_version to 700 for RHEL, in case we are
-	# not running in OBS
-	%global rhel_version 700
+    # OBS define's rhel_version to 700 for RHEL, in case we are
+    # not running in OBS
+    %global rhel_version 700
 %endif
 
 # OpenHPC packages require ohpc-filesystem which defines the basic
@@ -59,6 +59,7 @@ BuildRequires: ohpc-buildroot
 
 %{!?compiler_family: %global compiler_family gnu7}
 %{!?mpi_family: %global mpi_family openmpi3}
+%{!?python_family: %global python_family python3}
 
 # Compiler dependencies
 %if 0%{?ohpc_compiler_dependent} == 1
@@ -115,9 +116,32 @@ Requires:      openmpi3-%{compiler_family}%{PROJ_DELIM}
 %endif
 %endif
 
+# Python dependencies and macros
+%if 0%{?ohpc_python_dependent} == 1
+%if "%{python_family}" == "python3"
+%global __python %__python3
+%global python_lib_dir python3.4
+%if "%{rhel_version}" == "700"
+%global python_prefix python34
+%endif
+%if 0%{?suse_version}
+%global python_prefix python3
+%endif
+%endif
+%if "%{python_family}" == "python2"
+%global python_lib_dir python2.7
+%global python_prefix python
+%endif
+BuildRequires: %{python_prefix}-devel
+BuildRequires: %{python_prefix}-setuptools
+BuildRequires: python-rpm-macros
+Requires:      %{python_prefix}
+%endif
+
 %global ohpc_setup_compiler %{expand:\
-	. %{OHPC_ADMIN}/ohpc/OHPC_setup_compiler %{compiler_family} \
-	%if 0%{?ohpc_mpi_dependent} == 1 \
-		. %{OHPC_ADMIN}/ohpc/OHPC_setup_mpi %{mpi_family} \
-	%endif \
+    . %{OHPC_ADMIN}/ohpc/OHPC_setup_compiler %{compiler_family} \
+    %if 0%{?ohpc_mpi_dependent} == 1 \
+        . %{OHPC_ADMIN}/ohpc/OHPC_setup_mpi %{mpi_family} \
+    %endif \
 }
+

--- a/components/rms/slurm/SPECS/slurm.spec
+++ b/components/rms/slurm/SPECS/slurm.spec
@@ -72,8 +72,6 @@ Source1:    OHPC_macros
 # Build with PAM by default on linux
 %bcond_without pam
 
-BuildRequires: gtk2-devel
-Requires: gtk2
 Requires: munge%{PROJ_DELIM}
 
 %{?systemd_requires}

--- a/components/rms/slurm/SPECS/slurm.spec
+++ b/components/rms/slurm/SPECS/slurm.spec
@@ -72,6 +72,8 @@ Source1:    OHPC_macros
 # Build with PAM by default on linux
 %bcond_without pam
 
+BuildRequires: gtk2-devel
+Requires: gtk2
 Requires: munge%{PROJ_DELIM}
 
 %{?systemd_requires}


### PR DESCRIPTION
This PR adds the notion of a python family similar to our compiler and mpi families to allow a single spec file to produce multiple rpms for both python2.7 and python3.4. It defaults to python3, and a _link file in OBS can be used to use python2 as an alternative.

Signed-off-by: Reese Baird <reese.baird@intel.com>