### PR TITLE
Do not check that deleted spec files conform to project guidelines

### DIFF
--- a/tests/travis/check_spec.py
+++ b/tests/travis/check_spec.py
@@ -35,7 +35,7 @@ if len(sys.argv) != 2:
     print("SKIP. Needs a git range as parameter")
     sys.exit(0)
 
-command = ['git', 'diff', '--name-only', sys.argv[1]]
+command = ['git', 'diff', '--diff-filter=ACMRTUXB', '--name-only', sys.argv[1]]
 
 print("About to run command %s" % ' '.join(command))
 


### PR DESCRIPTION
I noticed with #1005 that Travis was attempting to check a deleted spec file to ensure that it had the required spec file components.  I don't think this is the desired behavior.  This PR should filter out deleted items from being checked if the version of `git` being used is less than 1.8.5.  From what I can tell, travis is using a CentOS 7 docker image which is git version 1.8.3.

```
$ git --version
git version 1.8.3.1
$ grep filter tests/travis/check_spec.py
command = ['git', 'diff', '--diff-filter=ACMRTUXB', '--name-only', sys.argv[1]]
$ tests/travis/check_spec.py 90ebc7959bb698545959a2e1e4c0f8e21211d197...36214738481f5189a665d66e699040d1e2ae6ef7
About to run command git diff --diff-filter=ACMRTUXB --name-only 90ebc7959bb698545959a2e1e4c0f8e21211d197...36214738481f5189a665d66e699040d1e2ae6ef7
Checking that (^Source42.*$|^Source.*OHPC_macros$|^%changelog.*|^DocDir.*|^BuildRoot.*|^%defattr\(-,root,root\).*|^.*%global.*PROJ_DELIM.*$) does not exist

--> Scanning spec file components/admin/lmod/SPECS/lmod.spec

--> Scanning spec file components/distro-packages/lua-filesystem/SPECS/lua-filesystem.spec

--> Scanning spec file components/distro-packages/lua-posix/SPECS/luaposix.spec

No consistency errors found. Exiting.
$ cat /etc/centos-release
CentOS Linux release 7.6.1810 (Core)
```

***edit*** according to #870 this issue also exists when renaming spec files.  From my testing, this PR fixes that issue as well.