### PR TITLE
arm hpc RPM packages do not currently enable Provides metadata for

### DIFF
--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -89,6 +89,7 @@ BuildRequires: intel_licenses
 %if "%{compiler_family}" == "arm"
 BuildRequires: arm-compilers-devel%{PROJ_DELIM}
 Requires:      arm-compilers-devel%{PROJ_DELIM}
+%global __requires_exclude ^libflang.*\\.so.*$|^libompstub\\.so.*|^libomp\\.so.*$|^libarmpl.*\\.so.*$|^libstdc++\\.so.*$
 %endif
 %if "%{compiler_family}" == "dts6"
 BuildRequires: devtoolset-6


### PR DESCRIPTION
.so's that are shipped with the compiler or performance
libraries. Until this is fixed, instruct rpmbuild to skip listing key
.so's provided by the compiler toolchain as formal Requires for ohpc
builds.

Signed-off-by: Karl W. Schulz <karl@ices.utexas.edu>