### PR TITLE
Don't use biosdevname for predictable network interface names

### DIFF
--- a/docs/recipes/install/common/add_ww_hosts_intro.tex
+++ b/docs/recipes/install/common/add_ww_hosts_intro.tex
@@ -22,7 +22,7 @@
 \begin{lstlisting}[language=bash,keywords={},upquote=true,basicstyle=\footnotesize\ttfamily]
 # Additional step required if desiring to use predictable network interface
 # naming schemes (e.g. en4s0f0). Skip if using eth# style names.
-[sms](*\#*) export kargs="${kargs} net.ifnames=1,biosdevname=1"
+[sms](*\#*) export kargs="${kargs} net.ifnames=1"
 [sms](*\#*) wwsh provision set --postnetdown=1 "${compute_regex}"
 \end{lstlisting}
 


### PR DESCRIPTION
There are two ways of doing the predictable network interface names
thing. The original biosdevname approach by Dell, and the newer scheme
by systemd/udev,
https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/
.

Most distros have dropped biosdevname (including RHEL upstream,
Fedora, see https://bugzilla.redhat.com/show_bug.cgi?id=965718 for
issues with biosdevname and why it was dropped), and are nowadays
using the udev naming convention.

RHEL 7, however, is a bit of a weird hybrid, in that in a default
installation the udev naming is used, except if it's a Dell system, in
which case biosdevname is used. This default logic can be overridden
with the biosdevname=0/1 kernel command line arguments. See
https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/networking_guide/sec-consistent_network_device_naming_using_biosdevname

For Warewulf, lets follow upstream and thus not force the use of
biosdevname, and instead use the udev scheme as specified by
net.ifnames=1 without the additional biosdevname=1 argument.