### PR TITLE
Update boost to 1.70.0

### DIFF
--- a/components/parallel-libs/boost/SOURCES/boost-1.66.0-bjam-build-flags.patch
+++ b/components/parallel-libs/boost/SOURCES/boost-1.66.0-bjam-build-flags.patch
@@ -1,0 +1,26 @@
+--- boost_1_66_0/tools/build/src/engine/build.jam~	2018-02-07 21:36:14.552201421 +0000
++++ boost_1_66_0/tools/build/src/engine/build.jam	2018-02-07 21:36:29.014173266 +0000
+@@ -4,7 +4,7 @@
+ #~ http://www.boost.org/LICENSE_1_0.txt)
+ 
+ # Clean env vars of any "extra" empty values.
+-for local v in ARGV CC CFLAGS LIBS
++for local v in ARGV CC CFLAGS LIBS RPM_OPT_FLAGS RPM_LD_FLAGS
+ {
+     local values ;
+     for local x in $($(v))
+@@ -215,12 +215,12 @@
+     : -L$(--python-lib[1]) -l$(--python-lib[2]) ;
+ ## GCC 2.x, 3.x, 4.x
+ toolset gcc gcc : "-o " : -D
+-    : -pedantic -fno-strict-aliasing
++    : -pedantic -fno-strict-aliasing $(RPM_OPT_FLAGS)
+     [ opt --release : [ opt --symbols : -g : -s ] -O3 ]
+     [ opt --debug : -g -O0 -fno-inline ]
+     [ opt --profile : -O3 -g -pg ]
+     -I$(--python-include) -I$(--extra-include) -Wno-long-long
+-    : -L$(--python-lib[1]) -l$(--python-lib[2]) ;
++    : -L$(--python-lib[1]) -l$(--python-lib[2]) $(RPM_LD_FLAGS) ;
+ ## GCC 2.x, 3.x on CYGWIN but without cygwin1.dll
+ toolset gcc-nocygwin gcc : "-o " : -D
+     : -s -O3 -mno-cygwin

--- a/components/parallel-libs/boost/SOURCES/boost-1.66.0-build-optflags.patch
+++ b/components/parallel-libs/boost/SOURCES/boost-1.66.0-build-optflags.patch
@@ -1,0 +1,53 @@
+--- boost_1_66_0/tools/build/src/tools/gcc.jam~ 2017-12-13 23:56:50.000000000 +0000
++++ boost_1_66_0/tools/build/src/tools/gcc.jam	2018-01-19 12:48:26.264755316 +0000
+@@ -603,7 +603,7 @@ rule compile.fortran ( targets * : sourc
+ 
+ actions compile.c++ bind PCH_FILE
+ {
+-    "$(CONFIG_COMMAND)" $(LANG) -ftemplate-depth-$(TEMPLATE_DEPTH) $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(PCH_FILE:D)" -I"$(INCLUDES)" -c -o "$(<:W)" "$(>:W)"
++    "$(CONFIG_COMMAND)" $(LANG) $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(PCH_FILE:D)" -I"$(INCLUDES)" -c -o "$(<:W)" "$(>:W)"
+ }
+ 
+ actions compile.c bind PCH_FILE
+@@ -613,7 +613,7 @@ actions compile.c bind PCH_FILE
+ 
+ actions compile.c++.preprocess bind PCH_FILE
+ {
+-    "$(CONFIG_COMMAND)" $(LANG) -ftemplate-depth-$(TEMPLATE_DEPTH) $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(PCH_FILE:D)" -I"$(INCLUDES)" "$(>:W)" -E >"$(<:W)"
++    "$(CONFIG_COMMAND)" $(LANG) $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(PCH_FILE:D)" -I"$(INCLUDES)" "$(>:W)" -E >"$(<:W)"
+ }
+ 
+ actions compile.c.preprocess bind PCH_FILE
+@@ -702,19 +702,19 @@ actions compile.c.pch
+ ###
+ 
+ # Declare flags and action for compilation.
+-toolset.flags gcc.compile OPTIONS <optimization>off   : -O0 ;
+-toolset.flags gcc.compile OPTIONS <optimization>speed : -O3 ;
+-toolset.flags gcc.compile OPTIONS <optimization>space : -Os ;
+-
+-toolset.flags gcc.compile OPTIONS <inlining>off  : -fno-inline ;
+-toolset.flags gcc.compile OPTIONS <inlining>on   : -Wno-inline ;
+-toolset.flags gcc.compile OPTIONS <inlining>full : -finline-functions -Wno-inline ;
+-
+-toolset.flags gcc.compile OPTIONS <warnings>off : -w ;
+-toolset.flags gcc.compile OPTIONS <warnings>on  : -Wall ;
+-toolset.flags gcc.compile OPTIONS <warnings>all : -Wall ;
+-toolset.flags gcc.compile OPTIONS <warnings>extra : -Wall -Wextra ;
+-toolset.flags gcc.compile OPTIONS <warnings>pedantic : -Wall -Wextra -pedantic ;
++toolset.flags gcc.compile OPTIONS <optimization>off   :  ;
++toolset.flags gcc.compile OPTIONS <optimization>speed :  ;
++toolset.flags gcc.compile OPTIONS <optimization>space :  ;
++
++toolset.flags gcc.compile OPTIONS <inlining>off  :  ;
++toolset.flags gcc.compile OPTIONS <inlining>on   :  ;
++toolset.flags gcc.compile OPTIONS <inlining>full :  ;
++
++toolset.flags gcc.compile OPTIONS <warnings>off :  ;
++toolset.flags gcc.compile OPTIONS <warnings>on  :  ;
++toolset.flags gcc.compile OPTIONS <warnings>all :  ;
++toolset.flags gcc.compile OPTIONS <warnings>extra : ;
++toolset.flags gcc.compile OPTIONS <warnings>pedantic : ;
+ toolset.flags gcc.compile OPTIONS <warnings-as-errors>on : -Werror ;
+ 
+ toolset.flags gcc.compile OPTIONS <debug-symbols>on : -g ;

--- a/components/parallel-libs/boost/SPECS/boost.spec
+++ b/components/parallel-libs/boost/SPECS/boost.spec
@@ -21,9 +21,9 @@
 
 Summary:	Boost free peer-reviewed portable C++ source libraries
 Name:		%{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-Version:        1.69.0
+Version:        1.70.0
 
-%define version_exp 1_69_0
+%define version_exp 1_70_0
 
 Release:        1%{?dist}
 License:        BSL-1.0


### PR DESCRIPTION
This includes a patch to pickup the default optimization flags from the OS to build boost.

It also changes the output during the compile to print the actual compiler invocation to see in the build logs which compiler flags have been used.

Fixes: #971