### PR TITLE
Updating pbspro x86_64 recipes to support munge

### DIFF
--- a/docs/recipes/install/centos7/x86_64/warewulf/pbspro/steps.tex
+++ b/docs/recipes/install/centos7/x86_64/warewulf/pbspro/steps.tex
@@ -151,6 +151,7 @@ repository, which is shipped with CentOS and is enabled by default.
 [sms](*\#*) (*\chrootinstall*) pbspro-execution-ohpc
 [sms](*\#*) perl -pi -e "s/PBS_SERVER=\S+/PBS_SERVER=${sms_name}/" $CHROOT/etc/pbs.conf
 [sms](*\#*) echo "PBS_LEAF_NAME=${sms_name}" >> /etc/pbs.conf
+[sms](*\#*) echo "PBS_AUTH_METHOD=munge" >> /etc/pbs.conf
 [sms](*\#*) chroot $CHROOT opt/pbs/libexec/pbs_habitat
 [sms](*\#*) perl -pi -e "s/\$clienthost \S+/\$clienthost ${sms_name}/" $CHROOT/var/spool/pbs/mom_priv/config
 [sms](*\#*) echo "\$usecp *:/home /home" >> $CHROOT/var/spool/pbs/mom_priv/config
@@ -200,13 +201,15 @@ repository, which is shipped with CentOS and is enabled by default.
 \input{common/nagios}
 
 \clearpage
+\paragraph{Add \mrsh{}}
+\input{common/mrsh}
+
 \paragraph{Add \Ganglia{} monitoring}
 \input{common/ganglia}
 
 \paragraph{Add \clustershell{}}
 \input{common/clustershell}
 
-%\clearpage
 \paragraph{Add \genders{}}
 \input{common/genders}
 
@@ -219,6 +222,7 @@ repository, which is shipped with CentOS and is enabled by default.
 %\clearpage
 \subsubsection{Import files} \label{sec:file_import}
 \input{common/import_ww_files}
+\input{common/import_ww_files_pbs.tex}
 \input{common/import_ww_files_ib_centos}
 \input{common/finalize_provisioning}
 \input{common/add_ww_hosts_intro}

--- a/docs/recipes/install/common/import_ww_files_pbs.tex
+++ b/docs/recipes/install/common/import_ww_files_pbs.tex
@@ -1,0 +1,8 @@
+\noindent To import the cryptographic key that is required by the {\em munge} authentication 
+library to be available on every host in the resource management pool, issue the following:
+
+% begin_ohpc_run
+\begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true]
+[sms](*\#*) wwsh file import /etc/munge/munge.key
+\end{lstlisting}
+% \end_ohpc_run

--- a/docs/recipes/install/common/mrsh.tex
+++ b/docs/recipes/install/common/mrsh.tex
@@ -1,9 +1,8 @@
 \mrsh{} is a secure remote shell utility, like ssh, which uses \MUNGE{} 
-for authentication and encryption. By using the \MUNGE{} installation used by 
-\SLURM{}, \mrsh{} provides shell access to systems using the same \MUNGE{} key 
-without having to track {ssh} keys. Like {ssh}, \mrsh{} provides a 
-remote copy command, {\em mrcp}, and can be used as a {\em rcmd} by {\em
-pdsh}. Example installation and configuration is as follows:
+for authentication and encryption. By using the \MUNGE{} package, \mrsh{} provides 
+shell access to systems using the same \MUNGE{} key  without having to track {ssh} keys. 
+Like {ssh}, \mrsh{} provides a  remote copy command, {\em mrcp}, and can be used as 
+a {\em rcmd} by {\em pdsh}. Example installation and configuration is as follows:
 
 %\clearpage
 % begin_ohpc_run

--- a/docs/recipes/install/common/pbspro_startup.tex
+++ b/docs/recipes/install/common/pbspro_startup.tex
@@ -15,7 +15,9 @@ resource management under \rms{}.
 % begin_ohpc_run
 % ohpc_comment_header Resource Manager Startup \ref{sec:rms_startup}
 \begin{lstlisting}[language=bash,keywords={}]
-# start pbspro daemons on master host
+# start munge and pbspro daemons on master host
+[sms](*\#*) systemctl enable munge
+[sms](*\#*) systemctl start munge
 [sms](*\#*) systemctl enable pbs
 [sms](*\#*) systemctl start pbs
 \end{lstlisting}

--- a/docs/recipes/install/sles12/x86_64/warewulf/pbspro/steps.tex
+++ b/docs/recipes/install/sles12/x86_64/warewulf/pbspro/steps.tex
@@ -125,6 +125,7 @@
 [sms](*\#*) (*\chrootinstall*) pbspro-execution-ohpc
 [sms](*\#*) perl -pi -e "s/PBS_SERVER=\S+/PBS_SERVER=${sms_name}/" $CHROOT/etc/pbs.conf
 [sms](*\#*) echo "PBS_LEAF_NAME=${sms_name}" >> /etc/pbs.conf
+[sms](*\#*) echo "PBS_AUTH_METHOD=munge" >> /etc/pbs.conf
 [sms](*\#*) chroot $CHROOT opt/pbs/libexec/pbs_habitat
 [sms](*\#*) perl -pi -e "s/\$clienthost \S+/\$clienthost ${sms_name}/" $CHROOT/var/spool/pbs/mom_priv/config
 [sms](*\#*) echo "\$usecp *:/home /home" >> $CHROOT/var/spool/pbs/mom_priv/config
@@ -183,6 +184,9 @@
 \input{common/nagios}
 
 \clearpage
+\paragraph{Add \mrsh{}}
+\input{common/mrsh}
+
 \paragraph{Add \Ganglia{} monitoring}
 \input{common/ganglia}
 
@@ -203,6 +207,7 @@
 %\clearpage
 \subsubsection{Import files} \label{sec:file_import}
 \input{common/import_ww_files}
+\input{common/import_ww_files_pbs.tex}
 \input{common/import_ww_files_ib_sles}
 \input{common/finalize_provisioning}
 \vspace*{0.8cm}


### PR DESCRIPTION
PBS Professional 14.1.x supports munge integration.

- Updating steps.tex for SLES and CentOS to include PBS_AUTH_METHOD variable, adding common/mrsh.tex, and common/import_ww_files_pbs.tex.
- Removed SLURM specific reference in common/mrsh.tex (not necessary to reference only SLURM)
- Updated common/pbspro_startup.tex to enable and start munge

Signed-off-by: Scott Suchyta <scott@altair.com>