### PR TITLE
easybuild: a macro needs a '%'

### DIFF
--- a/components/dev-tools/easybuild/SPECS/easybuild.spec
+++ b/components/dev-tools/easybuild/SPECS/easybuild.spec
@@ -98,7 +98,7 @@ setenv          EBROOTEASYBUILD         %{install_path}/software/EasyBuild/%{ver
 setenv          EBVERSIONEASYBUILD      %{version}
 setenv          EB_PYTHON               python3
 
-prepend-path	PYTHONPATH	    %{install_path}/software/EasyBuild/%{version}/lib/python{python3_version}/site-packages
+prepend-path	PYTHONPATH	    %{install_path}/software/EasyBuild/%{version}/lib/python%{python3_version}/site-packages
 
 EOF
 


### PR DESCRIPTION
@boegel @koomie 

There is a single '%' missing and thus the macro is not expanded. Simple fix.