### PR TITLE
Build SLURM with numa and hwloc support.

### DIFF
--- a/components/rms/slurm/SPECS/slurm.spec
+++ b/components/rms/slurm/SPECS/slurm.spec
@@ -11,6 +11,8 @@
 %include %{_sourcedir}/OHPC_macros
 %global _with_mysql  1
 %global _with_pmix --with-pmix=%{OHPC_ADMIN}/pmix
+%global _with_hwloc 1
+%global _with_numa 1
 
 %define pname slurm
 


### PR DESCRIPTION
This is needed for SLURM's NUMA affinity features to work.

Signed-off-by: Kevin Pedretti <ktpedre@sandia.gov>