### PR TITLE
Removed duplicated gnu9

### DIFF
--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -79,15 +79,11 @@ BuildRequires: ohpc-buildroot
 %if "%{compiler_family}" == "gnu9"
 BuildRequires: gnu9-compilers%{PROJ_DELIM} >= 9.2.0
 Requires:      gnu9-compilers%{PROJ_DELIM} >= 9.2.0
-%endif
+%endif # gnu9
 %if "%{compiler_family}" == "gnu8"
 BuildRequires: gnu8-compilers%{PROJ_DELIM} >= 8.3.0
 Requires:      gnu8-compilers%{PROJ_DELIM} >= 8.3.0
 %endif # gnu8
-%if "%{compiler_family}" == "gnu9"
-BuildRequires: gnu9-compilers%{PROJ_DELIM} >= 9.2.0
-Requires:      gnu9-compilers%{PROJ_DELIM} >= 9.2.0
-%endif # gnu9
 
 %if "%{compiler_family}" == "intel"
 %if 0%{OHPC_BUILD}


### PR DESCRIPTION
gnu9 is defined from L.79 to L.82.

Signed-off-by: Naohiro Tamura <naohirot@jp.fujitsu.com>