### PR TITLE
Update ohpc-find-requires

### DIFF
--- a/components/admin/ohpc-filesystem/SOURCES/ohpc-find-requires
+++ b/components/admin/ohpc-filesystem/SOURCES/ohpc-find-requires
@@ -28,7 +28,7 @@ fi
 searchPath="$2"
 
 if [ -z "$searchPath" ];then
-    >&2echo "Required search path argument not provided"
+    >&2 echo "Required search path argument not provided"
     exit 1
 fi
 


### PR DESCRIPTION
fix error printing in case of a missing search path