### PR TITLE
SPEC file cleanups

### DIFF
--- a/components/admin/clustershell/SPECS/clustershell.spec
+++ b/components/admin/clustershell/SPECS/clustershell.spec
@@ -1,5 +1,3 @@
-%{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
-
 %include %{_sourcedir}/OHPC_macros
 
 %define pname clustershell
@@ -21,7 +19,6 @@ Patch1:        clustershell-1.8-no-requires.patch
 %if 0%{?suse_version} == 1110
 BuildArch:     x86_64
 %else
-#%%if 0%%{?fedora} 
 BuildArch:     noarch
 %endif
 
@@ -47,7 +44,7 @@ Syntax highlighting in the VIM editor for ClusterShell configuration files.
 
 %prep
 %setup -q -n %{pname}-%{version}
-%patch1 -p1 
+%patch1 -p1
 
 %build
 %{__python} setup.py build
@@ -124,11 +121,6 @@ EOF
 %{OHPC_PUB}
 %exclude %{vimdatadir}
 %exclude %{install_path}/share/vim/
-#%{_mandir}/man1/clubak.1*
-#%{_mandir}/man1/clush.1*
-#%{_mandir}/man1/nodeset.1*
-#%{_mandir}/man5/clush.conf.5*
-#%{_mandir}/man5/groups.conf.5*
 %dir %{_sysconfdir}/clustershell
 %{_sysconfdir}/clustershell/clush.conf
 %{_sysconfdir}/clustershell/groups.conf
@@ -141,12 +133,6 @@ EOF
 %doc %{_sysconfdir}/clustershell/groups.d/*.example
 %doc %{_sysconfdir}/clustershell/groups.conf.d/README
 %doc %{_sysconfdir}/clustershell/groups.conf.d/*.example
-#%doc %{_sysconfdir}/clustershell/*.example
-#%{python_sitelib}/ClusterShell/
-#%{python_sitelib}/ClusterShell-*-py?.?.egg-info
-#%{_bindir}/clubak
-#%{_bindir}/clush
-#%{_bindir}/nodeset
 
 %files -n vim-%{name}
 %dir %{install_path}/share/vim/
@@ -156,4 +142,3 @@ EOF
 %{vimdatadir}/ftdetect/clustershell.vim
 %{vimdatadir}/syntax/clushconf.vim
 %{vimdatadir}/syntax/groupsconf.vim
-

--- a/components/admin/lmod/SPECS/lmod.spec
+++ b/components/admin/lmod/SPECS/lmod.spec
@@ -44,7 +44,7 @@ BuildRequires: tcl
 %if 0%{?sles_version} || 0%{?suse_version}
 BuildRequires: procps
 %endif
-   
+
 %if 0%{?sles_version} || 0%{?suse_version}
 Conflicts: Modules
 %else
@@ -152,7 +152,7 @@ setenv LMOD_PREPEND_BLOCK "normal"
 
 if ( \`id -u\` == "0" ) then
    setenv MODULEPATH "%{OHPC_ADMIN}/modulefiles:%{OHPC_MODULES}"
-else   
+else
    setenv MODULEPATH "%{OHPC_MODULES}"
 endif
 
@@ -160,7 +160,7 @@ endif
 source %{OHPC_ADMIN}/lmod/lmod/init/csh >/dev/null
 
 # Load baseline OpenHPC environment
-module try-add ohpc 
+module try-add ohpc
 
 EOF
 
@@ -174,4 +174,3 @@ EOF
 %config %{_sysconfdir}/profile.d/lmod.csh
 %{OHPC_PUB}
 %doc License README.md README_lua_modulefiles.txt INSTALL
-

--- a/components/admin/mrsh/SPECS/mrsh.spec
+++ b/components/admin/mrsh/SPECS/mrsh.spec
@@ -33,7 +33,7 @@ BuildRequires: autoconf
 BuildRequires: automake
 BuildRequires: libtool
 
-#%define _prefix %{OHPC_HOME}/admin/%{pname}
+%define _prefix %{OHPC_HOME}/admin/%{pname}
 
 %description
 Remote shell programs that use munge authentication rather than
@@ -63,7 +63,7 @@ rsh compatability package for mrcp/mrlogin/mrsh
 %endif
 
 %build
-%configure %{?_without_pam} 
+%configure %{?_without_pam}
 make
 
 %install
@@ -151,5 +151,5 @@ if [ -x /etc/init.d/xinetd ]; then
 elif [ -x /bin/systemctl ]; then
     if /bin/systemctl status xinetd | grep -q running; then
        /bin/systemctl restart xinetd
-    fi 
+    fi
 fi

--- a/components/admin/ndoutils/SPECS/ndoutils.spec
+++ b/components/admin/ndoutils/SPECS/ndoutils.spec
@@ -41,24 +41,13 @@ BuildRequires:      mysql-devel
 Provides:           %{pname}
 
 # Nagios is required also for user and group
-%if 0%{?rhel} == 5
-Requires:           nagios < 3
-%else
 Requires:           nagios >= 4
-%endif
 
 %if 0%{?fedora} || 0%{?rhel} >= 7
 BuildRequires:      systemd
 Requires(post):     systemd
 Requires(preun):    systemd
 Requires(postun):   systemd
-%endif
-
-%if 0%{?rhel} == 5 || 0%{?rhel} == 6
-Requires(post):     /sbin/chkconfig
-Requires(preun):    /sbin/chkconfig
-Requires(preun):    /sbin/service
-Requires(postun):   /sbin/service
 %endif
 
 %if 0%{?sles_version} || 0%{?suse_version}
@@ -94,13 +83,6 @@ mkdir -p %{buildroot}%{_libdir}/nagios/brokers
 
 # Nagios 4 support + common components
 %make_install
-
-# Nagios 2 support (override)
-%if 0%{?rhel} == 5
-    pushd src
-    make install-2x DESTDIR=%{?buildroot}
-    popd
-%endif
 
 mv %{buildroot}%{_sbindir}/ndomod.o \
     %{buildroot}%{_libdir}/nagios/brokers/ndomod.so
@@ -152,16 +134,10 @@ mkdir -p %{buildroot}%{_localstatedir}/run/ndoutils
 %{_sbindir}/sockdebug
 
 %if 0%{?fedora} || 0%{?rhel} >= 7
-
-#%dir %attr(-,nagios,root) /run/%{pname}/
 %{_tmpfilesdir}/ndoutils.conf
 %{_unitdir}/ndo2db.service
-
 %else
-
-#%dir %attr(-,nagios,root) %{_localstatedir}/run/ndoutils
 %{_initrddir}/ndo2db
-
 %endif
 %dir %attr(-,nagios,root) %{_localstatedir}/run/ndoutils
 
@@ -175,23 +151,5 @@ mkdir -p %{buildroot}%{_localstatedir}/run/ndoutils
 
 %postun
 %systemd_postun_with_restart ndo2db.service
-
-%endif
-
-%if 0%{?rhel} == 6
-
-%post
-/sbin/chkconfig --add ndo2db
-
-%preun
-if [ "$1" = 0 ]; then
-    /sbin/service ndo2db stop >/dev/null 2>&1 || :
-    /sbin/chkconfig --del ndo2db
-fi
-
-%postun
-if [ "$1" -ge "1" ]; then
-    /sbin/service ndo2db condrestart >/dev/null 2>&1 || :
-fi
 
 %endif

--- a/components/admin/powerman/SPECS/powerman.spec
+++ b/components/admin/powerman/SPECS/powerman.spec
@@ -18,29 +18,14 @@ Release: 1%{?dist}
 
 Summary: PowerMan - centralized power control for clusters
 License: GPL
-Group:     %{PROJ_NAME}/admin
+Group: %{PROJ_NAME}/admin
 Url: http://code.google.com/p/powerman/
-#Source0: %{pname}-%{version}.tar.gz
 Source0: https://github.com/chaos/%{pname}/releases/download/%{version}/%{pname}-%{version}.tar.gz
 
 %if 0%{?rhel}
 %define _with_httppower 1
 %define _with_snmppower 1
 %define _with_genders 1
-%define _with_tcp_wrappers 1
-%endif
-
-%if 0%{?chaos}
-%define _with_httppower 1
-%define _with_snmppower 1
-%define _with_genders 1
-%define _with_tcp_wrappers 1
-%endif
-
-%if 0%{?fedora}
-%define _with_httppower 1
-%define _with_snmppower 1
-%define _with_genders 0
 %define _with_tcp_wrappers 1
 %endif
 
@@ -69,8 +54,8 @@ Summary: Libraries for applications using PowerMan
 Group: System Environment/Libraries
 
 %description
-PowerMan is a tool for manipulating remote power control (RPC) devices from a 
-central location. Several RPC varieties are supported natively by PowerMan and 
+PowerMan is a tool for manipulating remote power control (RPC) devices from a
+central location. Several RPC varieties are supported natively by PowerMan and
 Expect-like configurability simplifies the addition of new devices.
 
 %description -n %{pname}-devel%{PROJ_DELIM}
@@ -92,7 +77,7 @@ A shared library for applications using PowerMan.
 make
 
 %install
-make install DESTDIR=$RPM_BUILD_ROOT 
+make install DESTDIR=$RPM_BUILD_ROOT
 
 #drop local state dir to avoid making systemd angry when it creates the statedir on start
 rm -rf $RPM_BUILD_ROOT/%{_localstatedir}
@@ -118,7 +103,7 @@ fi
 if [ -x /sbin/ldconfig ]; then /sbin/ldconfig %{_libdir}; fi
 
 %files
-%doc DISCLAIMER 
+%doc DISCLAIMER
 %doc COPYING
 %doc NEWS
 %doc TODO

--- a/components/distro-packages/ipmiutil/SPECS/ipmiutil.spec
+++ b/components/distro-packages/ipmiutil/SPECS/ipmiutil.spec
@@ -9,11 +9,6 @@
 #
 #----------------------------------------------------------------------------eh-
 
-# spec file for package ipmiutil 
-#
-# Copyright (c) 2012 Andy Cress
-#
-
 %include %{_sourcedir}/OHPC_macros
 
 %define pname ipmiutil
@@ -26,32 +21,22 @@ License:   BSD 3-clause
 Group:     %{PROJ_NAME}/distro-packages
 Source0:   https://downloads.sourceforge.net/project/ipmiutil/%{pname}-%{version}.tar.gz
 URL:       http://ipmiutil.sourceforge.net
-provides: %{pname}
-# Suggests: cron or vixie-cron or cronie or similar
-%if 0%{?fedora} >= 15
-BuildRequires: systemd autoconf automake
-Requires: systemd-units
-%endif
+Provides: %{pname}
 %if 0%{?suse_version} >= 1210
 %define req_systemd 1
 %endif
 %if 0%{?sles_version} >= 10
-BuildRequires: libopenssl-devel 
+BuildRequires: libopenssl-devel
 %else
-BuildRequires: openssl-devel 
+BuildRequires: openssl-devel
 %endif
 %if 0%{?req_systemd}
 BuildRequires: gcc gcc-c++ libtool systemd
 %define unit_dir  %{_unitdir}
 %define systemd_fls %{unit_dir}
-# Requires: %{?systemd_requires}
 %else
-BuildRequires: gcc gcc-c++ libtool 
-%if 0%{?fedora} == 16
-%define unit_dir  /lib/systemd/system
-%else
+BuildRequires: gcc gcc-c++ libtool
 %define unit_dir  %{_unitdir}
-%endif
 %define systemd_fls %{_datadir}/%{pname}
 %endif
 %define init_dir  %{_initrddir}
@@ -59,10 +44,10 @@ BuildRequires: gcc gcc-c++ libtool
 %description
 The ipmiutil package provides easy-to-use utilities to view the SEL,
 perform an IPMI chassis reset, set up the IPMI LAN and Platform Event Filter
-entries to allow SNMP alerts, Serial-Over-LAN console, event daemon, and 
+entries to allow SNMP alerts, Serial-Over-LAN console, event daemon, and
 other IPMI tasks.
 These can be invoked with the metacommand ipmiutil, or via subcommand
-shortcuts as well.  IPMIUTIL can also write sensor thresholds, FRU asset tags, 
+shortcuts as well.  IPMIUTIL can also write sensor thresholds, FRU asset tags,
 and has a full IPMI configuration save/restore.
 An IPMI driver can be provided by either the OpenIPMI driver (/dev/ipmi0)
 or the Intel IPMI driver (/dev/imb), etc.  If used locally and no driver is
@@ -90,15 +75,12 @@ useful for building custom IPMI applications.
 %setup -q -n %{pname}-%{version}
 
 %build
-%if 0%{?fedora} >= 15
-autoconf
-%endif
 %if 0%{?req_systemd}
 %configure --enable-systemd --enable-libsensors
 %else
 %configure --enable-libsensors
 %endif
-make 
+make
 
 %install
 make install DESTDIR=%{buildroot}
@@ -111,23 +93,23 @@ make install DESTDIR=%{buildroot}
 %{_bindir}/ievents
 %{_sbindir}/iseltime
 %{_sbindir}/ipmi_port
-%{_sbindir}/ialarms 
+%{_sbindir}/ialarms
 %{_sbindir}/iconfig
-%{_sbindir}/icmd 
-%{_sbindir}/ifru 
-%{_sbindir}/igetevent 
-%{_sbindir}/ihealth 
-%{_sbindir}/ilan 
-%{_sbindir}/ireset 
-%{_sbindir}/isel 
-%{_sbindir}/isensor 
-%{_sbindir}/iserial 
-%{_sbindir}/isol 
-%{_sbindir}/iwdt 
-%{_sbindir}/ipicmg 
-%{_sbindir}/ifirewall 
-%{_sbindir}/ifwum 
-%{_sbindir}/ihpm 
+%{_sbindir}/icmd
+%{_sbindir}/ifru
+%{_sbindir}/igetevent
+%{_sbindir}/ihealth
+%{_sbindir}/ilan
+%{_sbindir}/ireset
+%{_sbindir}/isel
+%{_sbindir}/isensor
+%{_sbindir}/iserial
+%{_sbindir}/isol
+%{_sbindir}/iwdt
+%{_sbindir}/ipicmg
+%{_sbindir}/ifirewall
+%{_sbindir}/ifwum
+%{_sbindir}/ihpm
 %{_datadir}/%{pname}/ipmiutil_evt
 %{_datadir}/%{pname}/ipmiutil_asy
 %{_datadir}/%{pname}/ipmiutil_wdt
@@ -172,11 +154,10 @@ make install DESTDIR=%{buildroot}
 %{_mandir}/man8/iekanalyzer.8*
 %{_mandir}/man8/itsol.8*
 %{_mandir}/man8/idcmi.8*
-%doc AUTHORS ChangeLog COPYING NEWS README TODO 
+%doc AUTHORS ChangeLog COPYING NEWS README TODO
 %doc doc/UserGuide
 
 %files -n %{pname}-devel%{PROJ_DELIM}
-# %{_datadir}/%{name} is used by both ipmiutil and ipmituil-devel
 %dir %{_datadir}/%{pname}
 %{_datadir}/%{pname}/ipmi_sample.c
 %{_datadir}/%{pname}/ipmi_sample_evt.c
@@ -214,7 +195,7 @@ then
       cp -f ${scr_dir}/ipmiutil_wdt.service %{unit_dir}
       cp -f ${scr_dir}/ipmi_port.service    %{unit_dir}
       # systemctl enable ipmi_port.service >/dev/null 2>&1 || :
-   else 
+   else
       cp -f ${scr_dir}/ipmiutil_wdt %{init_dir}
       cp -f ${scr_dir}/ipmiutil_asy %{init_dir}
       cp -f ${scr_dir}/ipmiutil_evt %{init_dir}
@@ -224,7 +205,7 @@ then
 %endif
 
    # Run some ipmiutil command to see if any IPMI interface works.
-   %{_bindir}/ipmiutil sel -v >/dev/null 2>&1 || : 
+   %{_bindir}/ipmiutil sel -v >/dev/null 2>&1 || :
    IPMIret=$?
    # If IPMIret==0, the IPMI cmd was successful, and IPMI is enabled locally.
    if [ $IPMIret -eq 0 ]; then
@@ -239,11 +220,11 @@ then
          elif [ -x /sbin/chkconfig ]; then
             /sbin/chkconfig --add ipmi_port
             /sbin/chkconfig --add ipmiutil_wdt
-            /sbin/chkconfig --add ipmiutil_evt 
+            /sbin/chkconfig --add ipmiutil_evt
             /sbin/chkconfig --add ipmi_info
          fi
       fi
-   
+
       # Capture a snapshot of IPMI sensor data once now for later reuse.
       sensorout=$vardir/sensor_out.txt
       if [ ! -f $sensorout ]; then
@@ -295,7 +276,7 @@ then
         systemctl stop ipmi_port.service    >/dev/null 2>&1 || :
 %endif
      fi
-   else 
+   else
      if [ -x /sbin/service ]; then
         /sbin/service ipmi_port stop       >/dev/null 2>&1 || :
         /sbin/service ipmiutil_wdt stop    >/dev/null 2>&1 || :

--- a/components/mpi-families/mvapich2/SPECS/mvapich2.spec
+++ b/components/mpi-families/mvapich2/SPECS/mvapich2.spec
@@ -59,14 +59,14 @@ Conflicts: %{pname}-%{compiler_family}%{PROJ_DELIM}
 %if 0%{?sles_version} || 0%{?suse_version}
 Buildrequires: ofed
 %endif
-%if 0%{?rhel_version} || 0%{?centos_version}
+%if 0%{?rhel}
 Buildrequires: rdma-core-devel
 %endif
 
 Requires: prun%{PROJ_DELIM}
 
 BuildRequires: bison
-BuildRequires: libibmad-devel 
+BuildRequires: libibmad-devel
 BuildRequires: zlib-devel
 
 # Default library install path

--- a/components/mpi-families/openmpi/SPECS/openmpi.spec
+++ b/components/mpi-families/openmpi/SPECS/openmpi.spec
@@ -60,7 +60,7 @@ BuildRequires:  pmix%{PROJ_DELIM}
 BuildRequires:  libevent-devel
 %endif
 BuildRequires:  hwloc-devel
-%if 0%{?centos_version} == 700
+%if 0%{?rhel}
 BuildRequires: libtool-ltdl
 %endif
 %if 0%{with_slurm}

--- a/components/parallel-libs/trilinos/SPECS/trilinos.spec
+++ b/components/parallel-libs/trilinos/SPECS/trilinos.spec
@@ -47,9 +47,6 @@ BuildRequires:  netcdf-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 %if "%{compiler_family}" != "intel" && "%{compiler_family}" != "arm"
 BuildRequires:  openblas-%{compiler_family}%{PROJ_DELIM}
 %endif
-%if 0%{?suse_version} <= 1110
-%{!?python_sitearch: %global python_sitearch %(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
-%endif
 
 #!BuildIgnore: post-build-checks
 #!BuildIgnore: brp-check-suse

--- a/components/perf-tools/dimemas/SPECS/dimemas.spec
+++ b/components/perf-tools/dimemas/SPECS/dimemas.spec
@@ -65,11 +65,9 @@ module load boost
 ./bootstrap
 CFLAGS="-std=c99" LDFLAGS="-lstdc++" ./configure --prefix=%{install_path} --with-boost=$BOOST_DIR
 
-
-make %{?_smp_mflags} 
+make %{?_smp_mflags}
 
 %install
-
 export NO_BRP_CHECK_RPATH=true
 
 # OpenHPC compiler designation
@@ -124,8 +122,6 @@ EOF
 
 %{__mkdir} -p $RPM_BUILD_ROOT/%{_docdir}
 
-
 %files
 %{OHPC_PUB}
-
 %doc

--- a/components/perf-tools/extrae/SPECS/extrae.spec
+++ b/components/perf-tools/extrae/SPECS/extrae.spec
@@ -19,8 +19,8 @@
 Summary:	Extrae tool
 Name:		%{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Version:	3.5.2
-Release:	3
-License:	GNU
+Release:	3%{?dist}
+License:	LGPLv2+
 Group:		%{PROJ_NAME}/perf-tools
 URL:		https://tools.bsc.es
 Source0:	https://ftp.tools.bsc.es/extrae/extrae-%{version}-src.tar.bz2
@@ -47,10 +47,7 @@ This is the %{compiler_family}-%{mpi_family} version.
 %setup -q -n %{pname}-%{version}
 %patch1 -p1
 
-
 %build
-#export BUILDING_RPM=true
-
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
 
@@ -65,10 +62,9 @@ export compiler_vars="CC=icc CXX=icpc MPICC=mpicc MPIF90=mpiifort"
 
 ./bootstrap
 ./configure $compiler_vars --with-xml-prefix=/usr --with-papi=$PAPI_DIR  --without-unwind --without-dyninst --disable-openmp-intel --prefix=%{install_path} --with-mpi=$MPI_DIR
-make %{?_smp_mflags} 
+make %{?_smp_mflags}
 
 %install
-
 export NO_BRP_CHECK_RPATH=true
 
 # OpenHPC compiler designation
@@ -127,8 +123,5 @@ EOF
 
 %{__mkdir} -p $RPM_BUILD_ROOT/%{_docdir}
 
-
 %files
 %{OHPC_PUB}
-
-%doc

--- a/components/perf-tools/geopm/SPECS/geopm.spec
+++ b/components/perf-tools/geopm/SPECS/geopm.spec
@@ -36,6 +36,7 @@ BuildRequires: libtool-ltdl-devel
 BuildRequires: python
 BuildRequires: python-devel
 BuildRequires: unzip
+BuildRequires: zlib-devel
 
 %if 0%{?suse_version} >= 1320
 BuildRequires: openssh

--- a/components/perf-tools/pdtoolkit/SPECS/pdtoolkit.spec
+++ b/components/perf-tools/pdtoolkit/SPECS/pdtoolkit.spec
@@ -28,12 +28,9 @@ Provides:       %{name} = %{version}%{release}
 Provides:       %{name} = %{version}
 
 #!BuildIgnore: post-build-checks
-#define _unpackaged_files_terminate_build      0
-#define __check_files /bin/true
 
 # Default library install path
 %define install_path %{OHPC_LIBS}/%{compiler_family}/%{pname}/%version
-
 
 %description
 Program Database Toolkit (PDT) is a framework for analyzing source code written in several programming languages and for making rich program knowledge accessible to developers of static and dynamic analysis tools. PDT implements a standard program representation, the program database (PDB), that can be accessed in a uniform way through a class library supporting common PDB operations.

--- a/components/perf-tools/scalasca/SPECS/scalasca.spec
+++ b/components/perf-tools/scalasca/SPECS/scalasca.spec
@@ -26,7 +26,6 @@ URL:       http://www.scalasca.org
 Source0:   http://apps.fz-juelich.de/scalasca/releases/scalasca/2.4/dist/scalasca-%{version}.tar.gz
 Requires:  lmod%{PROJ_DELIM} >= 7.6.1
 BuildRequires: scorep-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-BuildRequires: scorep-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  scorep-%{compiler_family}-%{mpi_family}%{PROJ_DELIM} >= 4.0
 BuildRequires: zlib-devel
 

--- a/components/perf-tools/tau/SPECS/tau.spec
+++ b/components/perf-tools/tau/SPECS/tau.spec
@@ -148,7 +148,7 @@ export CONFIG_ARCH=%{machine}
 %if %{compiler_family} != intel
     -opari \
 %endif
-    -extrashlibopts="-fPIC -L/tmp%{install_path}/lib" 
+    -extrashlibopts="-fPIC -L/tmp%{install_path}/lib"
 
 make install
 make exports
@@ -179,7 +179,7 @@ make clean
 %if %{compiler_family} != intel
     -opari \
 %endif
-    -extrashlibopts="-fPIC -L$MPI_LIB_DIR -lmpi -L/tmp%{install_path}/lib" 
+    -extrashlibopts="-fPIC -L$MPI_LIB_DIR -lmpi -L/tmp%{install_path}/lib"
 
 make install
 make exports

--- a/components/provisioning/warewulf-common/SPECS/warewulf-common.spec
+++ b/components/provisioning/warewulf-common/SPECS/warewulf-common.spec
@@ -8,9 +8,6 @@
 #
 #----------------------------------------------------------------------------eh-
 
-%{!?_rel:%{expand:%%global _rel 0.r%(test "1686" != "0000" && echo "1686" || svnversion | sed 's/[^0-9].*$//' | grep '^[0-9][0-9]*$' || git svn find-rev `git show -s --pretty=format:%h` || echo 0000)}}
-
-
 %include %{_sourcedir}/OHPC_macros
 
 %define pname warewulf-common
@@ -20,7 +17,7 @@
 Name:    %{pname}%{PROJ_DELIM}
 Summary: A suite of tools for clustering
 Version: 3.8.1
-Release: %{_rel}%{?dist}
+Release: 1%{?dist}
 License: US Dept. of Energy (BSD-like)
 Group:   %{PROJ_NAME}/provisioning
 URL:     http://warewulf.lbl.gov/
@@ -40,16 +37,8 @@ BuildArch: noarch
 %if 0%{?suse_version}
 Requires: mysql perl-DBD-mysql
 %else
-# 07/23/14 travis.post@intel.com - alternate package names for RHEL7
-%if 0%{?rhel_version} > 600 || 0%{?centos_version} > 600
 Requires: mariadb-server perl-DBD-MySQL
 Requires: perl-Term-ReadLine-Gnu
-%else
-%if 0%{?rhel_version} < 700 || 0%{?centos_version} < 700
-Requires: mysql-server perl-DBD-mysql
-BuildRequires: db4-utils
-%endif
-%endif
 %endif
 
 %description

--- a/components/provisioning/warewulf-ipmi/SPECS/warewulf-ipmi.spec
+++ b/components/provisioning/warewulf-ipmi/SPECS/warewulf-ipmi.spec
@@ -8,29 +8,20 @@
 #
 #----------------------------------------------------------------------------eh-
 
-%{!?_rel:%{expand:%%global _rel 0.r%(test "1686" != "0000" && echo "1686" || svnversion | sed 's/[^0-9].*$//' | grep '^[0-9][0-9]*$' || git svn find-rev `git show -s --pretty=format:%h` || echo 0000)}}
-
 %include %{_sourcedir}/OHPC_macros
 
 %define pname warewulf-ipmi
 %define dname ipmi
 %define wwpkgdir /srv/warewulf
 
-%if 0%{?PROJ_NAME:1}
-%define rpmname %{pname}-%{PROJ_NAME}
-%else
-%define rpmname %{pname}
-%endif
-
-Name: %{rpmname}
+Name: %{pname}%{PROJ_DELIM}
 Summary: IPMI Module for Warewulf
 Version: 3.8.1
-Release: %{_rel}%{?dist}
+Release: 1%{?dist}
 License: US Dept. of Energy (BSD-like)
 Group: %{PROJ_NAME}/provisioning
 URL: http://warewulf.lbl.gov/
 Source0: https://github.com/warewulf/warewulf3/archive/%{version}.tar.gz#/warewulf3-%{version}.tar.gz
-ExclusiveOS: linux
 Requires: warewulf-common%{PROJ_DELIM}
 BuildRequires: autoconf
 BuildRequires: automake
@@ -64,12 +55,12 @@ if [ ! -f configure ]; then
     ./autogen.sh
 fi
 %configure --localstatedir=%{wwpkgdir}
-%{__make} %{?mflags}
+%{__make} %{?_smp_mflags}
 
 
 %install
 cd %{dname}
-%{__make} install DESTDIR=$RPM_BUILD_ROOT %{?mflags_install}
+%{__make} install DESTDIR=$RPM_BUILD_ROOT
 
 %{__mkdir} -p $RPM_BUILD_ROOT/%{_docdir}
 

--- a/components/runtimes/charliecloud/SPECS/charliecloud.spec
+++ b/components/runtimes/charliecloud/SPECS/charliecloud.spec
@@ -16,7 +16,7 @@
 Summary:   Lightweight user-defined software stacks for high-performance computing
 Name:      %{pname}%{PROJ_DELIM}
 Version:   0.9.2
-Release:   %{?dist}
+Release:   1%{?dist}
 License:   Apache-2.0
 Group:     %{PROJ_NAME}/runtimes
 URL:       https://hpc.github.io/charliecloud/
@@ -33,7 +33,7 @@ Source10:  charliecloud.1
 Patch1:    charliecloud-language_highlight.patch
 Patch2:    charliecloud-test-build.patch
 
-BuildRequires: python 
+BuildRequires: python
 BuildRequires: rsync
 
 # Default library install path

--- a/components/serial-libs/scotch/SPECS/scotch.spec
+++ b/components/serial-libs/scotch/SPECS/scotch.spec
@@ -16,7 +16,7 @@
 
 Name:		%{pname}-%{compiler_family}%{PROJ_DELIM}
 Version:	6.0.6
-Release:	1
+Release:	1%{?dist}
 Summary:	Graph, mesh and hypergraph partitioning library
 License:	CeCILL-C
 Group:		%{PROJ_NAME}/serial-libs


### PR DESCRIPTION
This mainly removes conditionals from SPEC files for distributions (EL5, EL6, Fedora) which OpenHPC does not support. It also cleans up trailing whitespace and commented out lines.