### PR TITLE
travis: configure travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: required
+language: c
+env:
+  - TEST=check_spec
+services:
+  - docker
+script:
+  - sudo docker build -t ohpc.${TEST} -f tests/travis/Dockerfile.${TEST} --build-arg TRAVIS_COMMIT_RANGE=$TRAVIS_COMMIT_RANGE .

--- a/tests/travis/.gitignore
+++ b/tests/travis/.gitignore
@@ -1,0 +1,1 @@
+!Makefile

--- a/tests/travis/Dockerfile.check_spec
+++ b/tests/travis/Dockerfile.check_spec
@@ -1,0 +1,13 @@
+FROM centos:7
+
+ARG TRAVIS_COMMIT_RANGE
+ENV TRAVIS_COMMIT_RANGE=$TRAVIS_COMMIT_RANGE
+ENV PYTHON_BINARY=python36
+
+RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN yum install -y git ${PYTHON_BINARY}
+
+COPY . /ohpc
+WORKDIR /ohpc
+
+RUN ${PYTHON_BINARY} tests/travis/check_spec.py ${TRAVIS_COMMIT_RANGE}

--- a/tests/travis/check_spec.py
+++ b/tests/travis/check_spec.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python3
+
+# this script needs at least python 3.5 for
+# subprocess.run()
+
+import re
+import subprocess
+import sys
+
+regex_wrong = [
+    # make sure there is no Source999
+    '^Source999.*$',
+    # make sure OHPC_macros is not listed
+    '^Source.*OHPC_macros$',
+    # make sure there is no %changelog
+    '^%changelog.*',
+    # make sure there is no DocDir
+    '^DocDir.*',
+    # make sure there is no BuildRoot
+    '^BuildRoot.*',
+    # make sure there is no %defattr(-,root,root)
+    '^%defattr\(-,root,root\).*',
+    ]
+
+if len(sys.argv) != 2:
+    print("SKIP. Needs a git range as parameter")
+    sys.exit(0)
+
+command = ['git', 'diff', '--name-only', sys.argv[1]]
+
+print("About to run command %s" % ' '.join(command))
+
+result = subprocess.run(command, stdout=subprocess.PIPE)
+
+regex_wrong_string = '(' + '|'.join(regex_wrong) + ')'
+
+print("Checking that %s does not exist" % regex_wrong_string)
+
+pattern = re.compile(regex_wrong_string)
+
+if result.returncode != 0:
+    sys.exit(1)
+
+found = False
+spec_found = False
+
+for spec in result.stdout.decode('utf-8').split('\n'):
+    if not spec.endswith('.spec'):
+        continue
+    spec_found = True
+    with open(spec) as infile:
+        for line in infile:
+            if pattern.match(line):
+                print("Found %s in %s" % (line.rstrip(), spec))
+                found = True
+
+if not spec_found:
+    print("SKIP. Commit without changes to a SPEC file.")
+
+if found:
+    print("ERROR:Found an error in one of the SPEC files.")
+    sys.exit(1)
+
+print("No errors found. Exiting.")
+sys.exit(0)


### PR DESCRIPTION
Our initial travis test is a small python script which only looks at the
SPEC files of the pull request and checks if they include any lines we
do not need. Currently this includes:

 * '^Source999.*$' (That is reserved for OHPC_macros)
 * '^Source.*OHPC_macros$' (That is not necessary anymore)
 * '^%changelog.*' (We removed all changelogs)
 * '^DocDir.*' (Set by OHPC_macros)
 * '^BuildRoot.*' (Not necessary anymore)
 * '^%defattr\(-,root,root\).*' (Setting the default value is not necessary)

With this initial travis setup running we can easily include more and
more checks in the future.

Signed-off-by: Adrian Reber <areber@redhat.com>