### PR TITLE
Explicitly require SLURM to include hwloc support.

### DIFF
--- a/components/rms/slurm/SPECS/slurm.spec
+++ b/components/rms/slurm/SPECS/slurm.spec
@@ -11,6 +11,7 @@
 %include %{_sourcedir}/OHPC_macros
 %global _with_mysql  1
 %global _with_pmix --with-pmix=%{OHPC_ADMIN}/pmix
+%global _with_hwloc --with-hwloc
 
 %define pname slurm
 


### PR DESCRIPTION
This will find the base OS version, not the OpenHPC hwloc version.
If rebuilding SLURM RPMs and the base OS does not have hwloc-devel installed, SLURM will be built without hwloc support.  Adding the --with-hwloc forces a dependency on hwloc-devel.

Signed-off-by: Kevin Pedretti <ktpedre@sandia.gov>