### PR TITLE
CMake: Bump to 3.12.1 and use more system libraries as dependencies

### DIFF
--- a/components/dev-tools/cmake/LICENSE
+++ b/components/dev-tools/cmake/LICENSE
@@ -1,5 +1,5 @@
 CMake - Cross Platform Makefile Generator
-Copyright 2000-2017 Kitware, Inc. and Contributors
+Copyright 2000-2018 Kitware, Inc. and Contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The following individuals and institutions are among the Contributors:
 
 * Aaron C. Meadows <cmake@shadowguarddev.com>
+* Adriaan de Groot <groot@kde.org>
 * Aleksey Avdeev <solo@altlinux.ru>
 * Alexander Neundorf <neundorf@kde.org>
 * Alexander Smorkalov <alexander.smorkalov@itseez.com>
@@ -68,13 +69,16 @@ The following individuals and institutions are among the Contributors:
 * Matthaeus G. Chajdas
 * Matthias Kretz <kretz@kde.org>
 * Matthias Maennich <matthias@maennich.net>
+* Michael Stürmer
 * Miguel A. Figueroa-Villanueva
 * Mike Jackson
 * Mike McQuaid <mike@mikemcquaid.com>
 * Nicolas Bock <nicolasbock@gmail.com>
 * Nicolas Despres <nicolas.despres@gmail.com>
 * Nikita Krupen'ko <krnekit@gmail.com>
+* NVIDIA Corporation <www.nvidia.com>
 * OpenGamma Ltd. <opengamma.com>
+* Patrick Stotko <stotko@cs.uni-bonn.de>
 * Per Øyvind Karlsen <peroyvind@mandriva.org>
 * Peter Collingbourne <peter@pcc.me.uk>
 * Petr Gotthard <gotthard@honeywell.com>

--- a/components/dev-tools/cmake/SPECS/cmake.spec
+++ b/components/dev-tools/cmake/SPECS/cmake.spec
@@ -12,8 +12,8 @@
 
 %define pname cmake
 
-%define major_version 3.11
-%define minor_version 4
+%define major_version 3.12
+%define minor_version 1
 
 Summary: CMake is an open-source, cross-platform family of tools designed to build, test and package software.
 Name:    %{pname}%{PROJ_DELIM}
@@ -25,15 +25,21 @@ Group:          %{PROJ_NAME}/dev-tools
 URL:            https://cmake.org/
 Source0:        https://cmake.org/files/v%{major_version}/cmake-%{version}.tar.gz
 BuildRequires:  gcc-c++
-BuildRequires:  libarchive-devel
+BuildRequires:  libarchive-devel >= 3.1
 BuildRequires:  curl-devel
 BuildRequires:  ncurses-devel
 BuildRequires:  xz-devel
 BuildRequires:  zlib-devel
 BuildRequires:  pkgconfig
-%if 0%{!?sles_version} && 0%{!?suse_version}
-BuildRequires:  bzip2-devel
+%if 0%{?sles_version} || 0%{?suse_version}
+BuildRequires:  libexpat-devel
+%else
 BuildRequires:  expat-devel
+
+# The following three dependencies on EL7 come from EPEL
+BuildRequires:  rhash-devel
+BuildRequires:  libuv-devel >= 1.10
+BuildRequires:  jsoncpp-devel
 %endif
 
 %define install_path %{OHPC_UTILS}/%{pname}/%version
@@ -47,18 +53,17 @@ of your choice.
 %prep
 %setup -q -n %{pname}-%{version}
 
-./bootstrap --prefix=%{install_path} --no-qt-gui \
-%if 0%{!?sles_version} && 0%{!?suse_version}
---system-bzip2 \
---system-expat \
+./bootstrap --system-libs \
+%if 0%{?sles_version} || 0%{?suse_version}
+--no-system-librhash \
+--no-system-libuv \
+--no-system-jsoncpp \
 %endif
---system-curl \
---system-zlib \
---system-liblzma \
---system-libarchive
+--no-qt-gui \
+--prefix=%{install_path}
 
 %build
-%{__make} %{?mflags}
+%{__make} %{?_smp_mflags}
 
 %install
 %{__make} install DESTDIR=$RPM_BUILD_ROOT %{?mflags_install}


### PR DESCRIPTION
3.12 addressed an important bug introduced into 3.11 that causes the Intel C compiler to not be able to properly use -std=gnu11 and instead always use -std=c11, which forces ANSI C compatibility and breaks POSIX functionality.