### PR TITLE
Update lscpu call to use "geopmread --cache" in GEOPM tests

### DIFF
--- a/tests/perf-tools/geopm/tests/lscpu.sh
+++ b/tests/perf-tools/geopm/tests/lscpu.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-lscpu -x > /tmp/geopm-lscpu.log
+geopmread --cache


### PR DESCRIPTION
- Name of lscpu cache file has changed from "/tmp/geopm-lscpu.log" to
  "/tmp/geopm-topo-cache".

Signed-off-by: Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>