### PR TITLE
MPI specfile updates to support OpenSUSE Leap 15

### DIFF
--- a/components/mpi-families/mpich/SPECS/mpich.spec
+++ b/components/mpi-families/mpich/SPECS/mpich.spec
@@ -75,6 +75,7 @@ export CPATH=${PMIX_INC}
 %endif
 
 ./configure --prefix=%{install_path} \
+            --libdir=%{install_path}/lib \
 %if 0%{with_slurm}
             --with-pm=no --with-pmi=slurm \
 %endif

--- a/components/mpi-families/mvapich2/SPECS/mvapich2.spec
+++ b/components/mpi-families/mvapich2/SPECS/mvapich2.spec
@@ -88,6 +88,7 @@ across multiple networks.
 %build
 %ohpc_setup_compiler
 ./configure --prefix=%{install_path} \
+            --libdir=%{install_path}/lib \
 	    --enable-cxx \
 	    --enable-g=dbg \
             --with-device=ch3:mrail \

--- a/components/mpi-families/openmpi/SPECS/openmpi.spec
+++ b/components/mpi-families/openmpi/SPECS/openmpi.spec
@@ -128,7 +128,7 @@ Open MPI jobs.
 %ohpc_setup_compiler
 
 
-BASEFLAGS="--prefix=%{install_path} --disable-static --enable-builtin-atomics --with-sge --enable-mpi-cxx"
+BASEFLAGS="--prefix=%{install_path} --libdir=%{install_path}/lib --disable-static --enable-builtin-atomics --with-sge --enable-mpi-cxx"
 
 # build against external pmix and libevent
 %if 0%{with_pmix}

--- a/tests/perf-tools/geopm/tests/lscpu.sh
+++ b/tests/perf-tools/geopm/tests/lscpu.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-lscpu -x > /tmp/geopm-lscpu.log
+geopmread --cache


### PR DESCRIPTION
Signed-off-by: jcsiadal <jeremy.c.siadal@intel.com>

I'm hitting this issue with several specfiles. Autoconf treats OpenSUSE 15 as a multiarch OS and defaults %libdir to /lib64. OpenHPC specfiles hardcode [PREFIX]/lib in scripts and %files, so the simpler fix is to force ./configure to use the desired directory.

With the OpenMPI build and resulting RPMs working, this allows about a dozen other current packages to build correctly under OpenSUSE Leap 15.1.

