### PR TITLE
First cut at adding plumbing for microarchitecture optimized builds.

### DIFF
--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -68,6 +68,27 @@ BuildRequires: ohpc-buildroot
 %{!?compiler_family: %global compiler_family gnu8}
 %{!?mpi_family: %global mpi_family openmpi3}
 %{!?python_family: %global python_family python3}
+%{!?uarch: %global uarch generic}
+
+# Default optimization flags are empty
+# These are only used if a spec file calls the "%ohpc_setup_optflags" macro.
+%define ohpc_optflags %{nil}
+%define ohpc_optflags_uarch %{nil}
+
+# Microarchitecture dependencies
+%if 0%{?ohpc_uarch_dependent} == 1
+
+%global UARCH_DELIM %{nil}
+
+# Arm uarch targets
+%ifarch aarch64
+%if "%{uarch}" == "tx2"
+%global UARCH_DELIM -tx2
+%global ohpc_optflags_uarch -mtune=thunderx2t99 -mcpu=thunderx2t99
+%endif
+%endif
+
+%endif
 
 # Compiler dependencies
 %if 0%{?ohpc_compiler_dependent} == 1
@@ -154,3 +175,9 @@ Requires:      %{python_prefix}
     %endif \
 }
 
+%global ohpc_setup_optflags %{expand:\
+    export CFLAGS="%ohpc_optflags %ohpc_optflags_uarch"
+    export CXXFLAGS="%ohpc_optflags %ohpc_optflags_uarch"
+    export FFLAGS="%ohpc_optflags %ohpc_optflags_uarch"
+    export FCFLAGS="%ohpc_optflags %ohpc_optflags_uarch"
+}

--- a/components/serial-libs/openblas/SPECS/openblas.spec
+++ b/components/serial-libs/openblas/SPECS/openblas.spec
@@ -10,12 +10,13 @@
 
 # OpenBLAS build that is dependent on compiler toolchain
 %define ohpc_compiler_dependent 1
+%define ohpc_uarch_dependent 1
 %include %{_sourcedir}/OHPC_macros
 
 # Base package name
 %define pname openblas
 
-Name:           %{pname}-%{compiler_family}%{PROJ_DELIM}
+Name:           %{pname}-%{compiler_family}%{UARCH_DELIM}%{PROJ_DELIM}
 Version:        0.3.5
 Release:        1%{?dist}
 Summary:        An optimized BLAS library based on GotoBLAS2
@@ -34,7 +35,7 @@ ExclusiveArch:  %ix86 ia64 ppc ppc64 ppc64le x86_64 aarch64
 OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version.
 
 # Default library install path
-%define install_path %{OHPC_LIBS}/%{compiler_family}/%{pname}/%version
+%define install_path %{OHPC_LIBS}/%{compiler_family}/%{pname}%{UARCH_DELIM}/%version
 
 %prep
 %setup -q -n OpenBLAS-%{version}
@@ -53,7 +54,11 @@ OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version.
 %endif
 # Temporary fix, OpenBLAS does not autodetect aarch64
 %ifarch aarch64
+%if "%{uarch}" == "tx2"
+%define openblas_target TARGET=THUNDERX2T99 NUM_THREADS=256
+%else
 %define openblas_target TARGET=ARMV8 NUM_THREADS=256
+%endif
 %define nbjobs_option MAKE_NB_JOBS=4
 %endif
 
@@ -79,8 +84,8 @@ sed -i 's|%{buildroot}||g' %{buildroot}%{install_path}/lib/pkgconfig/openblas.pc
 rm -f %{buildroot}%{install_path}/lib/*a
 
 # OpenHPC module file
-%{__mkdir} -p %{buildroot}%{OHPC_MODULEDEPS}/%{compiler_family}/%{pname}
-%{__cat} << EOF > %{buildroot}/%{OHPC_MODULEDEPS}/%{compiler_family}/%{pname}/%{version}
+%{__mkdir} -p %{buildroot}%{OHPC_MODULEDEPS}/%{compiler_family}/%{pname}%{UARCH_DELIM}
+%{__cat} << EOF > %{buildroot}/%{OHPC_MODULEDEPS}/%{compiler_family}/%{pname}%{UARCH_DELIM}/%{version}
 #%Module1.0#####################################################################
 
 proc ModulesHelp { } {
@@ -109,10 +114,10 @@ setenv          %{PNAME}_INC        %{install_path}/include
 family "openblas"
 EOF
 
-%{__cat} << EOF > %{buildroot}/%{OHPC_MODULEDEPS}/%{compiler_family}/%{pname}/.version.%{version}
+%{__cat} << EOF > %{buildroot}/%{OHPC_MODULEDEPS}/%{compiler_family}/%{pname}%{UARCH_DELIM}/.version.%{version}
 #%Module1.0#####################################################################
 ##
-## version file for %{pname}-%{version}
+## version file for %{pname}%{UARCH_DELIM}-%{version}
 ##
 set     ModulesVersion      "%{version}"
 EOF


### PR DESCRIPTION
The goal is to make it easier for vendors and end-users to rebuild
OpenHPC packages with microarchitecture optimizations, if they choose
to do so.