### PR TITLE
Use caf and cafrun wrappers for opencoarrays tests

### DIFF
--- a/tests/libs/opencoarrays/configure.ac
+++ b/tests/libs/opencoarrays/configure.ac
@@ -18,8 +18,8 @@ else
 fi
 
 # set compilers to use MPI toolchain 
-F77=mpif77
-FC=mpif90
+F77=caf
+FC=caf
 
 # test compilers
 AC_PROG_F77

--- a/tests/libs/opencoarrays/tests/rm_execution
+++ b/tests/libs/opencoarrays/tests/rm_execution
@@ -31,3 +31,27 @@ ARGS=8
     fi
 
 }
+
+@test "[libs/OpenCoarrays] hello_multiverse binary runs under resource manager using cafrun script ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
+    if [ ! -s hello ];then
+		flunk "hello binary does not exist"
+    fi
+
+    if echo "$LMOD_FAMILY_MPI" | grep -q mvapich ; then
+		export MV2_ENABLE_AFFINITY=0
+    fi
+
+    if [ "$LMOD_FAMILY_MPI" != "impi" ];then
+		cafcmd="cafrun -np $TASKS ./hello"
+
+		if [ "$rm" = "slurm" ];then
+			srun $cafcmd
+			assert_success
+		elif [ "$rm" = "pbspro" ];then
+			qsub -W block=true $cafcmd
+			assert_success
+		fi
+	fi
+
+}
+


### PR DESCRIPTION
In #884 it was determined that the `caf` wrapper script was broken.  According to the [documentation](https://github.com/sourceryinstitute/OpenCoarrays/blob/master/GETTING_STARTED.md) this wrapper is the preferred method for using opencoarrays.  In order to ensure that this script is working going forward, this PR modifies the existing opencoarrays tests to use `caf` instead of calling `mpif*` directly.  Additionally, it adds another resource manager test to ensure that `cafrun` runs MPI jobs as expected.

When I tested this on OpenHPC 1.3.8.1 the tests fail with an expected error[1] as described in #884.  With the current 1.3.9 that's staged, these tests pass for openmpi3 and mpich.  I'm seeing failures for mvapich2 but I believe that's a known issue.

[1]
```
## ----------- ##
## Core tests. ##
## ----------- ##

configure:1921: checking for a BSD-compatible install
configure:1989: result: /bin/install -c
configure:2000: checking whether build environment is sane
configure:2055: result: yes
configure:2206: checking for a thread-safe mkdir -p
configure:2245: result: /bin/mkdir -p
configure:2252: checking for gawk
configure:2268: found /bin/gawk
configure:2279: result: gawk
configure:2290: checking whether make sets $(MAKE)
configure:2312: result: yes
configure:2341: checking whether make supports nested variables
configure:2358: result: yes
configure:2453: checking whether make supports nested variables
configure:2470: result: yes
configure:2483: checking for OPENCOARRAYS_DIR environment variable
configure:2491: result: no
configure:2606: checking for Fortran 77 compiler version
configure:2615: caf --version >&5
Failed to find static library /opt/ohpc/pub/libs/gnu8/mpich/opencoarrays/2.6.3/lib64/libcaf_mpi.a or shared library alternatives.
Error in /opt/ohpc/pub/libs/gnu8/mpich/opencoarrays/2.6.3/bin/caf in function . on line 235. Please report this error at http://bit.ly/OpenCoarrays-new-issue
configure:2626: $? = 0
configure:2615: caf -v >&5
Failed to find static library /opt/ohpc/pub/libs/gnu8/mpich/opencoarrays/2.6.3/lib64/libcaf_mpi.a or shared library alternatives.
Error in /opt/ohpc/pub/libs/gnu8/mpich/opencoarrays/2.6.3/bin/caf in function . on line 235. Please report this error at http://bit.ly/OpenCoarrays-new-issue
configure:2626: $? = 0
configure:2615: caf -V >&5
Failed to find static library /opt/ohpc/pub/libs/gnu8/mpich/opencoarrays/2.6.3/lib64/libcaf_mpi.a or shared library alternatives.
Error in /opt/ohpc/pub/libs/gnu8/mpich/opencoarrays/2.6.3/bin/caf in function . on line 235. Please report this error at http://bit.ly/OpenCoarrays-new-issue
configure:2626: $? = 0
configure:2615: caf -qversion >&5
Failed to find static library /opt/ohpc/pub/libs/gnu8/mpich/opencoarrays/2.6.3/lib64/libcaf_mpi.a or shared library alternatives.
Error in /opt/ohpc/pub/libs/gnu8/mpich/opencoarrays/2.6.3/bin/caf in function . on line 235. Please report this error at http://bit.ly/OpenCoarrays-new-issue
configure:2626: $? = 0
configure:2641: checking whether the Fortran 77 compiler works
configure:2663: caf   conftest.f  >&5
Failed to find static library /opt/ohpc/pub/libs/gnu8/mpich/opencoarrays/2.6.3/lib64/libcaf_mpi.a or shared library alternatives.
Error in /opt/ohpc/pub/libs/gnu8/mpich/opencoarrays/2.6.3/bin/caf in function . on line 235. Please report this error at http://bit.ly/OpenCoarrays-new-issue
configure:2667: $? = 0
configure:2705: result: no
configure: failed program was:
|       program main
|
|       end
configure:2710: error: in `/home/ohpc-test/tests/libs/opencoarrays':
configure:2712: error: Fortran 77 compiler cannot create executables
```