### PR TITLE
rms/pbspro: remove centos7.6 patch landed on latest version; revert

### DIFF
--- a/components/rms/pbspro/SPECS/pbspro.spec
+++ b/components/rms/pbspro/SPECS/pbspro.spec
@@ -78,6 +78,8 @@ BuildRequires: libedit-devel
 BuildRequires: libical-devel
 BuildRequires: ncurses-devel
 BuildRequires: perl
+BuildRequires: postgresql-devel >= 9.1
+BuildRequires: postgresql-contrib >= 9.1
 BuildRequires: python-devel >= 2.6
 BuildRequires: python-devel < 3.0
 BuildRequires: tcl-devel
@@ -92,15 +94,11 @@ BuildRequires: libXft-devel
 BuildRequires: fontconfig
 BuildRequires: timezone
 BuildRequires: python-xml
-BuildRequires: postgresql10-devel
-BuildRequires: postgresql10-contrib
 %else
 BuildRequires: expat-devel
 BuildRequires: openssl-devel
 BuildRequires: libXext
 BuildRequires: libXft
-BuildRequires: postgresql-devel >= 9.1
-BuildRequires: postgresql-contrib >= 9.1
 %endif
 
 # Pure python extensions use the 32 bit library path
@@ -248,7 +246,6 @@ functionality of PBS Professional.
 %prep
 %setup -n %{pbs_name}-%{pbs_version}
 %if 0%{?rhel}
-%patch0 -p1
 %endif
 
 %build


### PR DESCRIPTION
changes to buildrequires for postgres

Signed-off-by: Karl W. Schulz <karl@ices.utexas.edu>