### PR TITLE
Update msr-safe to version 1.3.0

### DIFF
--- a/components/perf-tools/msr-safe/SPECS/msr-safe.spec
+++ b/components/perf-tools/msr-safe/SPECS/msr-safe.spec
@@ -17,7 +17,7 @@
 
 
 Name:           %{pname}%{PROJ_DELIM}
-Version:        1.2.1
+Version:        1.3.0
 Release:        1
 License:        GPLv3+
 Summary:        Allows safer access to model specific registers (MSRs)


### PR DESCRIPTION
The spank plugin that ships with the previous version (v1.2.1) is broken.

Signed-off-by: Brad Geltz <brad.geltz@intel.com>