### PR TITLE
Add information about OpenHPC based containers

### DIFF
--- a/containers/Dockerfile.ohpc-gnu8
+++ b/containers/Dockerfile.ohpc-gnu8
@@ -1,0 +1,10 @@
+FROM centos:centos7
+
+MAINTAINER The OpenHPC Project
+
+RUN yum -y install http://build.openhpc.community/OpenHPC:/1.3/CentOS_7/x86_64/ohpc-release-1.3-1.el7.x86_64.rpm && \
+    yum -y install gnu8-compilers-ohpc lmod-ohpc && \
+    yum clean all
+
+ENV LD_LIBRARY_PATH="/opt/ohpc/pub/compiler/gcc/8.3.0/lib64"
+ENV PATH="/opt/ohpc/pub/compiler/gcc/8.3.0/bin:${PATH}"

--- a/containers/Dockerfile.ohpc-gnu8-mpich
+++ b/containers/Dockerfile.ohpc-gnu8-mpich
@@ -1,0 +1,8 @@
+FROM ohpc-gnu8:1.3.9
+
+MAINTAINER The OpenHPC Project
+
+RUN yum -y install mpich-gnu8-ohpc && \
+    yum clean all
+
+ENV PATH="/opt/ohpc/pub/mpi/mpich-gnu8-ohpc/3.3.1/bin:${PATH}"

--- a/containers/Dockerfile.ohpc-gnu8-mvapich2
+++ b/containers/Dockerfile.ohpc-gnu8-mvapich2
@@ -1,0 +1,8 @@
+FROM ohpc-gnu8:1.3.9
+
+MAINTAINER The OpenHPC Project
+
+RUN yum -y install mvapich2-gnu8-ohpc && \
+    yum clean all
+
+ENV PATH="/opt/ohpc/pub/mpi/mvapich2-gnu8/2.3.2/bin:${PATH}"

--- a/containers/Dockerfile.ohpc-gnu8-openmpi3
+++ b/containers/Dockerfile.ohpc-gnu8-openmpi3
@@ -1,0 +1,8 @@
+FROM ohpc-gnu8:1.3.9
+
+MAINTAINER The OpenHPC Project
+
+RUN yum -y install openmpi3-gnu8-ohpc && \
+    yum clean all
+
+ENV PATH="/opt/ohpc/pub/mpi/openmpi3-gnu8/3.1.4/bin:${PATH}"

--- a/containers/Makefile
+++ b/containers/Makefile
@@ -1,0 +1,57 @@
+COMPILER := gnu8
+MPIS := openmpi3 mpich mvapich2
+CONTAINERS := $(COMPILER) $(addprefix $(COMPILER)-,$(MPIS))
+CONTAINER_RUNTIME := podman
+CONTAINERS_PUSH := $(addsuffix -push,$(CONTAINERS))
+COMPILER_CHECK := $(addsuffix -check,$(COMPILER))
+MPIS_CHECK := $(addsuffix -check,$(addprefix $(COMPILER)-,$(MPIS)))
+
+DEST ?= quay.io/adrianreber/
+VERSION ?= 1.3.9
+
+.PHONY: all $(CONTAINERS) push $(CONTAINERS_PUSH) $(COMPILER_CHECK) $(MPIS_CHECK) clean
+
+all: $(CONTAINERS)
+
+$(CONTAINERS):
+	$(CONTAINER_RUNTIME) build . -f Dockerfile.ohpc-$@ --tag=ohpc-$@:$(VERSION)
+
+define PUSH
+$(1)-push: $(1)
+	$(CONTAINER_RUNTIME) push ohpc-$(1):$(VERSION) $(DEST)ohpc-$(1):$(VERSION)
+	$(CONTAINER_RUNTIME) push ohpc-$(1):$(VERSION) $(DEST)ohpc-$(1):latest
+endef
+$(foreach c,$(CONTAINERS),$(eval $(call PUSH,$(c))))
+
+push: $(CONTAINERS_PUSH)
+
+$(COMPILER_CHECK): $(COMPILER)
+	rm -f test/hello
+	$(CONTAINER_RUNTIME) run --rm -v `pwd`/test:/tmp:z ohpc-$<:$(VERSION) gcc -o /tmp/hello /tmp/hello.c
+	$(CONTAINER_RUNTIME) run --rm -v `pwd`/test:/tmp:z ohpc-$<:$(VERSION) /tmp/hello
+	rm -f test/hello
+
+define MPI_CHECK
+$(1)-check: $(1)
+	rm -f test/hello test/mpi-hello
+	$(CONTAINER_RUNTIME) run --rm -v `pwd`/test:/tmp:z ohpc-$(1):$(VERSION) mpicc -o /tmp/hello /tmp/hello.c
+	$(CONTAINER_RUNTIME) run --rm -v `pwd`/test:/tmp:z ohpc-$(1):$(VERSION) /tmp/hello
+	$(CONTAINER_RUNTIME) run --rm -v `pwd`/test:/tmp:z ohpc-$(1):$(VERSION) mpicc -o /tmp/mpi-hello /tmp/mpi-hello.c
+	if [[ "$(1)" == *"openmpi"* ]]; then \
+		mkdir /tmp/podman-mpirun ;\
+		. $(MODULESHOME)/init/bash && module purge && \
+		. $(MODULESHOME)/init/bash && module load `echo $(1) | sed -e "s,-, ,g"` ;\
+		OMPI_MCA_orte_tmpdir_base=/tmp/podman-mpirun mpirun $(CONTAINER_RUNTIME) run -v /tmp/podman-mpirun:/tmp/podman-mpirun --env-host --rm -v `pwd`/test:/tmp:z --userns=keep-id  --net=host --pid=host --ipc=host ohpc-$(1):$(VERSION) /tmp/mpi-hello ;\
+		rm -rf /tmp/podman-mpirun test/podman-mpirun ;\
+		. $(MODULESHOME)/init/bash && module purge ;\
+	elif [[ "$(1)" == *"mpich"* ]]; then \
+		$(CONTAINER_RUNTIME) run --rm -v `pwd`/test:/tmp:z ohpc-$(1):$(VERSION) /tmp/mpi-hello ;\
+	fi
+	rm -f test/hello test/mpi-hello
+endef
+$(foreach c,$(addprefix $(COMPILER)-,$(MPIS)),$(eval $(call MPI_CHECK,$(c))))
+
+check: $(COMPILER_CHECK) $(MPIS_CHECK)
+
+clean:
+	rm -f test/hello test/mpi-hello

--- a/containers/README.md
+++ b/containers/README.md
@@ -1,0 +1,77 @@
+# OpenHPC container images
+
+> (Everything defaults to `podman` as it provides the possibility to build
+> containers without running as root. See 
+> https://podman.io/blogs/2019/10/28/podman-with-nfs.html for details.)
+
+The OpenHPC project currently provides the following container images:
+
+ * ohpc-gnu8:1.3.9
+ * ohpc-gnu8-mpich:1.3.9
+ * ohpc-gnu8-mvapich2:1.3.9
+ * ohpc-gnu8-openmpi3:1.3.9
+
+All containers images are also available with the version specifier `latest`.
+
+`ohpc-gnu8` is based on `centos7` and all other container images are based on
+`ohpc-gnu8`.
+
+Currently all container images are reachable at `quay.io/adrianreber/`:
+
+`podman pull quay.io/adrianreber/ohpc-gnu8:latest`
+
+## Rebuilding the OpenHPC container images
+
+The OpenHPC container images can be locally rebuilt just by running `make`.
+To override the version with which the container images are tagged use a
+command like this: `VERSION=10.30 make`.
+
+Using the command `make push` the container images will be built and pushed
+to their default location. The container registry can be changed with the
+following command: `DEST=container.registry/path make push`.
+
+## Using the OpenHPC container images
+
+One possible use case is to have quick access to the OpenHPC provided compiler
+and MPI compiler:
+```
+$ cat test/hello.c 
+#include <stdio.h>
+
+int main()
+{
+	printf("Hello, world!\n");
+}
+$ podman run --rm -v `pwd`/test:/tmp:z ohpc-gnu8:1.3.9 gcc -o /tmp/hello /tmp/hello.c
+$ podman run --rm -v `pwd`/test:/tmp:z ohpc-gnu8:1.3.9 /tmp/hello
+Hello, world!
+$ podman run --rm -v `pwd`/test:/tmp:z ohpc-gnu8-mpich:1.3.9 mpicc -o /tmp/mpi-hello /tmp/mpi-hello.c
+$ podman run --rm -v `pwd`/test:/tmp:z ohpc-gnu8-mpich:1.3.9 /tmp/mpi-hello
+ Hello, world (1 procs total)
+    --> Process #   0 of   1 is alive. ->962f5dcd6374
+```
+
+It is also possible to build containers based on the OpenHPC containers:
+```
+$ cat Dockerfile
+FROM quay.io/adrianreber/ohpc-gnu8-mpich:latest
+
+COPY mpi-hello.c /home
+RUN mpicc -o /home/mpi-hello /home/mpi-hello.c
+
+WORKDIR /home
+CMD mpirun -np 8 /home/mpi-hello
+
+$ podman build . --tag=my-ohpc-container
+$ podman run my-ohpc-container
+
+ Hello, world (8 procs total)
+    --> Process #   0 of   8 is alive. ->c7121a4fcc95
+    --> Process #   1 of   8 is alive. ->c7121a4fcc95
+    --> Process #   2 of   8 is alive. ->c7121a4fcc95
+    --> Process #   3 of   8 is alive. ->c7121a4fcc95
+    --> Process #   4 of   8 is alive. ->c7121a4fcc95
+    --> Process #   5 of   8 is alive. ->c7121a4fcc95
+    --> Process #   6 of   8 is alive. ->c7121a4fcc95
+    --> Process #   7 of   8 is alive. ->c7121a4fcc95
+```

--- a/containers/test/hello.c
+++ b/containers/test/hello.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main()
+{
+	printf("Hello, world!\n");
+}

--- a/containers/test/mpi-hello.c
+++ b/containers/test/mpi-hello.c
@@ -1,0 +1,38 @@
+#include "mpi.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(argc, argv, env)
+     int argc;
+     char *argv[];
+     char *env[];
+
+{
+  int num_procs, num_local;
+  char mach_name[MPI_MAX_PROCESSOR_NAME];
+  int mach_len;
+
+  MPI_Init (&argc,&argv);
+  MPI_Comm_size (MPI_COMM_WORLD, &num_procs);
+  MPI_Comm_rank (MPI_COMM_WORLD, &num_local);
+  MPI_Get_processor_name(mach_name,&mach_len);
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  if(num_local == 0)
+    {
+      printf("\n Hello, world (%i procs total)\n",num_procs);
+      //printf("   -> Env. variable KOOMIE_TEST = %s\n",getenv("OMPI_MCA_ns_nds_vpid"));
+      //      printf("   -> Env. variable KOOMIE_TEST = %s\n",getenv("LD_LIBRARY_PATH"));
+    }
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  printf("    --> Process # %3i of %3i is alive. ->%s\n",
+	 num_local,num_procs,mach_name);
+
+  MPI_Finalize();
+  return 0;
+
+}


### PR DESCRIPTION
(This is still using my private quay.io registry URLs, which can be replaced later with the real location)

During SC19 there were a couple of questions about OpenHPC based containers. Although it is easy to create an OpenHPC based container (see Dockerfiles) it is even more convenient if it already exists.

Details about the containers can be found in the README.md file.

 * `make` # to build all container
 * `make push` # build and push all container to a registry
 * `make check` # run some simple checks using the containers