### PR TITLE
Define PNAME globally

### DIFF
--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -34,6 +34,9 @@
 
 DocDir:    %{OHPC_PUB}/doc/contrib
 
+# This actually does not work with %%global
+%define PNAME %(eval tr [a-z] [A-Z] <<< %{pname})
+
 # Instead of having Source[1-9]: OHPC_macros in every SPEC file,
 # this sets Source42 for all SPEC files which include OHPC_macros.
 Source42: OHPC_macros

--- a/components/admin/conman/SPECS/conman.spec
+++ b/components/admin/conman/SPECS/conman.spec
@@ -12,7 +12,6 @@
 
 # Base package name
 %define pname conman
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 
 Name:		%{pname}%{PROJ_DELIM}

--- a/components/admin/nagios-plugins/SPECS/nagios-plugins.spec
+++ b/components/admin/nagios-plugins/SPECS/nagios-plugins.spec
@@ -15,7 +15,6 @@
 
 # Base package name
 %define pname nagios-plugins
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 %global _hardened_build 1
 

--- a/components/admin/ndoutils/SPECS/ndoutils.spec
+++ b/components/admin/ndoutils/SPECS/ndoutils.spec
@@ -12,7 +12,6 @@
 
 # Base package name
 %define pname ndoutils
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Name:               %{pname}%{PROJ_DELIM}
 Version:            2.1.3

--- a/components/admin/nrpe/SPECS/nrpe.spec
+++ b/components/admin/nrpe/SPECS/nrpe.spec
@@ -12,7 +12,6 @@
 
 # Base package name
 %define pname nrpe
-%define PNAME %(tr [a-z] [A-Z] <<< %{pname})
 
 %if 0%{?fedora} > 19
 %global _hardened_build 1

--- a/components/dev-tools/easybuild/SPECS/easybuild.spec
+++ b/components/dev-tools/easybuild/SPECS/easybuild.spec
@@ -12,7 +12,6 @@
 
 # Base package name
 %define pname easybuild
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 %define vsc_base_ver 2.8.3
 %define vsc_install_ver 0.11.2

--- a/components/dev-tools/hwloc/SPECS/hwloc.spec
+++ b/components/dev-tools/hwloc/SPECS/hwloc.spec
@@ -11,7 +11,6 @@
 %include %{_sourcedir}/OHPC_macros
 
 %define pname hwloc
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Name:           %{pname}%{PROJ_DELIM}
 Version:        1.11.10

--- a/components/dev-tools/mpi4py/SPECS/python-mpi4py.spec
+++ b/components/dev-tools/mpi4py/SPECS/python-mpi4py.spec
@@ -21,7 +21,6 @@
 
 # Base package name
 %define pname mpi4py
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Name:           %{python_prefix}-%{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Version:        3.0.0

--- a/components/dev-tools/numpy/SPECS/python-numpy.spec
+++ b/components/dev-tools/numpy/SPECS/python-numpy.spec
@@ -20,7 +20,6 @@ Requires:      openblas-%{compiler_family}%{PROJ_DELIM}
 
 # Base package name
 %define pname numpy
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Name:           %{python_prefix}-%{pname}-%{compiler_family}%{PROJ_DELIM}
 Version:        1.15.0

--- a/components/dev-tools/python/SPECS/python.spec
+++ b/components/dev-tools/python/SPECS/python.spec
@@ -21,7 +21,7 @@ Version:        2.7.12
 Release:        70.1%{?dist}
 Summary:        Python Interpreter
 License:        Python-2.0
-Group:          Development/Languages/Python
+Group:          %{PROJ_NAME}/distro-packages
 Url:            http://www.python.org/
 %define         tarversion %{version}
 %define         tarname Python-%{tarversion}

--- a/components/dev-tools/python/SPECS/python.spec
+++ b/components/dev-tools/python/SPECS/python.spec
@@ -14,7 +14,6 @@
 
 # Base package name
 %define pname python
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Name:           %{pname}-%{compiler_family}%{PROJ_DELIM}
 Version:        2.7.12

--- a/components/dev-tools/scipy/SPECS/python-scipy.spec
+++ b/components/dev-tools/scipy/SPECS/python-scipy.spec
@@ -23,7 +23,6 @@ Requires: openblas-%{compiler_family}%{PROJ_DELIM}
 
 # Base package name
 %define pname scipy
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Name:           %{python_prefix}-%{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Version:        1.1.0

--- a/components/dev-tools/valgrind/SPECS/valgrind.spec
+++ b/components/dev-tools/valgrind/SPECS/valgrind.spec
@@ -11,7 +11,6 @@
 %include %{_sourcedir}/OHPC_macros
 
 %define pname valgrind
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Summary:   Valgrind Memory Debugger
 Name:      %{pname}%{PROJ_DELIM}

--- a/components/io-libs/adios/SPECS/adios.spec
+++ b/components/io-libs/adios/SPECS/adios.spec
@@ -18,7 +18,6 @@
 
 # Base package name
 %define pname adios
-%define PNAME %(tr [a-z] [A-Z] <<< %{pname})
 
 Summary: The Adaptable IO System (ADIOS)
 Name:    %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}

--- a/components/io-libs/hdf5/SPECS/hdf5.spec
+++ b/components/io-libs/hdf5/SPECS/hdf5.spec
@@ -14,7 +14,6 @@
 
 # Base package name
 %define pname hdf5
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Summary:   A general purpose library and file format for storing scientific data
 Name:      %{pname}-%{compiler_family}%{PROJ_DELIM}

--- a/components/io-libs/netcdf-CXX/SPECS/netcdf-cxx4.spec
+++ b/components/io-libs/netcdf-CXX/SPECS/netcdf-cxx4.spec
@@ -16,7 +16,6 @@
 # Base package name
 
 %define pname netcdf-cxx
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z] | tr - _)
 
 Name:           %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Summary:        C++ Libraries for the Unidata network Common Data Form

--- a/components/io-libs/netcdf-Fortran/SPECS/netcdf-fortran.spec
+++ b/components/io-libs/netcdf-Fortran/SPECS/netcdf-fortran.spec
@@ -16,7 +16,6 @@
 # Base package name
 
 %define pname netcdf-fortran
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z] | tr - _)
 
 Name:           %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Summary:        Fortran Libraries for the Unidata network Common Data Form

--- a/components/io-libs/netcdf/SPECS/netcdf.spec
+++ b/components/io-libs/netcdf/SPECS/netcdf.spec
@@ -16,7 +16,6 @@
 # Base package name
 
 %define pname netcdf
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 %define ncdf_so_major 7
 

--- a/components/io-libs/phdf5/SPECS/hdf5.spec
+++ b/components/io-libs/phdf5/SPECS/hdf5.spec
@@ -17,7 +17,6 @@
 
 # Base package name
 %define pname hdf5
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Summary:   A general purpose library and file format for storing scientific data
 Name:      p%{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}

--- a/components/io-libs/pnetcdf/SPECS/pnetcdf.spec
+++ b/components/io-libs/pnetcdf/SPECS/pnetcdf.spec
@@ -17,7 +17,6 @@
 
 # Base package name
 %define pname pnetcdf
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Summary:   A Parallel NetCDF library (PnetCDF)
 Name:      %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}

--- a/components/io-libs/sionlib/SPECS/sionlib.spec
+++ b/components/io-libs/sionlib/SPECS/sionlib.spec
@@ -15,7 +15,6 @@
 
 # Base package name
 %define pname sionlib
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Summary:   Scalable I/O Library for Parallel Access to Task-Local Files
 Name:      %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}

--- a/components/parallel-libs/boost/SPECS/boost.spec
+++ b/components/parallel-libs/boost/SPECS/boost.spec
@@ -18,7 +18,6 @@
 
 # Base package name
 %define pname boost
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Summary:	Boost free peer-reviewed portable C++ source libraries
 Name:		%{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}

--- a/components/parallel-libs/fftw/SPECS/fftw.spec
+++ b/components/parallel-libs/fftw/SPECS/fftw.spec
@@ -15,7 +15,6 @@
 
 # Base package name
 %define pname fftw
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 # Not building quad-precision because: "quad precision is not supported in MPI"
 %global precision_list single double long-double

--- a/components/parallel-libs/hypre/SPECS/hypre.spec
+++ b/components/parallel-libs/hypre/SPECS/hypre.spec
@@ -20,7 +20,6 @@ Requires:      openblas-%{compiler_family}%{PROJ_DELIM}
 
 # Base package name
 %define pname hypre
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Name:           %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Version:        2.14.0

--- a/components/parallel-libs/hypre/SPECS/hypre.spec
+++ b/components/parallel-libs/hypre/SPECS/hypre.spec
@@ -27,7 +27,7 @@ Version:        2.14.0
 Release:        1%{?dist}
 Summary:        Scalable algorithms for solving linear systems of equations
 License:        LGPL-2.1
-Group:          ohpc/parallel-libs
+Group:          %{PROJ_NAME}/parallel-libs
 Url:            http://www.llnl.gov/casc/hypre/
 Source:         https://github.com/LLNL/hypre/archive/v%{version}.tar.gz#/hypre-%{version}.tar.gz
 %if 0%{?suse_version} <= 1110

--- a/components/parallel-libs/mfem/SPECS/mfem.spec
+++ b/components/parallel-libs/mfem/SPECS/mfem.spec
@@ -16,7 +16,6 @@
 
 # Base package name
 %define pname mfem
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Name:           %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Summary:        Lightweight, general, scalable C++ library for finite element methods

--- a/components/parallel-libs/mumps/SPECS/mumps.spec
+++ b/components/parallel-libs/mumps/SPECS/mumps.spec
@@ -17,7 +17,6 @@
 
 # Base package name
 %define pname mumps
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Name:           %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Version:        5.1.2

--- a/components/parallel-libs/opencoarrays/SPECS/opencoarrays.spec
+++ b/components/parallel-libs/opencoarrays/SPECS/opencoarrays.spec
@@ -16,7 +16,6 @@
 
 # Base package name
 %define pname opencoarrays
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Name:           %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Summary:        ABI to leverage the parallel programming features of the Fortran 2018 DIS

--- a/components/parallel-libs/petsc/SPECS/petsc.spec
+++ b/components/parallel-libs/petsc/SPECS/petsc.spec
@@ -20,7 +20,6 @@ Requires:      scalapack-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 
 # Base package name
 %define pname petsc
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Name:           %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Summary:        Portable Extensible Toolkit for Scientific Computation

--- a/components/parallel-libs/scalapack/SPECS/scalapack.spec
+++ b/components/parallel-libs/scalapack/SPECS/scalapack.spec
@@ -20,7 +20,6 @@ Requires:      openblas-%{compiler_family}%{PROJ_DELIM}
 
 # Base package name
 %define pname scalapack
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Name:           %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Summary:        A subset of LAPACK routines redesigned for heterogenous computing

--- a/components/parallel-libs/scotch/SPECS/ptscotch.spec
+++ b/components/parallel-libs/scotch/SPECS/ptscotch.spec
@@ -16,7 +16,6 @@
 # Base package name
 %define base_pname scotch
 %define pname pt%{base_pname}
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Name:	%{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Version: 6.0.4

--- a/components/parallel-libs/slepc/SPECS/slepc.spec
+++ b/components/parallel-libs/slepc/SPECS/slepc.spec
@@ -21,7 +21,6 @@
 # Base package name
 
 %define pname slepc
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Name:           %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Version:        3.9.1

--- a/components/parallel-libs/superlu_dist/SPECS/superlu_dist.spec
+++ b/components/parallel-libs/superlu_dist/SPECS/superlu_dist.spec
@@ -15,7 +15,6 @@
 
 # Base package name
 %define pname superlu_dist
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 %define major   5
 %define libname libsuperlu_dist

--- a/components/parallel-libs/trilinos/SPECS/trilinos.spec
+++ b/components/parallel-libs/trilinos/SPECS/trilinos.spec
@@ -15,7 +15,6 @@
 
 # Base package name
 %define pname trilinos
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 %define ver_exp 12-12-1
 
 Name:           %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}

--- a/components/perf-tools/dimemas/SPECS/dimemas.spec
+++ b/components/perf-tools/dimemas/SPECS/dimemas.spec
@@ -15,7 +15,6 @@
 
 # Base package name
 %define pname dimemas
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Summary:	Dimemas tool
 Name:		%{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}

--- a/components/perf-tools/extrae/SPECS/extrae.spec
+++ b/components/perf-tools/extrae/SPECS/extrae.spec
@@ -15,7 +15,6 @@
 
 # Base package name
 %define pname extrae
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Summary:	Extrae tool
 Name:		%{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}

--- a/components/perf-tools/geopm/SPECS/geopm.spec
+++ b/components/perf-tools/geopm/SPECS/geopm.spec
@@ -15,7 +15,6 @@
 
 # Base package name
 %define pname geopm
-%define PNAME GEOPM
 
 # Install paths
 %define docdir %{OHPC_PUB}/doc/contrib/%{pname}-%{compiler_family}-%{mpi_family}-%{version}

--- a/components/perf-tools/imb/SPECS/imb.spec
+++ b/components/perf-tools/imb/SPECS/imb.spec
@@ -15,7 +15,6 @@
 
 # Base package name
 %define pname imb
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Summary:   Intel MPI Benchmarks (IMB)
 Name:      %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}

--- a/components/perf-tools/likwid/SPECS/likwid.spec
+++ b/components/perf-tools/likwid/SPECS/likwid.spec
@@ -15,7 +15,6 @@
 
 # Base package name
 %define pname likwid
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Summary:   Toolsuite of command line applications for performance oriented programmers
 Name:      %{pname}-%{compiler_family}%{PROJ_DELIM}

--- a/components/perf-tools/likwid/SPECS/likwid.spec
+++ b/components/perf-tools/likwid/SPECS/likwid.spec
@@ -32,7 +32,7 @@ BuildRequires: perl-Data-Dumper
 %define install_path %{OHPC_LIBS}/%{compiler_family}/%{pname}/%version
 
 %description
-LIKWID stands for “Like I Knew What I’m Doing.” It is an easy to use yet powerful
+LIKWID stands for "Like I Knew What I'm Doing." It is an easy to use yet powerful
 command line performance tool suite for the GNU/Linux operating system. While the
 focus of LIKWID is on x86 processors, some of the tools are portable and not
 limited to any specific architecture.

--- a/components/perf-tools/mpiP/SPECS/mpiP.spec
+++ b/components/perf-tools/mpiP/SPECS/mpiP.spec
@@ -27,7 +27,6 @@ Requires:      %{mpi_family}-gnu8%{PROJ_DELIM}
 
 # Base package name
 %define pname mpiP
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Summary:   mpiP: a lightweight profiling library for MPI applications.
 Name:      %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}

--- a/components/perf-tools/msr-safe/SPECS/msr-safe.spec
+++ b/components/perf-tools/msr-safe/SPECS/msr-safe.spec
@@ -14,7 +14,6 @@
 
 # Base package name
 %define pname msr-safe
-%define PNAME MSR-SAFE
 
 
 Name:           %{pname}%{PROJ_DELIM}

--- a/components/perf-tools/papi/SPECS/papi.spec
+++ b/components/perf-tools/papi/SPECS/papi.spec
@@ -12,7 +12,6 @@
 
 # Base package name
 %define pname papi
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Summary:   Performance Application Programming Interface
 Name:      %{pname}%{PROJ_DELIM}

--- a/components/perf-tools/paraver/SPECS/wxparaver.spec
+++ b/components/perf-tools/paraver/SPECS/wxparaver.spec
@@ -15,7 +15,6 @@
 
 # Base package name
 %define pname wxparaver
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Summary:	Paraver
 Name:		%{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}

--- a/components/perf-tools/pdtoolkit/SPECS/pdtoolkit.spec
+++ b/components/perf-tools/pdtoolkit/SPECS/pdtoolkit.spec
@@ -14,7 +14,6 @@
 
 # Base package name
 %define pname pdtoolkit
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Name: %{pname}-%{compiler_family}%{PROJ_DELIM}
 Version:        3.25

--- a/components/perf-tools/scalasca/SPECS/scalasca.spec
+++ b/components/perf-tools/scalasca/SPECS/scalasca.spec
@@ -15,7 +15,6 @@
 
 # Base package name
 %define pname scalasca
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Summary:   Toolset for performance analysis of large-scale parallel applications
 Name:      %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}

--- a/components/perf-tools/scalasca/SPECS/scalasca.spec
+++ b/components/perf-tools/scalasca/SPECS/scalasca.spec
@@ -38,8 +38,8 @@ BuildRequires: zlib-devel
 Scalasca is a software tool that supports the performance
 optimization of parallel programs by measuring and analyzing their
 runtime behavior. The analysis identifies potential performance
-bottlenecks – in particular those concerning communication and
-synchronization – and offers guidance in exploring their causes.
+bottlenecks - in particular those concerning communication and
+synchronization - and offers guidance in exploring their causes.
 
 Scalasca targets mainly scientific and engineering applications
 based on the programming interfaces MPI and OpenMP, including

--- a/components/perf-tools/scorep/SPECS/scorep.spec
+++ b/components/perf-tools/scorep/SPECS/scorep.spec
@@ -15,7 +15,6 @@
 
 # Base package name
 %define pname scorep
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Summary:   Scalable Performance Measurement Infrastructure for Parallel Codes
 Name:      %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}

--- a/components/perf-tools/tau/SPECS/tau.spec
+++ b/components/perf-tools/tau/SPECS/tau.spec
@@ -15,7 +15,6 @@
 
 # Base package name
 %define pname tau
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Name: %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 

--- a/components/rms/pmix/SPECS/pmix.spec
+++ b/components/rms/pmix/SPECS/pmix.spec
@@ -10,7 +10,6 @@
 
 %include %{_sourcedir}/OHPC_macros
 %global pname pmix
-%global PNAME %(tr [a-z] [A-Z] <<< %{pname})
 
 Summary: An extended/exascale implementation of PMI
 Name: %{pname}%{PROJ_DELIM}

--- a/components/runtimes/charliecloud/SPECS/charliecloud.spec
+++ b/components/runtimes/charliecloud/SPECS/charliecloud.spec
@@ -12,7 +12,6 @@
 
 # Base package name
 %define pname charliecloud
-%define PNAME CHARLIECLOUD
 
 Summary:   Lightweight user-defined software stacks for high-performance computing
 Name:      %{pname}%{PROJ_DELIM}

--- a/components/runtimes/ocr/SPECS/ocr.spec
+++ b/components/runtimes/ocr/SPECS/ocr.spec
@@ -14,7 +14,6 @@
 
 # Base package name
 %define pname ocr
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 # Build options
 

--- a/components/runtimes/singularity/SPECS/singularity.spec
+++ b/components/runtimes/singularity/SPECS/singularity.spec
@@ -34,7 +34,6 @@
 
 # Base package name
 %define pname singularity
-%define PNAME SINGULARITY
 
 # This allows us to pick up the default value from the configure
 %{!?with_slurm: %global with_slurm no}

--- a/components/serial-libs/R/SPECS/R.spec
+++ b/components/serial-libs/R/SPECS/R.spec
@@ -114,15 +114,15 @@ Provides:       R-utils = %{version}
 %description
 R is a language and environment for statistical computing and graphics.
 It is a GNU project which is similar to the S language and environment
-which was developed at Bell Laboratories (formerly AT&T, now Lucent Technologies)
-by John Chambers and colleagues.
+which was developed at Bell Laboratories (formerly AT&T, now Lucent
+Technologies) by John Chambers and colleagues.
 
-R can be considered as a different implementation of S.  There are some important
-differences, but much code written for S runs unaltered under R.
+R can be considered as a different implementation of S. There are some
+important differences, but much code written for S runs unaltered under R.
 
 R provides a wide variety of statistical (linear and nonlinear modelling,
-classical statistical tests, time-series analysis, classification, clustering, …)
-and graphical techniques, and is highly extensible.
+classical statistical tests, time-series analysis, classification,
+clustering, ...) and graphical techniques, and is highly extensible.
 
 %prep
 %setup -n R-%{version}

--- a/components/serial-libs/R/SPECS/R.spec
+++ b/components/serial-libs/R/SPECS/R.spec
@@ -18,7 +18,6 @@ Requires:      openblas-%{compiler_family}%{PROJ_DELIM}
 %endif
 
 %define 	pname R
-%define 	PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Name:		%{pname}-%{compiler_family}%{PROJ_DELIM}
 Release:	1%{?dist}

--- a/components/serial-libs/gsl/SPECS/gsl.spec
+++ b/components/serial-libs/gsl/SPECS/gsl.spec
@@ -14,7 +14,6 @@
 
 # Base package name
 %define pname gsl
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Summary:   GNU Scientific Library (GSL)
 Name:      %{pname}-%{compiler_family}%{PROJ_DELIM}

--- a/components/serial-libs/metis/SPECS/metis.spec
+++ b/components/serial-libs/metis/SPECS/metis.spec
@@ -14,7 +14,6 @@
 
 # Base package name
 %define pname metis
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Name:    %{pname}-%{compiler_family}%{PROJ_DELIM}
 Summary: Serial Graph Partitioning and Fill-reducing Matrix Ordering

--- a/components/serial-libs/openblas/SPECS/openblas.spec
+++ b/components/serial-libs/openblas/SPECS/openblas.spec
@@ -15,7 +15,6 @@
 
 # Base package name
 %define pname openblas
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Name:           %{pname}-%{compiler_family}%{PROJ_DELIM}
 Version:        0.3.0

--- a/components/serial-libs/plasma/SPECS/plasma.spec
+++ b/components/serial-libs/plasma/SPECS/plasma.spec
@@ -22,7 +22,6 @@ Requires:      openblas-%{compiler_family}%{PROJ_DELIM}
 
 # Base package name
 %define pname plasma
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Name:	%{pname}-%{compiler_family}%{PROJ_DELIM}
 Version: 2.8.0

--- a/components/serial-libs/scotch/SPECS/scotch.spec
+++ b/components/serial-libs/scotch/SPECS/scotch.spec
@@ -13,7 +13,6 @@
 %include %{_sourcedir}/OHPC_macros
 
 %define pname scotch
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Name:		%{pname}-%{compiler_family}%{PROJ_DELIM}
 Version:	6.0.6

--- a/components/serial-libs/superlu/SPECS/superlu.spec
+++ b/components/serial-libs/superlu/SPECS/superlu.spec
@@ -14,7 +14,6 @@
 
 # Base package name
 %define pname superlu
-%define PNAME %(echo %{pname} | tr [a-z] [A-Z])
 
 Name:           %{pname}-%{compiler_family}%{PROJ_DELIM}
 Summary:        A general purpose library for the direct solution of linear equations

--- a/tests/travis/check_spec.py
+++ b/tests/travis/check_spec.py
@@ -26,7 +26,7 @@ regex_wrong = [
 
 regex_required = [
     # Group designation should include %{PROJ_NAME} delimiter and known component area
-    '^Group:.*%{PROJ_NAME}/(admin|compiler-families|dev-tools|distro-packages|io-libs|lustre|mpi-families|parallel-libs|perf-tols|provisioning|rms|runtimes|serial-libs)$',
+    '^Group:.*%{PROJ_NAME}/(admin|compiler-families|dev-tools|distro-packages|io-libs|lustre|mpi-families|parallel-libs|perf-tools|provisioning|rms|runtimes|serial-libs)$',
     # Need a URL
     '(^URL:.*$|Url:.*$)',
     ]


### PR DESCRIPTION
The main reason for this PR is to move the definition of PNAME into OHPC_macros for all SPEC globally.

During the testing of this I fixed one encoding error in likwid.spec and one typo in our travis test script.