### PR TITLE
Updates msr-safe to version 1.4.0

### DIFF
--- a/components/perf-tools/msr-safe/SPECS/msr-safe.spec
+++ b/components/perf-tools/msr-safe/SPECS/msr-safe.spec
@@ -17,7 +17,7 @@
 
 
 Name:           %{pname}%{PROJ_DELIM}
-Version:        1.2.1
+Version:        1.4.0
 Release:        1
 License:        GPLv3+
 Summary:        Allows safer access to model specific registers (MSRs)


### PR DESCRIPTION
Add a patch on top of 1.3.0 from the master branch which fixes save restore for MSRs with open write masks.  This should be applied instead of #1008.  @bgeltz can you take that PR down?  Thanks.

relates to #1008 

