### PR TITLE
Fixed misc/get_source.sh OHPC_macros open error

### DIFF
--- a/misc/get_source.sh
+++ b/misc/get_source.sh
@@ -21,7 +21,7 @@ for i in `find . -name "${PATTERN}"`; do
 	pushd `dirname ${i}` > /dev/null
 	BASE=`basename ${i}`
 
-	SOURCES=`rpmspec --parse --define '_sourcedir ../SOURCES' --define 'rhel 7' ${BASE} | grep Source`
+	SOURCES=`rpmspec --parse --define '_sourcedir ../../..' --define 'rhel 8' ${BASE} | grep Source`
 	for u in ${SOURCES}; do
 		echo ${u}
 		if [[ "${u}" != *"http"* ]]; then


### PR DESCRIPTION
This patch fixed misc/get_source.sh "error: Unable to open
../SOURCES/OHPC_macros: No such file or directory" by updating
'_sourcedir' rpm macros, and also updated 'rhel' for OHPC 2.0.

Signed-off-by: Naohiro Tamura <naohirot@jp.fujitsu.com>