### PR TITLE
Patch intel-linux toolset to use -std=c++11 

### DIFF
--- a/components/parallel-libs/boost/SOURCES/boost-1.71.0-intel-bootstrap.patch
+++ b/components/parallel-libs/boost/SOURCES/boost-1.71.0-intel-bootstrap.patch
@@ -1,0 +1,13 @@
+--- boost_1_71_0/tools/build/src/engine/build.sh~       2019-10-09 13:19:04.837484245 -0700
++++ boost_1_71_0/tools/build/src/engine/build.sh        2019-10-09 13:19:30.843484245 -0700
+@@ -234,7 +234,8 @@
+             export LD_RUN_PATH
+             . ${B2_TOOLSET_ROOT}bin/iccvars.sh $ARCH
+         fi
+-        B2_CXX="${CXX} -xc++"
++       # https://github.com/boostorg/build/issues/475
++        B2_CXX="${CXX} -xc++  -std=c++11"
+         B2_CXXFLAGS_RELEASE="-O3 -s"
+         B2_CXXFLAGS_DEBUG="-O0 -g -p"
+     ;;
+

--- a/components/parallel-libs/boost/SPECS/boost.spec
+++ b/components/parallel-libs/boost/SPECS/boost.spec
@@ -40,6 +40,12 @@ Patch1:         boost_fenv_suse.patch
 %endif
 %endif
 
+# intel-linux toolset fix: https://github.com/boostorg/build/issues/475
+%if "%{compiler_family}" == "intel"
+Patch2:         boost-1.71.0-intel-bootstrap.patch
+%endif
+
+
 # optflag patch from Fedora
 Patch4: https://src.fedoraproject.org/rpms/boost/raw/master/f/boost-1.66.0-build-optflags.patch
 
@@ -92,6 +98,10 @@ see the boost-doc package.
 %if 0%{?sles_version} || 0%{?suse_version}
 %patch1 -p1
 %endif
+%endif
+
+%if "%{compiler_family}" == "intel"
+%patch2 -p1
 %endif
 
 # optflag patches from Fedora 


### PR DESCRIPTION
The boost `intel-linux` toolset has an issue[1] open regarding the missing `-std=c++11` for the intel compiler.  I've added a patch that implements the suggested fix from that issue.  I ran the boost ohpc test suite and the non resource manager based tests seem to be passing.  I haven't run the resource manager based tests as my local environment isn't yet set up for that.

Should fix #1035

[1] https://github.com/boostorg/build/issues/475