### PR TITLE
OHPC_macros: set disttag to current branch name

### DIFF
--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -28,7 +28,7 @@
 %global OHPC_MPI_STACKS %{OHPC_PUB}/mpi
 %global OHPC_UTILS      %{OHPC_PUB}/utils
 %global debug_package   %{nil}
-%global dist            .ohpc
+%global dist            .ohpc.1.3.6
 
 %{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 


### PR DESCRIPTION
This sets the disttag to the current branch name. This replicates OBS's
behavior to append the current release string to the release.

Currently this is ".ohpc.1.3.6"

Signed-off-by: Adrian Reber <areber@redhat.com>