### PR TITLE
Fix library location for OpenSUSE 15.1

### DIFF
--- a/components/admin/pdsh/SPECS/pdsh.spec
+++ b/components/admin/pdsh/SPECS/pdsh.spec
@@ -322,6 +322,7 @@ cp /usr/lib/rpm/config.guess config
 %endif
 
 ./configure --prefix=%{install_path} \
+    --libdir=%{install_path}/lib \
     --with-rcmd-rank-list="ssh mrsh rsh krb4 exec xcpu" \
     %{?_enable_debug}       \
     %{?_with_rsh}           \

--- a/components/dev-tools/automake/SPECS/automake.spec
+++ b/components/dev-tools/automake/SPECS/automake.spec
@@ -44,7 +44,7 @@ GNU's Autoconf package.
 
 %build
 export PATH=%{install_path}/bin:$PATH
-./configure --prefix=%{install_path}
+./configure --prefix=%{install_path} --libdir=%{install_path}/lib
 
 %install
 make %{?_smp_mflags} DESTDIR=$RPM_BUILD_ROOT install

--- a/components/dev-tools/hwloc/SPECS/hwloc.spec
+++ b/components/dev-tools/hwloc/SPECS/hwloc.spec
@@ -72,7 +72,7 @@ about the hardware, bind processes, and much more.
 sed -i 's/1.11 dist-bzip2 subdir-objects foreign tar-ustar parallel-tests -Wall -Werror/1.10 dist-bzip2 subdir-objects foreign tar-ustar -Wall -Werror/g' configure.ac
 %endif
 autoreconf --force --install
-./configure --prefix=%{install_path}
+./configure --prefix=%{install_path} --libdir=%{install_path}/lib 
 ##sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool
 ##sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
 %{__make} %{?_smp_mflags} V=1

--- a/components/dev-tools/libtool/SPECS/libtool.spec
+++ b/components/dev-tools/libtool/SPECS/libtool.spec
@@ -52,7 +52,7 @@ and GNU Automake).
 
 %build
 export PATH=%{install_path}/bin:$PATH
-./configure --prefix=%{install_path}
+./configure --prefix=%{install_path} --libdir=%{install_path}/lib 
 
 %install
 make %{?_smp_mflags} DESTDIR=$RPM_BUILD_ROOT install

--- a/components/dev-tools/python/SPECS/python.spec
+++ b/components/dev-tools/python/SPECS/python.spec
@@ -57,7 +57,7 @@ Patch37:        python-2.7.12-makeopcode.patch
 # COMMON-PATCH-END
 %define         python_version    %(echo %{tarversion} | head -c 3)
 BuildRequires:  automake
-%if 0%{?sles_version} || 0%{?suse_version}
+%if 0%{?sle_version} || 0%{?suse_version}
 BuildRequires:  fdupes
 BuildRequires:  netcfg
 BuildRequires:  libbz2-devel
@@ -140,6 +140,7 @@ touch Parser/asdl* Python/Python-ast.c Include/Python-ast.h
 
 ./configure \
     --prefix=%{install_path} \
+    --libdir=%{install_path}/lib \
     --with-fpectl \
     --enable-ipv6 \
     --enable-shared \

--- a/components/dev-tools/valgrind/SPECS/valgrind.spec
+++ b/components/dev-tools/valgrind/SPECS/valgrind.spec
@@ -37,7 +37,8 @@ AMD64/MacOSX.
 %setup -q -n %{pname}-%{version}
 
 %build
-./configure --prefix=%{install_path} || { cat config.log && exit 1; }
+./configure --prefix=%{install_path} \
+            --libdir=%{install_path}/lib || { cat config.log && exit 1; }
 make %{?_smp_mflags}
 
 %install

--- a/components/io-libs/adios/SPECS/adios.spec
+++ b/components/io-libs/adios/SPECS/adios.spec
@@ -53,8 +53,7 @@ Requires: lustre-client%{PROJ_DELIM}
 %endif
 BuildRequires: %{python_prefix}-numpy-%{compiler_family}%{PROJ_DELIM}
 
-
-%if 0%{?sles_version} || 0%{?suse_version}
+%if 0%{?sle_version} || 0%{?suse_version}
 # define fdupes, clean up rpmlint errors
 BuildRequires: fdupes libcurl4 libcurl-devel
 %else
@@ -119,6 +118,7 @@ cp /usr/lib/rpm/config.guess config
 %endif
 
 ./configure --prefix=%{install_path} \
+    --libdir=%{install_path}/lib \
     --enable-shared=yes \
     --enable-static=no \
 %if 0%{with_lustre}

--- a/components/io-libs/hdf5/SPECS/hdf5.spec
+++ b/components/io-libs/hdf5/SPECS/hdf5.spec
@@ -66,6 +66,7 @@ cp /usr/lib/rpm/config.guess bin
 %ohpc_setup_compiler
 
 ./configure --prefix=%{install_path} \
+            --libdir=%{install_path}/lib \
 	    --enable-fortran         \
             --enable-static=no       \
 	    --enable-shared          \

--- a/components/io-libs/netcdf-cxx/SPECS/netcdf-cxx4.spec
+++ b/components/io-libs/netcdf-cxx/SPECS/netcdf-cxx4.spec
@@ -84,6 +84,7 @@ export CPPFLAGS="-I$HDF5_INC -I$NETCDF_INC"
 export LDFLAGS="-L$HDF5_LIB -L$NETCDF_LIB"
 
 ./configure --prefix=%{install_path} \
+    --libdir=%{install_path}/lib \
     --enable-shared \
     --enable-netcdf-4 \
     --enable-dap \

--- a/components/io-libs/netcdf-fortran/SPECS/netcdf-fortran.spec
+++ b/components/io-libs/netcdf-fortran/SPECS/netcdf-fortran.spec
@@ -88,6 +88,7 @@ export CPPFLAGS="-I$HDF5_INC -I$NETCDF_INC"
 export LDFLAGS="-L$HDF5_LIB -L$NETCDF_LIB"
 
 ./configure FC=mpif90 --prefix=%{install_path} \
+    --libdir=%{install_path}/lib \
     --enable-shared \
     --with-pic \
     --disable-doxygen \

--- a/components/io-libs/netcdf/SPECS/netcdf.spec
+++ b/components/io-libs/netcdf/SPECS/netcdf.spec
@@ -80,12 +80,14 @@ NetCDF data is:
 %ohpc_setup_compiler
 
 module load phdf5
+
 export CPPFLAGS="-I$HDF5_INC"
 export LDFLAGS="-L$HDF5_LIB"
 export CFLAGS="-L$HDF5_LIB -I$HDF5_INC"
 export CC=mpicc
 
 ./configure --prefix=%{install_path} \
+    --libdir=%{install_path}/lib \
     --enable-shared \
     --enable-netcdf-4 \
     --enable-dap \

--- a/components/io-libs/phdf5/SPECS/hdf5.spec
+++ b/components/io-libs/phdf5/SPECS/hdf5.spec
@@ -71,6 +71,7 @@ export MPIFC=mpifc
 export MPICXX=mpicxx
 
 ./configure --prefix=%{install_path} \
+            --libdir=%{install_path}/lib \
 	    --enable-fortran         \
             --enable-static=no       \
             --enable-parallel        \

--- a/components/io-libs/pnetcdf/SPECS/pnetcdf.spec
+++ b/components/io-libs/pnetcdf/SPECS/pnetcdf.spec
@@ -64,7 +64,8 @@ MPIFC=mpifc \
 MPIF77=mpif77 \
 MPICXX=mpicxx \
 CFLAGS="-fPIC -DPIC" CXXFLAGS="-fPIC -DPIC" FCFLAGS="-fPIC" FFLAGS="-fPIC" \
-./configure --prefix=%{install_path} || { cat config.log && exit 1; }
+./configure --prefix=%{install_path} \
+            --libdir=%{install_path}/lib \|| { cat config.log && exit 1; }
 
 %{__make}
 

--- a/components/mpi-families/mpich/SPECS/mpich.spec
+++ b/components/mpi-families/mpich/SPECS/mpich.spec
@@ -77,6 +77,7 @@ export CPATH=${PMIX_INC}
 %endif
 
 ./configure --prefix=%{install_path} \
+            --libdir=%{install_path}/lib \
 %if 0%{with_slurm}
             --with-pm=no --with-pmi=slurm \
 %endif

--- a/components/mpi-families/mvapich2/SPECS/mvapich2.spec
+++ b/components/mpi-families/mvapich2/SPECS/mvapich2.spec
@@ -91,6 +91,7 @@ across multiple networks.
 %build
 %ohpc_setup_compiler
 ./configure --prefix=%{install_path} \
+            --libdir=%{install_path}/lib \
 	    --enable-cxx \
 	    --enable-g=dbg \
             --with-device=ch3:mrail \

--- a/components/parallel-libs/boost/SPECS/boost.spec
+++ b/components/parallel-libs/boost/SPECS/boost.spec
@@ -35,7 +35,7 @@ Source2:        mkl_boost_ublas_gemm.hpp
 Source3:        mkl_boost_ublas_matrix_prod.hpp
 Source100:      baselibs.conf
 %if "%{compiler_family}" == "llvm" || "%{compiler_family}" == "arm"
-%if 0%{?sles_version} || 0%{?suse_version}
+%if 0%{?sle_version} || 0%{?suse_version}
 Patch1:         boost_fenv_suse.patch
 %endif
 %endif
@@ -95,7 +95,7 @@ see the boost-doc package.
 %setup -q -n %{pname}_%{version_exp}
 
 %if "%{compiler_family}" == "llvm" || "%{compiler_family}" == "arm"
-%if 0%{?sles_version} || 0%{?suse_version}
+%if 0%{?sle_version} || 0%{?suse_version}
 %patch1 -p1
 %endif
 %endif

--- a/components/parallel-libs/fftw/SPECS/fftw.spec
+++ b/components/parallel-libs/fftw/SPECS/fftw.spec
@@ -75,6 +75,7 @@ for i in %{precision_list} ; do
 	cd ${i}
 	ln -s ../configure
 	./configure --prefix=%{install_path} ${LOOPBASEFLAGS} \
+                --libdir=%{install_path}/lib \
 		--enable-${i} \
 		--enable-static=no || { cat config.log && exit 1; }
 	make %{?_smp_mflags}

--- a/components/parallel-libs/mfem/SPECS/mfem.spec
+++ b/components/parallel-libs/mfem/SPECS/mfem.spec
@@ -65,6 +65,7 @@ module load superlu_dist
 
 make config \
     PREFIX=%{install_path} \
+    LIBDIR=%{install_path}/lib \
     CXXFLAGS="-O3 -fPIC -std=c++11" \
     MFEM_USE_MPI=YES \
     MFEM_USE_LAPACK=NO \

--- a/components/perf-tools/papi/SPECS/papi.spec
+++ b/components/perf-tools/papi/SPECS/papi.spec
@@ -48,7 +48,7 @@ running programs.
 %build
 
 cd src
-CFLAGS="-fPIC -DPIC" CXXFLAGS="-fPIC -DPIC" FCFLAGS="-fPIC" ./configure --with-static-lib=yes --with-shared-lib=yes --with-shlib --prefix=%{install_path}
+CFLAGS="-fPIC -DPIC" CXXFLAGS="-fPIC -DPIC" FCFLAGS="-fPIC" ./configure --with-static-lib=yes --with-shared-lib=yes --with-shlib --prefix=%{install_path} --libdir=%{install_path}/lib
 #DBG workaround to make sure libpfm just uses the normal CFLAGS
 DBG="" CFLAGS="-fPIC -DPIC" CXXFLAGS="-fPIC -DPIC" FCFLAGS="-fPIC" make
 

--- a/components/perf-tools/scalasca/SPECS/scalasca.spec
+++ b/components/perf-tools/scalasca/SPECS/scalasca.spec
@@ -83,7 +83,7 @@ CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --with-mpi=openmpi "
 CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --with-mpi=openmpi "
 %endif
 
-./configure --prefix=%{install_path} $CONFIGURE_OPTIONS
+./configure --prefix=%{install_path} --libdir=%{install_path}/lib $CONFIGURE_OPTIONS
 
 %install
 

--- a/components/perf-tools/scorep/SPECS/scorep.spec
+++ b/components/perf-tools/scorep/SPECS/scorep.spec
@@ -98,7 +98,11 @@ CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --with-mpi=openmpi "
 export CFLAGS="$RPM_OPT_FLAGS"
 export CXXFLAGS="$RPM_OPT_FLAGS"
 export LDFLAGS="$RPM_LD_FLAGS"
-./configure --prefix=%{install_path} --disable-static --enable-shared $CONFIGURE_OPTIONS
+./configure --prefix=%{install_path} \
+            --libdir=%{install_path}/lib \
+            --disable-static \
+            --enable-shared \
+            $CONFIGURE_OPTIONS
 
 make V=1 %{?_smp_mflags}
 

--- a/components/rms/pmix/SPECS/pmix.spec
+++ b/components/rms/pmix/SPECS/pmix.spec
@@ -49,7 +49,8 @@ This RPM contains all the tools necessary to compile and link against PMIx.
 %setup -q -n %{pname}-%{version}
 
 %build
-CFLAGS="%{optflags}" ./configure --prefix=%{install_path} || { cat config.log && exit 1; }
+CFLAGS="%{optflags}" ./configure --prefix=%{install_path} \
+            --libdir=%{install_path}/lib || { cat config.log && exit 1; }
 %{__make} %{?_smp_mflags}
 
 %install

--- a/components/serial-libs/gsl/SPECS/gsl.spec
+++ b/components/serial-libs/gsl/SPECS/gsl.spec
@@ -49,7 +49,9 @@ lends itself to being used in very high level languages (VHLLs).
 export CFLAGS="-fp-model strict $CFLAGS"
 %endif
 
-./configure --prefix=%{install_path} --disable-static || { cat config.log && exit 1; }
+./configure --prefix=%{install_path} \
+            --libdir=%{install_path}/lib \
+            --disable-static || { cat config.log && exit 1; }
 make %{?_smp_mflags}
 
 %install


### PR DESCRIPTION
Signed-off-by: jcsiadal <jeremy.c.siadal@intel.com>

Local builds on OpenSUSE are working, but library files will be located under "lib64". On CentOS and SLES12, these libraries are located under "lib". This update updates the configuration so that OpenSUSE 15 builds set the prefix correctly. No impact to CentOS 8 builds.

According to my notes, nothing else is needed to get these files building under OpenSUSE 15.

Also includes a few changes from "sles_version" to "sle_version", since we no longer need to support SLES 11 and earlier.