### PR TITLE
Fix adios python dependencies and build_order script

### DIFF
--- a/components/io-libs/adios/SPECS/adios.spec
+++ b/components/io-libs/adios/SPECS/adios.spec
@@ -11,6 +11,7 @@
 # Build that is dependent on compiler/mpi toolchains
 %define ohpc_compiler_dependent 1
 %define ohpc_mpi_dependent 1
+%define ohpc_python_dependent 1
 %include %{_sourcedir}/OHPC_macros
 
 %{!?with_lustre: %global with_lustre 0}
@@ -51,7 +52,7 @@ BuildRequires: python-devel
 BuildRequires: lustre-lite
 Requires: lustre-client%{PROJ_DELIM}
 %endif
-BuildRequires: python-numpy-%{compiler_family}%{PROJ_DELIM}
+BuildRequires: %{python_prefix}-numpy-%{compiler_family}%{PROJ_DELIM}
 
 
 %if 0%{?sles_version} || 0%{?suse_version}

--- a/misc/build_order.sh
+++ b/misc/build_order.sh
@@ -38,7 +38,7 @@ fi
 for i in `find . -name *.spec`; do
 	SPEC=`basename ${i}`
 	SOURCES="`dirname ${i}`/../SOURCES"
-	NAMES=`rpmspec -q ${i} --queryformat '%{name}:' 2> /dev/null`
+	NAMES=`rpmspec -q ${i} "${FLAGS[@]}" --queryformat '%{name}:' 2> /dev/null`
 	# Let's hope the first name is the right one
 	NAME=`echo ${NAMES} | cut -d: -f1`
 	REQ=`rpmspec -q ${i} "${FLAGS[@]}" --requires 2> /dev/null`


### PR DESCRIPTION
The build_order script stumbled about an unversioned python dependency in adios. This tries to fix this.