### PR TITLE
Annobin updates for CentOS and OpenSUSE

### DIFF
--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -47,7 +47,7 @@ Source42: OHPC_macros
 # macros defined in each specfile.
 %if 0%{!?rhel_version:1}
 %{?centos_version: %global rhel_version=%{centos_version}}
-%{?scientificlinux_version: %global rhel_version=%{scientific_version}}
+%{?scientificlinux_version: %global rhel_version=%{scientificlinux_version}}
 %if 0%{?rhel} == 7
     # OBS defines rhel_version to 700 for RHEL7
     %global rhel_version 700
@@ -57,13 +57,6 @@ Source42: OHPC_macros
     %global rhel_version 800
 %endif # rhel=8
 %endif # rhel_version
-
-# OpenHPC packages also require ohpc-buildroot to access macros used to define
-# compiler and MPI families
-%if 0%{!?ohpc_bootstrap:1}
-Requires: ohpc-filesystem
-BuildRequires: ohpc-buildroot
-%endif
 
 # OpenHPC convention: the default build configuration for compiler/MPI
 # dependent packages assumes the gnu compiler and openmpi family; however,
@@ -80,15 +73,11 @@ BuildRequires: ohpc-buildroot
 %if "%{compiler_family}" == "gnu9"
 BuildRequires: gnu9-compilers%{PROJ_DELIM} >= 9.2.0
 Requires:      gnu9-compilers%{PROJ_DELIM} >= 9.2.0
-%endif
+%endif # gnu9
 %if "%{compiler_family}" == "gnu8"
 BuildRequires: gnu8-compilers%{PROJ_DELIM} >= 8.3.0
 Requires:      gnu8-compilers%{PROJ_DELIM} >= 8.3.0
 %endif # gnu8
-%if "%{compiler_family}" == "gnu9"
-BuildRequires: gnu9-compilers%{PROJ_DELIM} >= 9.2.0
-Requires:      gnu9-compilers%{PROJ_DELIM} >= 9.2.0
-%endif # gnu9
 %if "%{compiler_family}" == "intel"
 BuildRequires: gcc-c++ intel-compilers-devel%{PROJ_DELIM}
 Requires:      gcc-c++ intel-compilers-devel%{PROJ_DELIM}
@@ -106,15 +95,29 @@ BuildRequires: llvm-compilers%{PROJ_DELIM} >= 9.0.0
 Requires:      llvm-compilers%{PROJ_DELIM} >= 9.0.0
 %endif # llvm
 
-# Disable annobin on RHEL based systems
-%if 0%{?rhel} == 8
-%undefine _annotated_build
-%endif
+# If this is RHEL8, and we're using an OpenHPC compiler, and
+# annobin is not explicitly disabled, then enable OpenHPC annobin.
+# For everything else, it will default to system annobin.
+%if 0%{?rhel} >= 8 && ! 0%{?no_ohpc_annobin}
+Requires: annobin-%{compiler_family}%{PROJ_DELIM}
+%endif # Use OHPC annobin
 
 %endif # compiler_depdendent
 
+# Explicitly disable annobin on non-RHEL 8 systems
+%if 0%{?rhel} != 8 
+%undefine _annotated_build
+%endif
+
+# OpenHPC packages also require ohpc-buildroot to access macros used to define
+# compiler and MPI families
+%if 0%{?ohpc_bootstrap} != 1
+Requires: ohpc-filesystem
+BuildRequires: ohpc-buildroot
+%endif
+
 # Disable RPM symlink analysis on files in %%{OHPC_HOME}.
-%global __libsymlink_exclude_path  %{OHPC_HOME}/.*$
+%global __libsymlink_exclude_path %{OHPC_HOME}/.*$
 
 # MPI dependencies
 %if 0%{?ohpc_mpi_dependent} == 1
@@ -176,7 +179,7 @@ Requires:      %{python_prefix}
 %global luaver 5.2
 %endif # sle12
 # Lua 5.3 is used by OpenSUSE/SLES 15 and RHEL/CentOS 8
-%if 0%{?sle_version} >= 150000 || 0%{?rhel_version} >=800
+%if 0%{?sle_version} >= 150000 || 0%{?rhel} >= 8
 %global luaver 5.3
 %endif # sle15/rh8
 %endif # lua_version not set

--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -95,19 +95,10 @@ BuildRequires: llvm-compilers%{PROJ_DELIM} >= 9.0.0
 Requires:      llvm-compilers%{PROJ_DELIM} >= 9.0.0
 %endif # llvm
 
-# If this is RHEL8, and we're using an OpenHPC compiler, and
-# annobin is not explicitly disabled, then enable OpenHPC annobin.
-# For everything else, it will default to system annobin.
-%if 0%{?rhel} >= 8 && ! 0%{?no_ohpc_annobin}
-Requires: annobin-%{compiler_family}%{PROJ_DELIM}
-%endif # Use OHPC annobin
-
 %endif # compiler_depdendent
 
-# Explicitly disable annobin on non-RHEL 8 systems
-%if 0%{?rhel} != 8 
+# Explicitly disable annobin on OopenHPC builds
 %undefine _annotated_build
-%endif
 
 # OpenHPC packages also require ohpc-buildroot to access macros used to define
 # compiler and MPI families

--- a/components/compiler-families/gnu-compilers/SPECS/gnu-compilers.spec
+++ b/components/compiler-families/gnu-compilers/SPECS/gnu-compilers.spec
@@ -8,6 +8,9 @@
 #
 #----------------------------------------------------------------------------eh-
 
+# GNU compilers are required for bootstrapping OpenHPC annobin
+%define no_ohpc_annobin 1
+
 %include %{_sourcedir}/OHPC_macros
 
 %global gnu_version 9.2.0
@@ -43,7 +46,7 @@ BuildRequires:  makeinfo
 BuildRequires:  texinfo
 %endif
 BuildRequires:  zlib-devel
-%if 0%{?sles_version} || 0%{?suse_version}
+%if 0%{?sle_version} || 0%{?suse_version}
 BuildRequires:  fdupes
 %endif
 Requires: glibc-devel
@@ -67,7 +70,11 @@ ln -s mpfr-%{mpfr_version} mpfr
 
 %{__mkdir} obj
 cd obj
-../configure --disable-multilib --enable-languages="c,c++,fortran"  --prefix=%{install_path} --disable-static --enable-shared
+../configure --disable-multilib \
+             --enable-languages="c,c++,fortran" \
+             --prefix=%{install_path} \
+             --disable-static \
+             --enable-shared 
 make %{?_smp_mflags}
 %install
 cd obj

--- a/components/compiler-families/gnu-compilers/SPECS/gnu-compilers.spec
+++ b/components/compiler-families/gnu-compilers/SPECS/gnu-compilers.spec
@@ -8,9 +8,6 @@
 #
 #----------------------------------------------------------------------------eh-
 
-# GNU compilers are required for bootstrapping OpenHPC annobin
-%define no_ohpc_annobin 1
-
 %include %{_sourcedir}/OHPC_macros
 
 %global gnu_version 9.2.0

--- a/components/dev-tools/annobin/SPECS/annobin.spec
+++ b/components/dev-tools/annobin/SPECS/annobin.spec
@@ -25,11 +25,16 @@ Group:   %{PROJ_NAME}/dev-tools
 URL:     https://fedoraproject.org/wiki/Toolchain/Watermark
 Source:  https://nickc.fedorapeople.org/annobin-%{version}.tar.xz
 BuildRequires: gmp-devel
-BuildRequires: elfutils-devel
 BuildRequires: binutils-devel
 BuildRequires: rpm-devel
+%if 0%{?rhel_version}
 BuildRequires: gcc-plugin-devel
-BuildRequires: annobin
+BuildRequires: elfutils-devel
+%endif
+%if 0%{?sle_version}
+BuildRequires: libdwarf-devel
+BuildRequires: libdw-devel
+%endif
 
 %description
 Provides a plugin for GCC that records extra information in the files
@@ -59,6 +64,10 @@ export ANNOBIN_PLUGIN_DIR=$(gcc --print-file-name=plugin)
 mkdir BUILDTMP
 export CFLAGS="$RPM_OPT_FLAGS"
 export CXXFLAGS="%{optflags}" 
+%if %{?sle_version}
+export CFLAGS="$CFLAGS -I/usr/include/libdwarf"
+export CXXFLAGS="$CXXFLAGS -I/usr/include/libdwarf" 
+%endif
 
 # Bootstrap build with OS-provided gcc and annobin
 ./configure --prefix=%{install_path} \

--- a/components/dev-tools/annobin/SPECS/annobin.spec
+++ b/components/dev-tools/annobin/SPECS/annobin.spec
@@ -64,7 +64,7 @@ export ANNOBIN_PLUGIN_DIR=$(gcc --print-file-name=plugin)
 mkdir BUILDTMP
 export CFLAGS="$RPM_OPT_FLAGS"
 export CXXFLAGS="%{optflags}" 
-%if %{?sle_version}
+%if 0%{?sle_version}
 export CFLAGS="$CFLAGS -I/usr/include/libdwarf"
 export CXXFLAGS="$CXXFLAGS -I/usr/include/libdwarf" 
 %endif

--- a/components/dev-tools/annobin/SPECS/annobin.spec
+++ b/components/dev-tools/annobin/SPECS/annobin.spec
@@ -9,7 +9,6 @@
 #
 #----------------------------------------------------------------------------eh-
 
-%define no_ohpc_annobin 1
 %define ohpc_compiler_dependent 1
 %include %{_sourcedir}/OHPC_macros
 %undefine _annotated_build


### PR DESCRIPTION
First, this fixes a typo for ScientificLinux and deletes the extra gnu9 entry in OHPC_macros.

This update implements the annobin package for CentOS. To avoid the chicken/egg problem, there is a flag to disable OpenHPC ohpc-annobin on any package, if needed. This allows gnu9 and ohpc-annobin to build. ohpc-annobin loads gnu9 and performs a bootstrap build; then rebuilds using itself.

I re-enabled annotation on CentOS 8. I've been rebuilding everything and it doesn't appear to have created additional build fails.

I added Requires needed for annobin to build under OpenSUSE. Have not tested that it works as expected, but it builds without error.