### PR TITLE
Add spank plugin to msr-safe to enable save/restore for jobs.

### DIFF
--- a/components/perf-tools/msr-safe/SOURCES/0001-Correcting-hash_for_each_possible-function.-Fixes-41.patch
+++ b/components/perf-tools/msr-safe/SOURCES/0001-Correcting-hash_for_each_possible-function.-Fixes-41.patch
@@ -1,0 +1,26 @@
+From aeb315ea8afa7e6bc675df7e905b505b5c16e0bb Mon Sep 17 00:00:00 2001
+From: Stephanie Labasan <labasan1@llnl.gov>
+Date: Mon, 30 Jul 2018 08:39:15 -0700
+Subject: [PATCH 1/2] Correcting hash_for_each_possible function. Fixes #41.
+
+Signed-off-by: Stephanie Labasan <labasan1@llnl.gov>
+---
+ msr_whitelist.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/msr_whitelist.c b/msr_whitelist.c
+index 6353796..440625d 100644
+--- a/msr_whitelist.c
++++ b/msr_whitelist.c
+@@ -300,7 +300,7 @@ static struct whitelist_entry *find_in_whitelist(u64 msr)
+     struct hlist_node *node;
+     if (whitelist)
+     {
+-        hash_or_each_possible(whitelist_hash, entry, node, hlist, msr)
++        hash_for_each_possible(whitelist_hash, entry, node, hlist, msr)
+         if (entry && entry->msr == msr)
+         {
+             return entry;
+-- 
+1.8.3.1
+

--- a/components/perf-tools/msr-safe/SOURCES/0002-Adding-slurm-spank-plugin-to-enable-MSR-save-restore.patch
+++ b/components/perf-tools/msr-safe/SOURCES/0002-Adding-slurm-spank-plugin-to-enable-MSR-save-restore.patch
@@ -1,0 +1,284 @@
+From 7fe73cd2eeabcb456ced6c59b512cee1e0e4aeb3 Mon Sep 17 00:00:00 2001
+From: "Christopher M. Cantalupo" <christopher.m.cantalupo@intel.com>
+Date: Mon, 10 Sep 2018 19:31:49 -0700
+Subject: [PATCH 2/2] Adding slurm spank plugin to enable MSR save restore.
+
+- Modified REAME to discuss importance of save/restore on
+  shared HPC systems.
+- Uses spank plugin to do epilog and prolog.
+- Popen call to msrsave to avoid linking issues.
+
+Signed-off-by: Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>
+---
+ .gitignore              |   1 +
+ Makefile                |  20 +++++-
+ README                  |  10 +++
+ msrsave/spank_msrsafe.c | 177 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 205 insertions(+), 3 deletions(-)
+ create mode 100644 msrsave/spank_msrsafe.c
+
+diff --git a/.gitignore b/.gitignore
+index 9c2c53f..1a03c26 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -9,5 +9,6 @@ Module.symvers
+ *.mod.c
+ *.unsigned
+ modules.order
++msrsave/libspank_msrsafe.so
+ msrsave/msrsave
+ msrsave/msrsave_test
+diff --git a/Makefile b/Makefile
+index 21370f7..fd22fe1 100644
+--- a/Makefile
++++ b/Makefile
+@@ -43,7 +43,7 @@ all: msrsave/msrsave
+ 
+ clean:
+ 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+-	rm -f msrsave/msrsave.o msrsave/msrsave msrsave/msrsave_test
++	rm -f msrsave/msrsave.o msrsave/msrsave msrsave/msrsave_test msrsave/spank_msrsafe.o msrsave/libspank_msrsafe.so
+ 
+ check: msrsave/msrsave_test
+ 	msrsave/msrsave_test
+@@ -58,10 +58,21 @@ msrsave/msrsave_test.o: msrsave/msrsave_test.c msrsave/msrsave.h
+ 
+ msrsave/msrsave_test: msrsave/msrsave_test.o msrsave/msrsave.o
+ 
++SLURM_CFLAGS ?= -I/usr/include -fPIC -shared
++SLURM_LDFLAGS ?= -L/usr/lib64 -lslurm -shared
++spank: msrsave/libspank_msrsafe.so
++
++msrsave/spank_msrsafe.o: msrsave/spank_msrsafe.c
++	$(CC) $(CFLAGS) $(SLURM_CFLAGS) -c $^ -o $@
++
++msrsave/libspank_msrsafe.so: msrsave/spank_msrsafe.o
++	$(CC) $(LDFLAGS) $(SLURM_LDFLAGS) $^ -o $@
++
+ INSTALL ?= install
+ prefix ?= $(HOME)/build
+ exec_prefix ?= $(prefix)
+ sbindir ?= $(exec_prefix)/sbin
++libdir ?= $(exec_preffix)/lib
+ datarootdir ?= $(prefix)/share
+ mandir ?= $(datarootdir)/man
+ man1dir ?= $(mandir)/man1
+@@ -72,6 +83,9 @@ install: msrsave/msrsave msrsave/msrsave.1
+ 	$(INSTALL) -d $(DESTDIR)/$(man1dir)
+ 	$(INSTALL) -m 644 msrsave/msrsave.1 $(DESTDIR)/$(man1dir)
+ 
+-.SUFFIXES: .c .o
+-.PHONY: all clean install
++install-spank: spank
++	$(INSTALL) -d $(DESTDIR)/$(libdir)/slurm
++	$(INSTALL) msrsave/libspank_msrsafe.so $(DESTDIR)/$(libdir)/slurm/libspank_msrsafe.so
+ 
++.SUFFIXES: .c .o
++.PHONY: all clean install spank install-spank
+diff --git a/README b/README
+index d2120dd..0bba323 100644
+--- a/README
++++ b/README
+@@ -63,6 +63,16 @@ The msrsave utility provides a mechanism for saving and restoring MSR values
+ based on entries in the whitelist. To restore MSR values, the register must
+ have an appropriate writemask.
+ 
++Modification of MSR's that are marked as safe in the whitelist may
++impact subsequent users on a shared HPC system.  It is important the
++resource manager on such a system use the msrsave utility to save and
++restore MSR values between allocating compute nodes to users.  An
++example of this has been implemented for the SLURM resource manager as
++a SPANK plugin.  This plugin can be built with the "make spank" target
++and installed with the "make install-spank" taget.  This uses the
++SLURM SPANK infrastructure to make a popen(3) call to the msrsave
++command line utility in the job epilogue and prologue.
++
+ Release
+ -------
+ 
+diff --git a/msrsave/spank_msrsafe.c b/msrsave/spank_msrsafe.c
+new file mode 100644
+index 0000000..844e64d
+--- /dev/null
++++ b/msrsave/spank_msrsafe.c
+@@ -0,0 +1,177 @@
++/*
++ * Copyright (c) 2018, Intel Corporation
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ *
++ *     * Redistributions of source code must retain the above copyright
++ *       notice, this list of conditions and the following disclaimer.
++ *
++ *     * Redistributions in binary form must reproduce the above copyright
++ *       notice, this list of conditions and the following disclaimer in
++ *       the documentation and/or other materials provided with the
++ *       distribution.
++ *
++ *     * Neither the name of Intel Corporation nor the names of its
++ *       contributors may be used to endorse or promote products derived
++ *       from this software without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
++ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
++ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
++ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
++ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
++ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
++ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY LOG OF THE USE
++ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++ */
++
++/*
++ * The msr-safe Linux kernel module enables user access to read and
++ * write capabilities for a restricted set of whitelisted Model
++ * Specific Registers (MSRs) on x86 platforms.  The purpose of this
++ * slurm plugin is to ensure that MSRs modified within a user’s slurm
++ * job allocation are reset to their original state before the compute
++ * node is returned to the pool available to other users of the
++ * system.  The msr-safe kernel module is targeting HPC systems that
++ * enforce single user occupancy per compute node, and is not
++ * appropriate for systems where compute nodes are shared between
++ * users.  The modifications that one user makes to whitelisted
++ * registers may impact subsequent users of the processor if not
++ * restored.
++ */
++
++#include <stdlib.h>
++#include <stdio.h>
++#include <signal.h>
++#include <errno.h>
++
++#include "slurm/spank.h"
++
++#define SLURM_SPANK_MSRSAFE_BUFFER_SIZE 1024
++
++SPANK_PLUGIN(msr-safe, 1);
++
++int slurm_spank_job_prolog(spank_t spank_ctx, int argc, char **argv);
++int slurm_spank_job_epilog(spank_t spank_ctx, int argc, char **argv);
++
++static int slurm_spank_msrsafe_system(const char *cmd);
++static void slurm_spank_msrsafe_popen_complete(int signum);
++static int slurm_spank_msrsafe_popen(const char *cmd, FILE **fid);
++
++static volatile unsigned g_is_popen_complete = 0;
++static struct sigaction g_popen_complete_signal_action;
++
++static void slurm_spank_msrsafe_popen_complete(int signum)
++{
++    if (signum == SIGCHLD) {
++        g_is_popen_complete = 1;
++    }
++}
++
++static int slurm_spank_msrsafe_popen(const char *cmd, FILE **fid)
++{
++    int err = 0;
++    *fid = NULL;
++
++    struct sigaction save_action;
++    g_popen_complete_signal_action.sa_handler = slurm_spank_msrsafe_popen_complete;
++    sigemptyset(&g_popen_complete_signal_action.sa_mask);
++    g_popen_complete_signal_action.sa_flags = 0;
++    err = sigaction(SIGCHLD, &g_popen_complete_signal_action, &save_action);
++    if (!err) {
++        *fid = popen(cmd, "r");
++        while (*fid && !g_is_popen_complete) {
++
++        }
++        g_is_popen_complete = 0;
++        sigaction(SIGCHLD, &save_action, NULL);
++    }
++    if (!err && *fid == NULL) {
++        err = errno ? errno : -1;
++    }
++    return err;
++}
++
++#ifndef SLURM_SPANK_MSRSAVE_TEST
++/* Do not compile slurm_spank_msrsafe_system if testing since requires
++   linking to slurm library for slurm_error() API and the function is
++   not executed by the test program. */
++
++static int slurm_spank_msrsafe_system(const char *cmd)
++{
++    const size_t buffer_size = SLURM_SPANK_MSRSAFE_BUFFER_SIZE - 1;
++    char buffer[SLURM_SPANK_MSRSAFE_BUFFER_SIZE];
++    FILE *fid = NULL;
++    int err = slurm_spank_msrsafe_popen(cmd, &fid);
++    if (!err) {
++        size_t num_read = 0;
++        do {
++            num_read = fread(buffer, sizeof(*buffer), buffer_size, fid);
++            buffer[num_read] = '\0';
++            if (num_read) {
++                slurm_info("%s", buffer);
++            }
++        } while (num_read == buffer_size);
++        err = pclose(fid);
++    }
++    return err;
++}
++
++#else /* BEGIN TEST PROGRAM */
++/* If test is defined then print the scripts to standard output rather
++   than executing them. */
++
++#include <stdio.h>
++#define slurm_spank_msrsafe_system printf
++
++int main(int argc, char **argv)
++{
++    spank_t spank_ctx;
++    const char *test_cmd = "ls --version";
++    printf("SAVE SCRIPT:\n");
++    slurm_spank_job_prolog(spank_ctx, 0, NULL);
++    printf("\n\nRESTORE SCRIPT:\n");
++    slurm_spank_job_epilog(spank_ctx, 0, NULL);
++    printf("\n\n");
++    FILE *fid;
++    char buffer[4096] = {0};
++    int err = slurm_spank_msrsafe_popen(test_cmd, &fid);
++    printf("CALLING \"%s\":\n", test_cmd);
++    fread(buffer, sizeof(char), 4096, fid);
++    printf("%s", buffer);
++    return 0;
++}
++
++#endif /* END TEST PROGRAM */
++
++#ifndef SLURM_SPANK_MSRSAVE_FILE_PREFIX
++#define SLURM_SPANK_MSRSAVE_FILE_PREFIX "/var/run/slurm-msrsave"
++#endif
++
++int slurm_spank_job_prolog(spank_t spank_ctx, int argc, char **argv)
++{
++    const char *save_script = "if [ -e /dev/cpu/msr_whitelist ]; then "
++                              "tmp_file=$(mktemp " SLURM_SPANK_MSRSAVE_FILE_PREFIX "-$(hostname -s).XXXXXXXXXX) && "
++                              "/usr/sbin/msrsave $tmp_file 2>&1; "
++                              "fi";
++    return slurm_spank_msrsafe_system(save_script);
++}
++
++int slurm_spank_job_epilog(spank_t spank_ctx, int argc, char **argv)
++{
++    const char *restore_script = "if [ -e /dev/cpu/msr_whitelist ]; then "
++                                 "tmp_files=$(ls -t " SLURM_SPANK_MSRSAVE_FILE_PREFIX "-$(hostname -s).*) && "
++                                 "tmp_file=$(echo $tmp_files | head -n1) && "
++                                 "/usr/sbin/msrsave -r $tmp_file 2>&1 && "
++                                 "rm $tmp_file 2>&1; "
++                                 "fi";
++
++    return slurm_spank_msrsafe_system(restore_script);
++}
++
++#undef SLURM_SPANK_MSRSAVE_FILE_PREFIX
+-- 
+1.8.3.1
+


### PR DESCRIPTION
- Include patch from msr-safe mainline that came in before
  the spank plugin as well.

Signed-off-by: Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>