### PR TITLE
Update post-build-check ignore macro

### DIFF
--- a/components/admin/nagios-plugins/SPECS/nagios-plugins.spec
+++ b/components/admin/nagios-plugins/SPECS/nagios-plugins.spec
@@ -76,7 +76,7 @@ BuildRequires: libdbi-devel
 
 %if 0%{?sles_version} || 0%{?suse_version}
 #!BuildIgnore: brp-check-suse
-BuildRequires: -post-build-checks
+#!BuildIgnore: post-build-checks
 %endif
 
 Requires: nagios-common%{PROJ_DELIM} >= 3.3.1-1

--- a/components/admin/nagios/SPECS/nagios.spec
+++ b/components/admin/nagios/SPECS/nagios.spec
@@ -64,7 +64,7 @@ BuildRequires: unzip
 
 %if 0%{?sles_version} || 0%{?suse_version}
 #!BuildIgnore: brp-check-suse
-BuildRequires: -post-build-checks
+#!BuildIgnore: post-build-checks
 BuildRequires: procps
 %else
 BuildRequires: procps-ng

--- a/components/admin/ndoutils/SPECS/ndoutils.spec
+++ b/components/admin/ndoutils/SPECS/ndoutils.spec
@@ -52,7 +52,7 @@ Requires(postun):   systemd
 
 %if 0%{?sles_version} || 0%{?suse_version}
 #!BuildIgnore: brp-check-suse
-BuildRequires: -post-build-checks
+#!BuildIgnore: post-build-checks
 %endif
 
 %description

--- a/components/admin/nrpe/SPECS/nrpe.spec
+++ b/components/admin/nrpe/SPECS/nrpe.spec
@@ -42,7 +42,7 @@ BuildRequires:  systemd
 
 %if 0%{?sles_version} || 0%{?suse_version}
 #!BuildIgnore: brp-check-suse
-BuildRequires: -post-build-checks
+#!BuildIgnore: post-build-checks
 %endif
 
 %if 0%{?suse_version}


### PR DESCRIPTION
Most of the other specfiles already implement the BuildIgnores comment. The remaining four use an invalid RPM syntax, so these packages cannot be compiled outside of OBS without correcting them first.