### PR TITLE
OpenHPC 1.3.6 spack config suggestion

### DIFF
--- a/components/dev-tools/spack/SPECS/spack.spec
+++ b/components/dev-tools/spack/SPECS/spack.spec
@@ -56,7 +56,11 @@ Most importantly, Spack is simple. It offers a simple spec syntax so that users 
 
 %install
 mkdir -p %{buildroot}%{install_path}
+mkdir -p %{buildroot}%{spack_install_path}
 rsync -av --exclude=.gitignore {etc,bin,lib,var,share,templates} %{buildroot}%{install_path}
+
+sed -i "s@    tcl:.*@    tcl: %{OHPC_MODULES}/spack@" %{buildroot}%{install_path}/etc/spack/defaults/config.yaml
+sed -i "s@  install_tree:.*@  install_tree: %{spack_install_path}@" %{buildroot}%{install_path}/etc/spack/defaults/config.yaml
 
 # OpenHPC module file
 %{__mkdir} -p %{buildroot}/%{OHPC_ADMIN}/modulefiles/spack
@@ -79,8 +83,8 @@ EOF
 
 %{__mkdir} -p %{buildroot}/%{_docdir}
 
-%post
-sed -i 's/  install_tree:.*/  install_tree:%{spack_install_path}/' %{install_path}/etc/defaults/config.yaml
+#%post
+#sed -i "s/  install_tree:.*/  install_tree:%{spack_install_path}/" %{install_path}/etc/defaults/config.yaml
 
 %clean
 rm -rf $RPM_BUILD_ROOT

--- a/components/dev-tools/spack/SPECS/spack.spec
+++ b/components/dev-tools/spack/SPECS/spack.spec
@@ -41,7 +41,7 @@ Requires: python2-mock
 DocDir:    %{OHPC_PUB}/doc/contrib
 
 %global install_path %{OHPC_ADMIN}/%{pname}/%version
-%global package_install_path %{OHPC_PUB}/%{pname}/%version
+%define spack_install_path %{OHPC_PUB}/%{pname}/%version
 # Turn off the brp-python-bytecompile script
 %global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
 
@@ -80,7 +80,7 @@ EOF
 %{__mkdir} -p %{buildroot}/%{_docdir}
 
 %post
-sed -i 's/  install_tree:.*/  install_tree:%{package_install_path}/' %{install_path}/etc/defaults/config.yaml
+sed -i 's/  install_tree:.*/  install_tree:%{spack_install_path}/' %{install_path}/etc/defaults/config.yaml
 
 %clean
 rm -rf $RPM_BUILD_ROOT

--- a/components/dev-tools/spack/SPECS/spack.spec
+++ b/components/dev-tools/spack/SPECS/spack.spec
@@ -83,9 +83,6 @@ EOF
 
 %{__mkdir} -p %{buildroot}/%{_docdir}
 
-#%post
-#sed -i "s/  install_tree:.*/  install_tree:%{spack_install_path}/" %{install_path}/etc/defaults/config.yaml
-
 %clean
 rm -rf $RPM_BUILD_ROOT
 %files

--- a/components/dev-tools/spack/SPECS/spack.spec
+++ b/components/dev-tools/spack/SPECS/spack.spec
@@ -41,6 +41,7 @@ Requires: python2-mock
 DocDir:    %{OHPC_PUB}/doc/contrib
 
 %global install_path %{OHPC_ADMIN}/%{pname}/%version
+%global package_install_path %{OHPC_PUB}/%{pname}/%version
 # Turn off the brp-python-bytecompile script
 %global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
 
@@ -77,6 +78,9 @@ prepend-path   MODULEPATH   %{install_path}/modules
 EOF
 
 %{__mkdir} -p %{buildroot}/%{_docdir}
+
+%post
+sed -i 's/  install_tree:.*/  install_tree:%{package_install_path}/' %{install_path}/etc/defaults/config.yaml
 
 %clean
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
Just a couple of changes to the default Spack configuration, so that admins will be able to install user-accessible software without having to make changes to the spack config. 

## Addition of the spack\_install\_path variable
Allows for Spack to create packages in a publicly-accessible
location by default. Currently 'spack install foo' results 
in foo being installed under `/opt/ohpc/admin/...`, which is 
inaccessible to users.
Modified in the %install section via
```
sed -i "s@  install_tree:.*@  install_tree: %{spack_install_path}@" %{buildroot}%{install_path}/etc/spack/defaults/config.yaml
```
(sed takes any delimiter - '@' doesn't conflict with path specification)

## Modifications to the default spack module install path
Installing modulefiles under default OHPC tree for now, with a spack
prefix - something like the 
below may be more appropriate, however, to differentiate between those
built by spack, and those provided by OpenHPC.
Putting spack modules in a custom location would also require modification of the 
spack module, to add those to the modulepath.
```
sed -i "s@    tcl:.*@  tcl: %{spack_install_path}/modules/@" %{buildroot}%{install_path}/etc/spack/defaults/config.yaml
```

Just modifying tcl path for now; lmod is not enabled by default in spack currently...
 discussion about default module system ongoing in the spack project.
 (https://github.com/spack/spack/pull/5955)

Please let me know if this should've been raised as an issue first!