### PR TITLE
easybuild integration

### DIFF
--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -25,6 +25,9 @@
 %global OHPC_MODULES    %{OHPC_PUB}/modulefiles
 %global OHPC_MODULEDEPS %{OHPC_PUB}/moduledeps
 %global OHPC_MPI_STACKS %{OHPC_PUB}/mpi
+%global OHPC_EASYBUILD  %{OHPC_PUB}/easybuild
+%global OHPC_EB_META    %{OHPC_EASYBUILD}/metadata
+%global OHPC_EB_ROBOT   %{OHPC_EASYBUILD}/robot
 %global OHPC_UTILS      %{OHPC_PUB}/utils
 %global debug_package   %{nil}
 %global dist            .ohpc.2.0.0
@@ -166,6 +169,17 @@ Requires:      %{python_prefix}
     %if 0%{?ohpc_mpi_dependent} == 1 \
         . %{OHPC_ADMIN}/ohpc/OHPC_setup_mpi %{mpi_family} \
     %endif \
+}
+
+%{!?module_name: %global module_name %{pname}}
+%{!?easybuild_name: %global easybuild_name %{pname}}
+
+%define easybuild_metadata %{expand:\
+	mkdir -p %{buildroot}%{OHPC_EB_META} \
+	echo "[%{module_name}/%{version}]" > %{buildroot}%{OHPC_EB_META}/%{module_name}-%{version}.cfg \
+	echo "name = %{easybuild_name}" >> %{buildroot}%{OHPC_EB_META}/%{module_name}-%{version}.cfg \
+	echo "version = %{version}" >> %{buildroot}%{OHPC_EB_META}/%{module_name}-%{version}.cfg \
+	echo "prefix = %{install_path}" >> %{buildroot}%{OHPC_EB_META}/%{module_name}-%{version}.cfg \
 }
 
 # Lua version

--- a/components/admin/ohpc-filesystem/SPECS/ohpc-filesystem.spec
+++ b/components/admin/ohpc-filesystem/SPECS/ohpc-filesystem.spec
@@ -42,6 +42,9 @@ builds.
 %install
 # The ohpc-filesystems owns all the common directories
 mkdir -p $RPM_BUILD_ROOT/opt/ohpc/pub/{apps,doc,compiler,libs,moduledeps,modulefiles,mpi}
+# This are the easybuild directories OpenHPC drops its
+# EasyBuild configuration files into.
+mkdir -p $RPM_BUILD_ROOT/opt/ohpc/pub/easybuild/{metadata,robot}
 mkdir -p $RPM_BUILD_ROOT/opt/ohpc/admin/ohpc
 mkdir -p $RPM_BUILD_ROOT/usr/lib/rpm/fileattrs
 
@@ -78,6 +81,9 @@ EOF
 %dir /opt/ohpc/pub/apps/
 %dir /opt/ohpc/pub/doc/
 %dir /opt/ohpc/pub/compiler/
+%dir /opt/ohpc/pub/easybuild/
+%dir /opt/ohpc/pub/easybuild/metadata
+%dir /opt/ohpc/pub/easybuild/robot
 %dir /opt/ohpc/pub/libs/
 %dir /opt/ohpc/pub/moduledeps/
 %dir /opt/ohpc/pub/modulefiles/

--- a/components/compiler-families/gnu-compilers/SPECS/gnu-compilers.spec
+++ b/components/compiler-families/gnu-compilers/SPECS/gnu-compilers.spec
@@ -13,6 +13,8 @@
 %global gnu_version 9.2.0
 %global gnu_major_ver 9
 %global pname gnu9-compilers
+%global module_name gnu%{gnu_major_ver}
+%global easybuild_name GCC
 
 # Define subcomponent versions required for build
 
@@ -125,7 +127,10 @@ EOF
 
 %{__mkdir_p} ${RPM_BUILD_ROOT}/%{_docdir}
 
+%{easybuild_metadata}
+
 %files
+%{OHPC_EB_META}/*cfg
 %{OHPC_MODULES}/gnu%{gnu_major_ver}/
 %dir %{OHPC_COMPILERS}/gcc
 %{install_path}

--- a/components/dev-tools/easybuild/SPECS/easybuild.spec
+++ b/components/dev-tools/easybuild/SPECS/easybuild.spec
@@ -110,5 +110,36 @@ EOF
 set     ModulesVersion      "%{version}"
 EOF
 
+# This is for the OpenHPC EasyBuild integration
+mkdir -p %{buildroot}/etc/easybuild.d
+%{__cat} << EOF > %{buildroot}/etc/easybuild.d/ohpc.cfg
+[config]
+external-modules-metadata=%{OHPC_EB_META}/*.cfg
+robot-paths=%%(DEFAULT_ROBOT_PATHS)s:%{OHPC_EB_ROBOT}
+EOF
+
+mkdir -p %{buildroot}/%{OHPC_EB_ROBOT}
+# This sets up the OpenHPC toolchain in EasyBuild
+# Unfortunately some parts are hardcoded.
+%{__cat} << EOF > %{buildroot}/%{OHPC_EB_ROBOT}/GCC-9.2.0-ohpc-gnu9.eb
+easyblock = 'Toolchain'
+
+homepage = 'https://github.com/openhpc/ohpc'
+name = 'GCC'
+version = '9.2.0'
+versionsuffix = '-ohpc-gnu9'
+
+description = """Toolchain provided by OpenHPC\n"""
+
+toolchain = SYSTEM
+
+dependencies = [
+    ('gnu9/9.2.0', EXTERNAL_MODULE),
+]
+
+moduleclass = 'toolchain'
+EOF
+
 %files
 %{OHPC_HOME}
+/etc/easybuild.d


### PR DESCRIPTION
With the help of @boegel I was able to create an integration of the OpenHPC compiler into EasyBuild.

In the end it does not really help a lot as no EasyBuild definition is yet aware of this toolchain and only used if explicitly selected (`--try-toolchain GCC,9.2.0-ohpc-gnu`). It is also not clear how EasyBuild can use the hierarchical module setup of OpenHPC (maybe by combining it into toolchain definitions???), but it is a first step towards a better integration of EasyBuild and OpenHPC.