### PR TITLE
Fixed 'ls' output in README for creating OHPC local repo

### DIFF
--- a/misc/dist/README.in
+++ b/misc/dist/README.in
@@ -7,7 +7,7 @@ local repository after download. To use, simply unpack the tarball where you
 would like to host the local repository and execute the make_repo.sh script.
 
 # ls /opt/ohpc/repos
-@DISTRO@  mk_repo  OpenHPC-@VERSION@.@DISTRO@.@ARCH@.tar OpenHPC.local.repo
+@DISTRO@  make_repo.sh  OpenHPC-@VERSION@.@DISTRO@.@ARCH@.tar OpenHPC.local.repo README
 
 # ./make_repo.sh
 --> Creating OpenHPC.local.repo file in @PACKAGE_MANAGER_DIR@


### PR DESCRIPTION
This patch corrected the 'ls' command output in README of
OpenHPC-@VERSION@.@DISTRO@.@ARCH@.tar.