### PR TITLE
Replaces INCLUDE with CPATH in the module files of all libraries providing headers.

### DIFF
--- a/components/dev-tools/python/SPECS/python.spec
+++ b/components/dev-tools/python/SPECS/python.spec
@@ -293,7 +293,7 @@ set             version         %{version}
 prepend-path    PATH                %{install_path}/bin
 prepend-path    PYTHONPATH          %{install_path}/lib/python2.7:%{install_path}/lib/python2.7/lib-dynload:/usr/lib64/python2.7/site-packages:/usr/lib/python2.7/site-packages
 prepend-path    MANPATH             %{install_path}/share/man
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path    LD_LIBRARY_PATH     %{install_path}/lib
 
 setenv          PYTHONHOME          %{install_path}

--- a/components/io-libs/adios/SPECS/adios.spec
+++ b/components/io-libs/adios/SPECS/adios.spec
@@ -211,7 +211,7 @@ set             version             %{version}
 depends-on phdf5
 
 prepend-path    PATH                %{install_path}/bin
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path    LD_LIBRARY_PATH     %{install_path}/lib
 prepend-path	PYTHONPATH          %{install_path}/python/lib64/python2.7/site-packages
 

--- a/components/io-libs/hdf5/SPECS/hdf5.spec
+++ b/components/io-libs/hdf5/SPECS/hdf5.spec
@@ -124,7 +124,7 @@ module-whatis "%{url}"
 set     version			    %{version}
 
 prepend-path    PATH                %{install_path}/bin
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path	LD_LIBRARY_PATH	    %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/io-libs/netcdf-CXX/SPECS/netcdf-cxx4.spec
+++ b/components/io-libs/netcdf-CXX/SPECS/netcdf-cxx4.spec
@@ -156,7 +156,7 @@ set             version             %{version}
 
 prepend-path    PATH                %{install_path}/bin
 prepend-path    MANPATH             %{install_path}/share/man
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path    LD_LIBRARY_PATH     %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/io-libs/netcdf/SPECS/netcdf.spec
+++ b/components/io-libs/netcdf/SPECS/netcdf.spec
@@ -160,7 +160,7 @@ depends-on phdf5
 
 prepend-path    PATH                %{install_path}/bin
 prepend-path    MANPATH             %{install_path}/share/man
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path    LD_LIBRARY_PATH     %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/io-libs/phdf5/SPECS/hdf5.spec
+++ b/components/io-libs/phdf5/SPECS/hdf5.spec
@@ -131,7 +131,7 @@ module-whatis "%{url}"
 set     version			    %{version}
 
 prepend-path    PATH                %{install_path}/bin
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path	LD_LIBRARY_PATH	    %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/io-libs/pnetcdf/SPECS/pnetcdf.spec
+++ b/components/io-libs/pnetcdf/SPECS/pnetcdf.spec
@@ -100,7 +100,7 @@ set     version                     %{version}
 
 prepend-path    PATH                %{install_path}/bin
 prepend-path    MANPATH             %{install_path}/share/man
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path    PKG_CONFIG_PATH     %{install_path}/lib/pkgconfig
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/io-libs/sionlib/SPECS/sionlib.spec
+++ b/components/io-libs/sionlib/SPECS/sionlib.spec
@@ -121,7 +121,7 @@ set     version			    %{version}
 
 prepend-path    PATH                %{install_path}/bin
 prepend-path    MANPATH             %{install_path}/share/man
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path	LD_LIBRARY_PATH	    %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/parallel-libs/boost/SPECS/boost.spec
+++ b/components/parallel-libs/boost/SPECS/boost.spec
@@ -172,7 +172,7 @@ set             version             %{version}
 
 prepend-path    PATH                %{install_path}/bin
 prepend-path    MANPATH             %{install_path}/share/man
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path    LD_LIBRARY_PATH     %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/parallel-libs/fftw/SPECS/fftw.spec
+++ b/components/parallel-libs/fftw/SPECS/fftw.spec
@@ -98,7 +98,7 @@ set     version			    %{version}
 
 prepend-path    PATH                %{install_path}/bin
 prepend-path    MANPATH             %{install_path}/share/man
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path	LD_LIBRARY_PATH	    %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/parallel-libs/hypre/SPECS/hypre.spec
+++ b/components/parallel-libs/hypre/SPECS/hypre.spec
@@ -212,7 +212,7 @@ if { ![is-loaded intel] } {
 }
 
 prepend-path    PATH                %{install_path}/bin
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path    LD_LIBRARY_PATH     %{install_path}/lib
 prepend-path    LD_LIBRARY_PATH     %{MKLROOT}/lib/intel64
 

--- a/components/parallel-libs/mfem/SPECS/mfem.spec
+++ b/components/parallel-libs/mfem/SPECS/mfem.spec
@@ -137,7 +137,7 @@ depends-on petsc
 depends-on superlu_dist
 
 prepend-path    PATH                %{install_path}/bin
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path    LD_LIBRARY_PATH     %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/parallel-libs/mumps/SPECS/mumps.spec
+++ b/components/parallel-libs/mumps/SPECS/mumps.spec
@@ -192,7 +192,7 @@ if { ![is-loaded intel] } {
 }
 
 prepend-path    PATH                %{install_path}/bin
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path    LD_LIBRARY_PATH     %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/parallel-libs/petsc/SPECS/petsc.spec
+++ b/components/parallel-libs/petsc/SPECS/petsc.spec
@@ -140,7 +140,7 @@ if { ![is-loaded intel] } {
 }
 
 prepend-path    PATH                %{install_path}/bin
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path    LD_LIBRARY_PATH     %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/parallel-libs/scotch/SPECS/ptscotch.spec
+++ b/components/parallel-libs/scotch/SPECS/ptscotch.spec
@@ -129,7 +129,7 @@ set     version			    %{version}
 
 prepend-path    PATH                %{install_path}/bin
 prepend-path    MANPATH             %{install_path}/share/man
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path	LD_LIBRARY_PATH	    %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/parallel-libs/slepc/SPECS/slepc.spec
+++ b/components/parallel-libs/slepc/SPECS/slepc.spec
@@ -119,7 +119,7 @@ set     version             %{version}
 
 depends-on petsc
 
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path    LD_LIBRARY_PATH     %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/parallel-libs/superlu_dist/SPECS/superlu_dist.spec
+++ b/components/parallel-libs/superlu_dist/SPECS/superlu_dist.spec
@@ -148,7 +148,7 @@ depends-on metis
 depends-on ptscotch
 
 prepend-path    PATH                %{install_path}/bin
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path    LD_LIBRARY_PATH     %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/parallel-libs/trilinos/SPECS/trilinos.spec
+++ b/components/parallel-libs/trilinos/SPECS/trilinos.spec
@@ -194,7 +194,7 @@ module-whatis "URL %{url}"
 set     version                     %{version}
 
 prepend-path    PATH                %{install_path}/bin
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path    LD_LIBRARY_PATH     %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/perf-tools/dimemas/SPECS/dimemas.spec
+++ b/components/perf-tools/dimemas/SPECS/dimemas.spec
@@ -97,7 +97,7 @@ set     version			    %{version}
 
 prepend-path    PATH                %{install_path}/bin
 prepend-path    MANPATH             %{install_path}/share/man
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path	LD_LIBRARY_PATH	    %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/perf-tools/extrae/SPECS/extrae.spec
+++ b/components/perf-tools/extrae/SPECS/extrae.spec
@@ -109,7 +109,7 @@ depends-on papi
 
 prepend-path    PATH                %{install_path}/bin
 prepend-path    MANPATH             %{install_path}/share/man
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path	LD_LIBRARY_PATH	    %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/perf-tools/geopm/SPECS/geopm.spec
+++ b/components/perf-tools/geopm/SPECS/geopm.spec
@@ -122,7 +122,7 @@ set     version             %{version}
 
 prepend-path    PATH                %{install_path}/bin
 prepend-path    PYTHONPATH          %{install_path}/lib/python2.7/site-packages
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path    LD_LIBRARY_PATH     %{install_path}/lib
 prepend-path    MANPATH             %{install_path}/share/man
 

--- a/components/perf-tools/likwid/SPECS/likwid.spec
+++ b/components/perf-tools/likwid/SPECS/likwid.spec
@@ -110,7 +110,7 @@ set     version                     %{version}
 
 prepend-path    PATH                %{install_path}/bin
 prepend-path    MANPATH             %{install_path}/man
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path    LD_LIBRARY_PATH     %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/perf-tools/papi/SPECS/papi.spec
+++ b/components/perf-tools/papi/SPECS/papi.spec
@@ -87,7 +87,7 @@ set     version                     %{version}
 
 prepend-path    PATH                %{install_path}/bin
 prepend-path    MANPATH             %{install_path}/share/man
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path    LD_LIBRARY_PATH     %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/perf-tools/paraver/SPECS/wxparaver.spec
+++ b/components/perf-tools/paraver/SPECS/wxparaver.spec
@@ -109,7 +109,7 @@ set     version			    %{version}
 
 prepend-path    PATH                %{install_path}/bin
 prepend-path    MANPATH             %{install_path}/share/man
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path	LD_LIBRARY_PATH	    %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/perf-tools/pdtoolkit/SPECS/pdtoolkit.spec
+++ b/components/perf-tools/pdtoolkit/SPECS/pdtoolkit.spec
@@ -156,7 +156,7 @@ set     version                     %{version}
 
 prepend-path    PATH                %{install_path}/%{arch_dir}/bin
 prepend-path    MANPATH             %{install_path}/man
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path    LD_LIBRARY_PATH     %{install_path}/%{arch_dir}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/perf-tools/scorep/SPECS/scorep.spec
+++ b/components/perf-tools/scorep/SPECS/scorep.spec
@@ -146,7 +146,7 @@ depends-on sionlib
 
 prepend-path    PATH                %{install_path}/bin
 prepend-path    MANPATH             %{install_path}/share/man
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path	LD_LIBRARY_PATH	    %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/perf-tools/tau/SPECS/tau.spec
+++ b/components/perf-tools/tau/SPECS/tau.spec
@@ -270,7 +270,7 @@ set     version                     %{version}
 
 prepend-path    PATH                %{install_path}/bin
 prepend-path    MANPATH             %{install_path}/man
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path    LD_LIBRARY_PATH     %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/rms/pmix/SPECS/pmix.spec
+++ b/components/rms/pmix/SPECS/pmix.spec
@@ -72,7 +72,7 @@ module-whatis "Version: %{version}"
 set     version                     %{version}
 
 prepend-path    MANPATH             %{install_path}/share/man
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path    LD_LIBRARY_PATH     %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/runtimes/ocr/SPECS/ocr.spec
+++ b/components/runtimes/ocr/SPECS/ocr.spec
@@ -131,7 +131,7 @@ module-whatis "%{url}"
 
 set             version		    %{version}
 
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path    LD_LIBRARY_PATH     %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}
@@ -171,7 +171,7 @@ module-whatis "%{url}"
 
 set             version		    %{version}
 
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path    LD_LIBRARY_PATH     %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/serial-libs/gsl/SPECS/gsl.spec
+++ b/components/serial-libs/gsl/SPECS/gsl.spec
@@ -84,7 +84,7 @@ set             version		    %{version}
 
 prepend-path    PATH                %{install_path}/bin
 prepend-path    MANPATH             %{install_path}/share/man
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path    LD_LIBRARY_PATH     %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/serial-libs/metis/SPECS/metis.spec
+++ b/components/serial-libs/metis/SPECS/metis.spec
@@ -100,7 +100,7 @@ module-whatis "%{url}"
 set     version			    %{version}
 
 prepend-path    PATH                %{install_path}/bin
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path	LD_LIBRARY_PATH	    %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/serial-libs/openblas/SPECS/openblas.spec
+++ b/components/serial-libs/openblas/SPECS/openblas.spec
@@ -134,7 +134,7 @@ module-whatis "%{url}"
 set     version             %{version}
 
 prepend-path    PATH                %{install_path}/bin
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path    LD_LIBRARY_PATH     %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/serial-libs/plasma/SPECS/plasma.spec
+++ b/components/serial-libs/plasma/SPECS/plasma.spec
@@ -159,7 +159,7 @@ if { ![is-loaded intel] } {
 
 prepend-path    PATH                %{install_path}/bin
 prepend-path    MANPATH             %{install_path}/share/man
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path	LD_LIBRARY_PATH	    %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/serial-libs/scotch/SPECS/scotch.spec
+++ b/components/serial-libs/scotch/SPECS/scotch.spec
@@ -114,7 +114,7 @@ set     version			    %{version}
 
 prepend-path    PATH                %{install_path}/bin
 prepend-path    MANPATH             %{install_path}/share/man
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path	LD_LIBRARY_PATH	    %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}

--- a/components/serial-libs/superlu/SPECS/superlu.spec
+++ b/components/serial-libs/superlu/SPECS/superlu.spec
@@ -122,7 +122,7 @@ if { ![is-loaded intel] } {
 }
 
 
-prepend-path    INCLUDE             %{install_path}/include
+prepend-path    CPATH               %{install_path}/include
 prepend-path    LD_LIBRARY_PATH     %{install_path}/lib
 
 setenv          %{PNAME}_DIR        %{install_path}


### PR DESCRIPTION
The module files for nearly all libraries set the wrong environment variable `INCLUDE` for the `include`-directory containing the header files.

The point is, that no compiler actually uses that variable.

Instead, `gcc` and `llvm` for instance use the following three variables:
1. `CPATH`
    Paths given via this variable apply to all supported languages and are appended at the end after all paths given via `-I`.
2. `C_INCLUDE_PATH`
    Paths given via this variable apply to `C` only and are appended at the end after all paths given via `-isystem`, which are processed after all paths given via `-I`.
3. `CPLUS_INCLUDE_PATH`
    This variable is the same as above, but for `C++`.

The question now is: What was the initial intention when that code was written?
- Did you want to bring the headers to a common path which could be included easily?
Because in this case, it is necessary to strip the colons out of `$INCLUDE` and replace them with multiple `-I`.
So people need something like
    ```bash
    INCPATHS="-I ${INCLUDE//:/ -I }"
    ```
    to get a proper command line for `gcc`.
- Since the first point is documented nowhere, I believe the intention was to bring the headers to a common path which the compiler searches by default.
In that case, the current situation is a bug and `INCLUDE` should be replaced by the appropriate of the variables above.

I used `CPATH` as the appropriate variable, so one has not to step down what is C++ and what is C.

I did not change the spec `.../components/io-libs/netcdf-Fortran/SPECS/netcdf-fortran.spec` because it is Fortran and there is no `CPATH`-alternative for that language.
I am not sure, whether I may have overlooked some other libraries which are actually Fortran rather than C/C++.

Also, I did not change the spec `.../components/compiler-families/gnu-compilers/SPECS/gnu-compilers.spec`.
`gcc` knows where its own headers are located, so they should not be part of `CPATH`.
In this case, I think one could delete the line prepending `gcc`'s include directory to `INCLUDE` entirely.
Nobody is ever going to make use of this.

However, this was just the first step.

Note, that there is also a variable called `LIBRARY_PATH` which points to directories with static libraries which would otherwise be added to the linker command via multiple `-L` switches.

My impression of environment modules is, that developers compiling their code on the head node before running it on compute nodes do not have to know that header files and libraries are located at some awkward paths such as `/opt/ohpc/pub/utils/valgrind/3.13.0/lib/valgrind/`.
They should be able to just write `include "..."` in their code and use `-l` switches on their linker commands with the compiler finding the appropriate files on its own.

Right now, developers have to know some specific paths, because for instance the static library `libcoregrind-amd64-linux.a` is only available under the path above and there is no dynamic version of it.

So, is there a specific reason, why `LIBRARY_PATH` is missing?
Right now, only EasyBuild is setting it, but it does not seem to be necessary.
At the same time sionlib, scorep, autotools and valgrind have static libraries without `LIBRARY_PATH` set.
As before, `gcc` has static libraries but does not need the variable.
`gcc` knows, where its libraries are.

Should I change this, too and create a new pull request?

Best regards
Wolfgang