### PR TITLE
Check that intel_pstate driver is disabled on the compute node.

### DIFF
--- a/tests/perf-tools/geopm/tests/test_module
+++ b/tests/perf-tools/geopm/tests/test_module
@@ -39,6 +39,12 @@ rpm=geopm-$LMOD_FAMILY_COMPILER-$LMOD_FAMILY_MPI-ohpc
     fi
 }
 
+@test "[$testname] Verify that intel_pstate driver is disabled ($LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
+    if ! run_serial_binary grep 'intel_pstate=disable' /proc/cmdline >& /dev/null; then
+        flunk "Kernel command line does not disable intel_pstate driver"
+    fi
+}
+
 # ----------
 # Binaries
 # ----------


### PR DESCRIPTION
Signed-off-by: Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>