### PR TITLE
pmix: remove unnecessary BuildRequires

### DIFF
--- a/components/rms/pmix/SPECS/pmix.spec
+++ b/components/rms/pmix/SPECS/pmix.spec
@@ -13,15 +13,14 @@
 
 Summary: An extended/exascale implementation of PMI
 Name: %{pname}%{PROJ_DELIM}
-Version: 2.2.2
+Version: 2.2.3
 Release: 1%{?dist}
 License: BSD
 URL: https://pmix.github.io/pmix/
 Group: %{PROJ_NAME}/rms
-Source: https://github.com/pmix/pmix/releases/download/v%{version}/pmix-%{version}.tar.bz2
+Source0: https://github.com/pmix/pmix/releases/download/v%{version}/pmix-%{version}.tar.bz2
 
 BuildRequires: libevent-devel
-BuildRequires: lmod-ohpc libtool-ohpc
 BuildRequires: gcc-c++
 #!BuildIgnore: post-build-checks
 


### PR DESCRIPTION
* remove BR on lmod and libtool as it is unused
* update to 2.2.3
* switch Source to Source0 (newer RPMs require that)

Signed-off-by: Adrian Reber <areber@redhat.com>