### PR TITLE
Move license files from/usr/share to %{OHPC_PUB}

### DIFF
--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -33,6 +33,7 @@
 %{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 DocDir:    %{OHPC_PUB}/doc/contrib
+%define _licensedir     %{OHPC_PUB}/doc/licenses
 
 # Define PNAME which can be used in modulefile generation for env vars (derived
 # from pname defined in each component .spec file)


### PR DESCRIPTION
Signed-off-by: jcsiadal <jeremy.c.siadal@intel.com>

Modern RPM specs should use the %license macro instead of the %doc macro for license files, so that licenses are installed even if the user disables documentation. I'm not recommending we change all of the current packages, but only make sure that installation works as intended when the %license macro is used.

Currently, designated license files will install to /usr/share/licenses. This patch moves licenses to %{OHPC_PUB}/doc/licenses.