### PR TITLE
Make munged log via syslog

### DIFF
--- a/components/rms/munge/SOURCES/munge.syslog.patch
+++ b/components/rms/munge/SOURCES/munge.syslog.patch
@@ -1,0 +1,11 @@
+--- src/etc/munge.service.in
++++ src/etc/munge.service.in
+@@ -6,7 +6,7 @@ After=time-sync.target
+ 
+ [Service]
+ Type=forking
+-ExecStart=@sbindir@/munged
++ExecStart=@sbindir@/munged --syslog
+ PIDFile=@localstatedir@/run/munge/munged.pid
+ User=munge
+ Group=munge

--- a/components/rms/munge/SPECS/munge.spec
+++ b/components/rms/munge/SPECS/munge.spec
@@ -53,6 +53,8 @@ Patch1:     %{pname}.logdir.patch
 Patch2:     %{pname}.initd.patch
 # 11/10/14 karl.w.schulz@intel.com - enable systemd-based startup
 Patch3:     %{pname}.service.patch
+# 2019-03-11 janne.blomqvist@aalto.fi - Enable syslog
+Patch4:     %{pname}.syslog.patch
 
 %if 0%{?suse_version} >= 1230
 Requires(pre):	shadow


### PR DESCRIPTION
By default munge writes logs by itself to
/var/long/munge/munged.log. This prevents those logs from being
forwarded to the log server (e.g. the OpenHPC SMS/admin machine), and
in case those logs for one reason or another grows rapidly (e.g.
https://github.com/dun/munge/issues/26) it can be a problem for
diskless nodes or compute nodes with small partitions for /var/log.

This should fix https://github.com/openhpc/ohpc/issues/943

Signed-off-by: Janne Blomqvist <janne.blomqvist@aalto.fi>