### PR TITLE
Update config files per GEOPM requirements.

### DIFF
--- a/components/admin/meta-packages/SPECS/meta-packages.spec
+++ b/components/admin/meta-packages/SPECS/meta-packages.spec
@@ -378,12 +378,13 @@ Collection of serial library builds for use with GNU compiler toolchain
 
 %package -n %{PROJ_NAME}-slurm-client
 Summary:   OpenHPC client packages for SLURM
+Requires:  msr-safe-slurm%{PROJ_DELIM}
+Requires:  munge%{PROJ_DELIM}
 Requires:  slurm%{PROJ_DELIM}
 Requires:  slurm-slurmd%{PROJ_DELIM}
 Requires:  slurm-contribs%{PROJ_DELIM}
 Requires:  slurm-example-configs%{PROJ_DELIM}
 Requires:  slurm-pam_slurm%{PROJ_DELIM}
-Requires:  munge%{PROJ_DELIM}
 %if 0%{?centos_version} || 0%{?rhel_version}
 Requires:  hwloc-libs
 %endif

--- a/components/perf-tools/geopm/SPECS/geopm.spec
+++ b/components/perf-tools/geopm/SPECS/geopm.spec
@@ -28,9 +28,6 @@ License:       BSD-3-Clause
 Group:         %{PROJ_NAME}/perf-tools
 URL:           https://geopm.github.io
 Source0:       https://github.com/geopm/geopm/releases/download/v%{version}/geopm-%{version}.tar.gz
-Requires:      kmod-msr-safe%{PROJ_DELIM}
-Requires:      msr-safe%{PROJ_DELIM}
-Requires:      msr-safe-slurm%{PROJ_DELIM}
 BuildRequires: autoconf
 BuildRequires: automake
 BuildRequires: hwloc-devel

--- a/components/perf-tools/msr-safe/SPECS/msr-safe.spec
+++ b/components/perf-tools/msr-safe/SPECS/msr-safe.spec
@@ -47,6 +47,7 @@ Allows safer access to model specific registers (MSRs)
 Summary: msr-safe slurm spank plugin
 Group: Development/Libraries
 Requires:       %{pname}%{PROJ_DELIM}
+Requires:       kmod-%{pname}%{PROJ_DELIM}
 BuildRequires:  slurm%{PROJ_DELIM}
 BuildRequires:  slurm-devel%{PROJ_DELIM}
 

--- a/components/rms/slurm/SPECS/slurm.spec
+++ b/components/rms/slurm/SPECS/slurm.spec
@@ -425,6 +425,8 @@ install -D -m755 contribs/sjstat %{buildroot}/%{_bindir}/sjstat
 %if 0%{?OHPC_BUILD}
 head -n -2 $RPM_BUILD_ROOT/%{_sysconfdir}/slurm.conf.example | grep -v ReturnToService > $RPM_BUILD_ROOT/%{_sysconfdir}/slurm.conf
 echo "# OpenHPC default configuration" >> $RPM_BUILD_ROOT/%{_sysconfdir}/slurm.conf
+# 10/2/18 brad.geltz@intel.com - Enabling the task/affinity plugin to add the --cpu-bind option to srun for GEOPM
+echo "TaskPlugin=task/affinity" >> $RPM_BUILD_ROOT/%{_sysconfdir}/slurm.conf
 echo "PropagateResourceLimitsExcept=MEMLOCK" >> $RPM_BUILD_ROOT/%{_sysconfdir}/slurm.conf
 echo "AccountingStorageType=accounting_storage/filetxt" >> $RPM_BUILD_ROOT/%{_sysconfdir}/slurm.conf
 echo "Epilog=/etc/slurm/slurm.epilog.clean" >> $RPM_BUILD_ROOT/%{_sysconfdir}/slurm.conf

--- a/docs/recipes/install/common/add_ww_hosts_finalize.tex
+++ b/docs/recipes/install/common/add_ww_hosts_finalize.tex
@@ -1,10 +1,4 @@
 % ohpc_validation_newline
-% ohpc_validation_comment Optionally, add arguments to bootstrap kernel
-% ohpc_command if [[ ${enable_kargs} -eq 1 ]]; then
-% ohpc_command   wwsh -y provision set "${compute_regex}" --kargs="${kargs}"
-% ohpc_command fi
-
-% ohpc_validation_newline
 % ohpc_validation_comment Restart ganglia services to pick up hostfile changes
 % ohpc_command if [[ ${enable_ganglia} -eq 1 ]];then
 % ohpc_command   systemctl restart gmond

--- a/docs/recipes/install/common/add_ww_hosts_intro.tex
+++ b/docs/recipes/install/common/add_ww_hosts_intro.tex
@@ -22,7 +22,7 @@
 \begin{lstlisting}[language=bash,keywords={},upquote=true,basicstyle=\footnotesize\ttfamily]
 # Additional step required if desiring to use predictable network interface
 # naming schemes (e.g. en4s0f0). Skip if using eth# style names.
-[sms](*\#*) wwsh provision set "${compute_regex}" --kargs "net.ifnames=1,biosdevname=1"
+[sms](*\#*) export kargs="${kargs} net.ifnames=1,biosdevname=1"
 [sms](*\#*) wwsh provision set --postnetdown=1 "${compute_regex}"
 \end{lstlisting}
 

--- a/docs/recipes/install/common/charliecloud_centos_warewulf_post.tex
+++ b/docs/recipes/install/common/charliecloud_centos_warewulf_post.tex
@@ -11,7 +11,7 @@ to build and run containers there.
 % ohpc_validation_comment Optionally, enable console redirection 
 \begin{lstlisting}[language=bash,keywords={},upquote=true]
 # Define node kernel arguments to support user namespaces
-[sms](*\#*) wwsh -y provision set "${compute_regex}" --kargs=namespace.unpriv_enable=1
+[sms](*\#*) export kargs="${kargs} namespace.unpriv_enable=1"
 
 # Increase per-user limit on the number of user namespaces that may be created
 [sms](*\#*) echo "user.max_user_namespaces=15076" >> $CHROOT/etc/sysctl.conf

--- a/docs/recipes/install/common/conman_post.tex
+++ b/docs/recipes/install/common/conman_post.tex
@@ -1,11 +1,8 @@
 If you chose to enable \conman{} in \S\ref{sec:add_conman}, additional
-boot-time kernel arguments are needed to enable serial console
-redirection. An example provisioning setting which adds to any other kernel arguments defined
-in \texttt{\$\{kargs\}} is as follows:
-
+warewulf configuration is needed as follows:
 % begin_ohpc_run
 % ohpc_validation_newline
-% ohpc_validation_comment Optionally, enable console redirection 
+% ohpc_validation_comment Optionally, enable console redirection
 % ohpc_command if [[ ${enable_ipmisol} -eq 1 ]];then
 % ohpc_indent 5
 \begin{lstlisting}[language=bash,keywords={},upquote=true]
@@ -15,3 +12,13 @@ in \texttt{\$\{kargs\}} is as follows:
 % ohpc_indent 0
 % ohpc_command fi
 % end_ohpc_run
+If any components have added to the boot time kernel command line argumenst for the compute nodes,
+the following command is required to store the configuration in Warewulf:
+% ohpc_validation_newline
+% ohpc_validation_comment Optionally, add arguments to bootstrap kernel
+% ohpc_command if [[ ${enable_kargs} -eq 1 ]]; then
+\begin{lstlisting}[language=bash,keywords={},upquote=true,basicstyle=\footnotesize\ttfamily]
+# Set optional compute node kernel command line arguments.
+[sms](*\#*) wwsh -y provision set "${compute_regex}" --kargs="${kargs}"
+\end{lstlisting}
+% ohpc_command fi

--- a/docs/recipes/install/common/geopm.tex
+++ b/docs/recipes/install/common/geopm.tex
@@ -1,38 +1,37 @@
-Global Extensible Open Power Manager (\GEOPM{}) is an extensible power
-management framework targeting high performance computing.  The library can be
-extended to support new control algorithms and new hardware power management
-features.  The \GEOPM{} package provides built in features ranging from static
-management of power policy for each individual compute node, to dynamic
-coordination of power policy and performance across all of the compute nodes
-hosting one MPI job on a portion of a distributed computing system.  The
-dynamic coordination is implemented as a hierarchical control system for
-scalable communication and decentralized control.  The following
-commands can be used to enable development on the {\em master} host and
-execution of the \GEOPM{} runtime on the {\em compute} hosts.
+Global Extensible Open Power Manager (\GEOPM{}) is a framework for exploring
+power and energy optimizations targeting high performance computing.  The
+library can be extended to support new control algorithms and new
+hardware-specific power management features.  The \GEOPM{} package provides
+built-in features ranging from static management of power policy for each
+individual compute node, to dynamic coordination of power policy and
+performance across all of the compute nodes hosting one MPI job on a portion of
+a distributed computing system.  The dynamic coordination is implemented as a
+hierarchical control system for scalable communication and decentralized
+control.
+
+\GEOPM{} will be installed with the Performance Tools meta package
+discussed in Section~\ref{sec:install_perf_tools}.  Once installed, arguments
+must be added to the kernel command line for the compute nodes:
 
 % begin_ohpc_run
 % ohpc_validation_newline
 % ohpc_command if [[ ${enable_geopm} -eq 1 ]];then
 % ohpc_indent 5
-% ohpc_validation_comment Install GEOPM on master and compute nodes
 \begin{lstlisting}[language=bash,keywords={},upquote=true]
-# Install GEOPM package on master
-[sms](*\#*) (*\install*) geopm-gnu7-openmpi3-ohpc
-
-# Install GEOPM package on compute node
-[sms](*\#*) (*\chrootinstall*) geopm-gnu7-openmpi3-ohpc
+# Disable Intel pstate driver because it interferes with GEOPM's operation.
+[sms](*\#*) export kargs="${kargs} intel_pstate=disable"
 \end{lstlisting}
 % ohpc_indent 0
 % ohpc_command fi
 % end_ohpc_run
 
-\noindent Installing the \GEOPM{} package on the {\em master} host will enable
-users to compile against the \GEOPM{} libraries and include headers, and
-installing on the {\em compute} hosts will enable applications to use
-\GEOPM{} at runtime.  For documentation on how to use \GEOPM{} please see
+\noindent The \GEOPM{} package uses \OHPC{}'s msr-safe kernel module
+to enable users to directly read and write whitelisted Model Specific
+Registers (MSRs).  For documentation on how to use \GEOPM{} please see
 the \GEOPM{} man pages which are all linked from the geopm(7) overview
 man page available in html here:
-\href{http://geopm.github.io/man/geopm.7.html}{\color{blue}{http://geopm.github.io/man/geopm.7.html}}.
+\href{http://geopm.github.io/man/geopm.7.html}
+{\color{blue}{http://geopm.github.io/man/geopm.7.html}}.
 Please see the \GEOPM{} tutorials and for working examples using the
-\GEOPM{} runtime here:
-\href{https://github.com/geopm/geopm/tree/dev/tutorial}{\color{blue}{https://github.com/geopm/geopm/tree/dev/tutorial}}.
+\GEOPM{} runtime here: \href{https://github.com/geopm/geopm/tree/dev/tutorial}
+{\color{blue}{https://github.com/geopm/geopm/tree/dev/tutorial}}.


### PR DESCRIPTION
- Disable intel_pstate kernel driver via the kernel cmdline.
- Enable SLURM's task/affinity plugin for per rank CPU pinning.

Signed-off-by: Brad Geltz <brad.geltz@intel.com>