### PR TITLE
msr-safe: comment out unknown kernel module macros

### DIFF
--- a/components/perf-tools/msr-safe/SPECS/msr-safe.spec
+++ b/components/perf-tools/msr-safe/SPECS/msr-safe.spec
@@ -33,14 +33,14 @@ Source5:        OHPC_macros
 DocDir:         %{OHPC_PUB}/doc/contrib
 Prefix:         %{_prefix}
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-BuildRequires:  %kernel_module_package_buildreqs
+#BuildRequires:  %kernel_module_package_buildreqs
 BuildRequires:  systemd
 %if 0%{?sles_version} || 0%{?suse_version}
 BuildRequires:  udev
 #!BuildIgnore: post-build-checks
 %endif
 
-%kernel_module_package default
+#%kernel_module_package default
 
 %description
 Allows safer access to model specific registers (MSRs)


### PR DESCRIPTION
Not sure if this is correct, but those macros are undefined and the
lustre SPEC has them also commented out.

Signed-off-by: Adrian Reber <areber@redhat.com>