### PR TITLE
Use less specific python version for travis

### DIFF
--- a/tests/travis/Dockerfile.check_spec
+++ b/tests/travis/Dockerfile.check_spec
@@ -2,7 +2,7 @@ FROM centos:7
 
 ARG TRAVIS_COMMIT_RANGE
 ENV TRAVIS_COMMIT_RANGE=$TRAVIS_COMMIT_RANGE
-ENV PYTHON_BINARY=python36
+ENV PYTHON_BINARY=python3
 
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum install -y git ${PYTHON_BINARY}


### PR DESCRIPTION
In #1032 travis is failing because the `python36` command is not found.  It looks like EPEL has deprecated this package in favor of the CentOS 7.7 provided one[1].

Because the default python3 is the appropriate version already and because the shebang in `check_spec.py` already calls out the less specific python version, I think it's appropriate that the Dockerfile be updated to match.

_edited to reflect the package was deprecated not renamed_

[1] https://lists.fedoraproject.org/archives/list/epel-devel@lists.fedoraproject.org/thread/GUSLTD5AJWFEGBFK5EYFVH3LHQVHUBAP/#AT736IKJUKNLP55YQETEFN2YJ5GM2YWO
