### PR TITLE
Remove noatime from NFS mount options

### DIFF
--- a/docs/recipes/install/common/warewulf_chroot_customize_centos.tex
+++ b/docs/recipes/install/common/warewulf_chroot_customize_centos.tex
@@ -21,8 +21,8 @@ example configuration.
 [sms](*\#*) wwinit ssh_keys
 
 # Add NFS client mounts of /home and /opt/ohpc/pub to base image
-[sms](*\#*) echo "${sms_ip}:/home /home nfs nfsvers=3,nodev,nosuid,noatime 0 0" >> $CHROOT/etc/fstab
-[sms](*\#*) echo "${sms_ip}:/opt/ohpc/pub /opt/ohpc/pub nfs nfsvers=3,nodev,noatime 0 0" >> $CHROOT/etc/fstab
+[sms](*\#*) echo "${sms_ip}:/home /home nfs nfsvers=3,nodev,nosuid 0 0" >> $CHROOT/etc/fstab
+[sms](*\#*) echo "${sms_ip}:/opt/ohpc/pub /opt/ohpc/pub nfs nfsvers=3,nodev 0 0" >> $CHROOT/etc/fstab
 
 # Export /home and OpenHPC public packages from master server
 [sms](*\#*) echo "/home *(rw,no_subtree_check,fsid=10,no_root_squash)" >> /etc/exports

--- a/docs/recipes/install/common/warewulf_chroot_customize_sles.tex
+++ b/docs/recipes/install/common/warewulf_chroot_customize_sles.tex
@@ -16,8 +16,8 @@ example configuration.
 [sms](*\#*) wwinit ssh_keys
 
 # Add NFS client mounts of /home and /opt/ohpc/pub to base image
-[sms](*\#*) echo "${sms_ip}:/home /home nfs nfsvers=3,nodev,nosuid,noatime 0 0" >> $CHROOT/etc/fstab
-[sms](*\#*) echo "${sms_ip}:/opt/ohpc/pub /opt/ohpc/pub nfs nfsvers=3,nodev,noatime 0 0" >> $CHROOT/etc/fstab
+[sms](*\#*) echo "${sms_ip}:/home /home nfs nfsvers=3,nodev,nosuid 0 0" >> $CHROOT/etc/fstab
+[sms](*\#*) echo "${sms_ip}:/opt/ohpc/pub /opt/ohpc/pub nfs nfsvers=3,nodev 0 0" >> $CHROOT/etc/fstab
 
 # Export /home and OpenHPC public packages from master server
 [sms](*\#*) echo "/home *(rw,no_subtree_check,fsid=10,no_root_squash)" >> /etc/exports

--- a/docs/recipes/install/common/xcat_chroot_customize_centos.tex
+++ b/docs/recipes/install/common/xcat_chroot_customize_centos.tex
@@ -11,8 +11,8 @@ example configuration.
 % ohpc_comment_header Customize system configuration \ref{sec:master_customization}
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true]
 # Add NFS client mounts of /home and /opt/ohpc/pub to base image
-[sms](*\#*) echo "${sms_ip}:/home /home nfs nfsvers=3,nodev,nosuid,noatime 0 0" >> $CHROOT/etc/fstab
-[sms](*\#*) echo "${sms_ip}:/opt/ohpc/pub /opt/ohpc/pub nfs nfsvers=3,nodev,noatime 0 0" >> $CHROOT/etc/fstab
+[sms](*\#*) echo "${sms_ip}:/home /home nfs nfsvers=3,nodev,nosuid 0 0" >> $CHROOT/etc/fstab
+[sms](*\#*) echo "${sms_ip}:/opt/ohpc/pub /opt/ohpc/pub nfs nfsvers=3,nodev 0 0" >> $CHROOT/etc/fstab
 
 # Export /home and OpenHPC public packages from master server
 [sms](*\#*) echo "/home *(rw,no_subtree_check,fsid=10,no_root_squash)" >> /etc/exports

--- a/docs/recipes/install/common/xcat_stateful_customize_centos.tex
+++ b/docs/recipes/install/common/xcat_stateful_customize_centos.tex
@@ -15,9 +15,9 @@ that will be hosted by the {\em master} host in this  example configuration.
 
 # Create NFS client mounts of /home and /opt/ohpc/pub on compute hosts
 [sms](*\#*) psh compute echo \
-        "\""${sms_ip}:/home /home nfs nfsvers=3,nodev,nosuid,noatime 0 0"\"" \>\> /etc/fstab
+        "\""${sms_ip}:/home /home nfs nfsvers=3,nodev,nosuid 0 0"\"" \>\> /etc/fstab
 [sms](*\#*) psh compute echo \
-        "\""${sms_ip}:/opt/ohpc/pub /opt/ohpc/pub nfs nfsvers=3,nodev,noatime 0 0"\"" \>\> /etc/fstab
+        "\""${sms_ip}:/opt/ohpc/pub /opt/ohpc/pub nfs nfsvers=3,nodev 0 0"\"" \>\> /etc/fstab
 [sms](*\#*) psh compute systemctl restart nfs
 
 # Mount NFS shares


### PR DESCRIPTION
In commit 67141e1a30912ee852fceca40fc6d6a0b6f20b19 I, among other
things, added noatime to the NFS mount options.  However, it turns out
that the Linux NFS client, in fact, ignores any atime related mount
options, and instead unconditionally implements its own relaxed atime
semantics.  For more detauils, see
http://man7.org/linux/man-pages/man5/nfs.5.html .