### PR TITLE
Update geopm to 0.5.1

### DIFF
--- a/components/perf-tools/geopm/SPECS/geopm.spec
+++ b/components/perf-tools/geopm/SPECS/geopm.spec
@@ -23,7 +23,7 @@
 
 Name:          %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Summary:       Global Extensible Open Power Manager
-Version:       0.5.0
+Version:       0.5.1
 Release:       1
 License:       BSD-3-Clause
 Group:         %{PROJ_NAME}/parallel-libs


### PR DESCRIPTION
We published a hotfix for a few issues.  This patch updates the spec file to point to version 0.5.1.