### PR TITLE
Update petsc to 3.11.3

### DIFF
--- a/components/parallel-libs/petsc/SOURCES/petsc.rpath.patch
+++ b/components/parallel-libs/petsc/SOURCES/petsc.rpath.patch
@@ -1,6 +1,6 @@
 --- petsc-3.7.0/config/BuildSystem/config/setCompilers.py	2016-04-25 08:17:04.000000000 -0700
 +++ petsc-3.7.0.patch/config/BuildSystem/config/setCompilers.py	2016-05-11 19:37:13.000000000 -0700
-@@ -1387,7 +1387,7 @@
+@@ -1443,7 +1443,7 @@
        self.pushLanguage(language)
        # test '-R' before '-rpath' as sun compilers [c,fortran] don't give proper errors with wrong options.
        if not Configure.isDarwin(self.log):

--- a/components/parallel-libs/petsc/SPECS/petsc.spec
+++ b/components/parallel-libs/petsc/SPECS/petsc.spec
@@ -25,7 +25,7 @@ Name:           %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Summary:        Portable Extensible Toolkit for Scientific Computation
 License:        2-clause BSD
 Group:          %{PROJ_NAME}/parallel-libs
-Version:        3.11.1
+Version:        3.11.3
 Release:        1%{?dist}
 Source0:        http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-%{version}.tar.gz
 Patch1:         petsc.rpath.patch


### PR DESCRIPTION
Signed-off-by: jcsiadal <jeremy.c.siadal@intel.com>

Updates PETSC to the latest version. This was needed to build the current version of PFLOTRAN.

I've testing the build process on CentOS 7.6 and my OpenSUSE 15.1 branch. I've compiled and run PFLOTRAN against the resulting petsc-intel-impi-ohpc rpm install.
