### PR TITLE
OHPC_macros: add dependency requirement for parallel packages using impi

### DIFF
--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -125,6 +125,9 @@ Requires:      llvm-compilers%{PROJ_DELIM} >= 9.0.0
 # MPI dependencies
 %if 0%{?ohpc_mpi_dependent} == 1
 %if "%{mpi_family}" == "impi"
+%if 0%{OHPC_BUILD}
+BuildRequires: impi%{PROJ_DELIM}
+%endif # OHPC_BUILD
 BuildRequires: intel-mpi-devel%{PROJ_DELIM}
 Requires:      intel-mpi-devel%{PROJ_DELIM}
 %global __requires_exclude ^libmpi\\.so.*$|^libmpifort\\.so.*$|^libmpicxx\\.so.*$


### PR DESCRIPTION
family.

Signed-off-by: Karl W. Schulz <karl@oden.utexas.edu>