### PR TITLE
Update metapackages

### DIFF
--- a/components/admin/losf/SPECS/losf.spec
+++ b/components/admin/losf/SPECS/losf.spec
@@ -37,11 +37,13 @@ provides: perl(LosF_rpm_utils)
 provides: perl(LosF_utils)
 provides: perl(LosF_history_utils)
 
-%if 0%{?sles_version} || 0%{?suse_version}
+%if 0%{?sle_version} || 0%{?suse_version}
 Requires: perl-Config-IniFiles >= 2.43
 Requires: perl-Log-Log4perl
-%else
+%else #rhel
+%if 0%{?rhel_version} < 800
 requires: yum-plugin-downloadonly
+%endif
 %endif
 
 %define __spec_install_post %{nil}

--- a/components/admin/meta-packages/SPECS/meta-packages.spec
+++ b/components/admin/meta-packages/SPECS/meta-packages.spec
@@ -8,10 +8,12 @@
 #
 #----------------------------------------------------------------------------eh-
 
+%undefine compiler_family
+%undefine mpi_family
+%undefine python_family
+%define ohpc_python_dependent 1
+
 %include %{_sourcedir}/OHPC_macros
-%global gnu_major_ver 9
-%global openmpi_major_ver 4
-%global python3_prefix python3
 
 Summary: Meta-packages to ease installation
 Name:    meta-packages
@@ -54,18 +56,18 @@ Requires:  make
 Requires:  man
 Requires:  net-tools
 Requires:  nfs-utils
-Requires:  ntp
+Requires:  chrony
 Requires:  OpenIPMI
 Requires:  pdsh%{PROJ_DELIM}
 Requires:  screen
 Requires:  sudo
-%if 0%{?centos_version} || 0%{?rhel_version}
+%if 0%{?rhel_version}
 Requires:  binutils
 Requires:  binutils-devel
 Requires:  man-db
 Requires:  yum-utils
 %endif
-%if 0%{?sles_version} || 0%{?suse_version}
+%if 0%{?sle_version} || 0%{?suse_version}
 Requires:  glibc-locale
 Requires:  nfs-kernel-server
 %endif
@@ -78,13 +80,13 @@ Requires:  binutils
 Requires:  libicu
 Requires:  libunwind
 Requires:  numactl
-%if 0%{?centos_version} || 0%{?rhel_version}
+%if 0%{?rhel_version}
 Requires:  cairo-devel
 Requires:  libpciaccess
-Requires:  python34
+Requires:  python3
 Requires:  libseccomp
 %endif
-%if 0%{?sles_version} || 0%{?suse_version}
+%if 0%{?sle_version} || 0%{?suse_version}
 Requires:  libcairo2
 Requires:  libpciaccess0
 Requires:  python3
@@ -103,74 +105,74 @@ Requires:  ganglia-web%{PROJ_DELIM}
 %description -n %{PROJ_NAME}-ganglia
 Collection of Ganglia monitoring and metrics packages
 
-%package -n %{PROJ_NAME}-gnu%{gnu_major_ver}-geopm
+%package -n %{PROJ_NAME}-%{compiler_family}-geopm
 Summary:   OpenHPC GEOPM power management for GNU
-Requires:  geopm-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  geopm-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  geopm-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-%description -n %{PROJ_NAME}-gnu%{gnu_major_ver}-geopm
+Requires:  geopm-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  geopm-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  geopm-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+%description -n %{PROJ_NAME}-%{compiler_family}-geopm
 Global Extensible Open Power Manager for use with GNU compiler toolchain
 
-%package -n %{PROJ_NAME}-gnu%{gnu_major_ver}-io-libs
+%package -n %{PROJ_NAME}-%{compiler_family}-io-libs
 Summary:   OpenHPC IO libraries for GNU
-Requires:  adios-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  adios-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  hdf5-gnu%{gnu_major_ver}%{PROJ_DELIM}
-Requires:  netcdf-cxx-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  netcdf-cxx-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  netcdf-fortran-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  netcdf-fortran-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  netcdf-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  netcdf-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  pnetcdf-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  pnetcdf-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  phdf5-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  phdf5-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
+Requires:  adios-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  adios-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  hdf5-%{compiler_family}%{PROJ_DELIM}
+Requires:  netcdf-cxx-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  netcdf-cxx-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  netcdf-fortran-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  netcdf-fortran-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  netcdf-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  netcdf-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  pnetcdf-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  pnetcdf-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  phdf5-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  phdf5-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 %ifnarch aarch64
-Requires:  adios-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  netcdf-cxx-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  netcdf-fortran-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  netcdf-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  pnetcdf-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  phdf5-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
+Requires:  adios-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  netcdf-cxx-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  netcdf-fortran-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  netcdf-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  pnetcdf-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  phdf5-%{compiler_family}-mvapich2%{PROJ_DELIM}
 %endif
-%description -n %{PROJ_NAME}-gnu%{gnu_major_ver}-io-libs
+%description -n %{PROJ_NAME}-%{compiler_family}-io-libs
 Collection of IO library builds for use with GNU compiler toolchain
 
-%package -n %{PROJ_NAME}-gnu%{gnu_major_ver}-mpich-io-libs
+%package -n %{PROJ_NAME}-%{compiler_family}-mpich-io-libs
 Summary:   OpenHPC IO libraries for GNU and MPICH
-Requires:  adios-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  netcdf-cxx-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  netcdf-fortran-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  netcdf-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  pnetcdf-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  phdf5-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  hdf5-gnu%{gnu_major_ver}%{PROJ_DELIM}
-%description -n %{PROJ_NAME}-gnu%{gnu_major_ver}-mpich-io-libs
+Requires:  adios-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  netcdf-cxx-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  netcdf-fortran-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  netcdf-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  pnetcdf-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  phdf5-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  hdf5-%{compiler_family}%{PROJ_DELIM}
+%description -n %{PROJ_NAME}-%{compiler_family}-mpich-io-libs
 Collection of IO library builds for use with GNU compiler toolchain and the MPICH runtime
 
-%package -n %{PROJ_NAME}-gnu%{gnu_major_ver}-mvapich2-io-libs
+%package -n %{PROJ_NAME}-%{compiler_family}-mvapich2-io-libs
 Summary:   OpenHPC IO libraries for GNU and MVAPICH2
-Requires:  adios-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  netcdf-cxx-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  netcdf-fortran-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  netcdf-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  pnetcdf-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  phdf5-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  hdf5-gnu%{gnu_major_ver}%{PROJ_DELIM}
-%description -n %{PROJ_NAME}-gnu%{gnu_major_ver}-mvapich2-io-libs
+Requires:  adios-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  netcdf-cxx-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  netcdf-fortran-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  netcdf-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  pnetcdf-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  phdf5-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  hdf5-%{compiler_family}%{PROJ_DELIM}
+%description -n %{PROJ_NAME}-%{compiler_family}-mvapich2-io-libs
 Collection of IO library builds for use with GNU compiler toolchain and the MVAPICH2 runtime
 
-%package -n %{PROJ_NAME}-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}-io-libs
+%package -n %{PROJ_NAME}-%{compiler_family}-%{mpi_family}-io-libs
 Summary:   OpenHPC IO libraries for GNU and OpenMPI
-Requires:  adios-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  netcdf-cxx-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  netcdf-fortran-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  netcdf-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  pnetcdf-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  phdf5-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  hdf5-gnu%{gnu_major_ver}%{PROJ_DELIM}
-%description -n %{PROJ_NAME}-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}-io-libs
+Requires:  adios-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  netcdf-cxx-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  netcdf-fortran-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  netcdf-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  pnetcdf-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  phdf5-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  hdf5-%{compiler_family}%{PROJ_DELIM}
+%description -n %{PROJ_NAME}-%{compiler_family}-%{mpi_family}-io-libs
 Collection of IO library builds for use with GNU compiler toolchain and the OpenMPI runtime
 
 %package -n %{PROJ_NAME}-nagios
@@ -181,213 +183,198 @@ Requires:  nrpe%{PROJ_DELIM}
 %description -n %{PROJ_NAME}-nagios
 Collection of Nagios monitoring and metrics packages
 
-%package -n %{PROJ_NAME}-gnu%{gnu_major_ver}-parallel-libs
+%package -n %{PROJ_NAME}-%{compiler_family}-parallel-libs
 Summary:   OpenHPC parallel libraries for GNU
-Requires:  boost-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  boost-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  fftw-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  fftw-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  hypre-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  hypre-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  mfem-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  mfem-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  mumps-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  mumps-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  petsc-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  petsc-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  opencoarrays-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  opencoarrays-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  scalapack-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  scalapack-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  slepc-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  slepc-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  ptscotch-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  ptscotch-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  superlu_dist-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  superlu_dist-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  trilinos-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  trilinos-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
+Requires:  boost-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  boost-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  fftw-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  fftw-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  hypre-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  hypre-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  mfem-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  mfem-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  mumps-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  mumps-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  petsc-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  petsc-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  opencoarrays-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  opencoarrays-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  scalapack-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  scalapack-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  slepc-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  slepc-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  ptscotch-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  ptscotch-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  superlu_dist-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  superlu_dist-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  trilinos-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  trilinos-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 %ifnarch aarch64
-Requires:  boost-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  fftw-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  hypre-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  mfem-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  mumps-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  petsc-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  opencoarrays-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  scalapack-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  slepc-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  ptscotch-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  superlu_dist-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  trilinos-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
+Requires:  boost-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  fftw-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  hypre-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  mfem-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  mumps-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  petsc-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  opencoarrays-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  scalapack-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  slepc-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  ptscotch-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  superlu_dist-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  trilinos-%{compiler_family}-mvapich2%{PROJ_DELIM}
 %endif
-%description -n %{PROJ_NAME}-gnu%{gnu_major_ver}-parallel-libs
+%description -n %{PROJ_NAME}-%{compiler_family}-parallel-libs
 Collection of parallel library builds for use with GNU compiler toolchain
 
-%package -n %{PROJ_NAME}-gnu%{gnu_major_ver}-mpich-parallel-libs
+%package -n %{PROJ_NAME}-%{compiler_family}-mpich-parallel-libs
 Summary:   OpenHPC parallel libraries for GNU and MPICH
-Requires:  boost-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  fftw-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  hypre-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  mfem-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  mumps-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  petsc-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  opencoarrays-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  scalapack-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  slepc-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  ptscotch-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  superlu_dist-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  trilinos-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-%description -n %{PROJ_NAME}-gnu%{gnu_major_ver}-mpich-parallel-libs
+Requires:  boost-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  fftw-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  hypre-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  mfem-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  mumps-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  petsc-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  opencoarrays-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  scalapack-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  slepc-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  ptscotch-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  superlu_dist-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  trilinos-%{compiler_family}-mpich%{PROJ_DELIM}
+%description -n %{PROJ_NAME}-%{compiler_family}-mpich-parallel-libs
 Collection of parallel library builds for use with GNU compiler toolchain and the MPICH runtime
 
-%package -n %{PROJ_NAME}-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}-parallel-libs
+%package -n %{PROJ_NAME}-%{compiler_family}-%{mpi_family}-parallel-libs
 Summary:   OpenHPC parallel libraries for GNU and OpenMPI
-Requires:  boost-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  fftw-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  hypre-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  mfem-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  mumps-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  petsc-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  opencoarrays-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  scalapack-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  slepc-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  ptscotch-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  superlu_dist-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  trilinos-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-%description -n %{PROJ_NAME}-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}-parallel-libs
+Requires:  boost-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  fftw-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  hypre-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  mfem-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  mumps-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  petsc-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  opencoarrays-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  scalapack-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  slepc-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  ptscotch-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  superlu_dist-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  trilinos-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+%description -n %{PROJ_NAME}-%{compiler_family}-%{mpi_family}-parallel-libs
 Collection of parallel library builds for use with GNU compiler toolchain and the OpenMPI runtime
 
-%package -n %{PROJ_NAME}-gnu%{gnu_major_ver}-perf-tools
+%package -n %{PROJ_NAME}-%{compiler_family}-perf-tools
 Summary:   OpenHPC performance tools for GNU
-Requires:  dimemas-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  dimemas-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  extrae-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  extrae-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  imb-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  imb-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  mpiP-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  mpiP-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  omb-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  omb-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  tau-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  tau-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  scalasca-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  scalasca-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  scorep-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  scorep-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
+Requires:  dimemas-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  dimemas-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  extrae-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  extrae-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  imb-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  imb-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  mpiP-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  mpiP-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  omb-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  omb-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  tau-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  tau-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  scalasca-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  scalasca-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  scorep-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  scorep-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 %ifnarch aarch64
-Requires:  dimemas-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  extrae-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  imb-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  likwid-gnu%{gnu_major_ver}%{PROJ_DELIM}
-Requires:  mpiP-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  omb-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
+Requires:  dimemas-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  extrae-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  imb-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  likwid-%{compiler_family}%{PROJ_DELIM}
+Requires:  mpiP-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  omb-%{compiler_family}-mvapich2%{PROJ_DELIM}
 Requires:  papi%{PROJ_DELIM}
-Requires:  tau-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  scalasca-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  scorep-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
+Requires:  tau-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  scalasca-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  scorep-%{compiler_family}-mvapich2%{PROJ_DELIM}
 %endif
-%description -n %{PROJ_NAME}-gnu%{gnu_major_ver}-perf-tools
+%description -n %{PROJ_NAME}-%{compiler_family}-perf-tools
 Collection of performance tool builds for use with GNU compiler toolchain
 
-%package -n %{PROJ_NAME}-gnu%{gnu_major_ver}-mpich-perf-tools
+%package -n %{PROJ_NAME}-%{compiler_family}-mpich-perf-tools
 Summary:   OpenHPC performance tools for GNU and MPICH
-Requires:  dimemas-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  extrae-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  imb-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  mpiP-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  omb-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  tau-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  scalasca-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  scorep-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
+Requires:  dimemas-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  extrae-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  imb-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  mpiP-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  omb-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  tau-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  scalasca-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  scorep-%{compiler_family}-mpich%{PROJ_DELIM}
 Requires:  papi%{PROJ_DELIM}
-%description -n %{PROJ_NAME}-gnu%{gnu_major_ver}-mpich-perf-tools
+%description -n %{PROJ_NAME}-%{compiler_family}-mpich-perf-tools
 Collection of performance tool builds for use with GNU compiler toolchain and the MPICH runtime
 
-%package -n %{PROJ_NAME}-gnu%{gnu_major_ver}-mvapich2-perf-tools
+%package -n %{PROJ_NAME}-%{compiler_family}-mvapich2-perf-tools
 Summary:   OpenHPC performance tools for GNU and MVAPICH2
-Requires:  dimemas-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  extrae-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  imb-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  likwid-gnu%{gnu_major_ver}%{PROJ_DELIM}
-Requires:  mpiP-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  omb-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  tau-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  scalasca-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  scorep-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
+Requires:  dimemas-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  extrae-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  imb-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  likwid-%{compiler_family}%{PROJ_DELIM}
+Requires:  mpiP-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  omb-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  tau-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  scalasca-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  scorep-%{compiler_family}-mvapich2%{PROJ_DELIM}
 Requires:  papi%{PROJ_DELIM}
-%description -n %{PROJ_NAME}-gnu%{gnu_major_ver}-mvapich2-perf-tools
+%description -n %{PROJ_NAME}-%{compiler_family}-mvapich2-perf-tools
 Collection of performance tool builds for use with GNU compiler toolchain and the MVAPICH2 runtime
 
-%package -n %{PROJ_NAME}-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}-perf-tools
+%package -n %{PROJ_NAME}-%{compiler_family}-%{mpi_family}-perf-tools
 Summary:   OpenHPC performance tools for GNU and OpenMPI
-Requires:  dimemas-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  extrae-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  imb-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  likwid-gnu%{gnu_major_ver}%{PROJ_DELIM}
-Requires:  mpiP-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  omb-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  tau-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  scalasca-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  scorep-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
+Requires:  dimemas-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  extrae-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  imb-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  likwid-%{compiler_family}%{PROJ_DELIM}
+Requires:  mpiP-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  omb-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  tau-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  scalasca-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  scorep-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  papi%{PROJ_DELIM}
-%description -n %{PROJ_NAME}-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}-perf-tools
+%description -n %{PROJ_NAME}-%{compiler_family}-%{mpi_family}-perf-tools
 Collection of performance tool builds for use with GNU compiler toolchain and the OpenMPI runtime
 
-%package -n %{PROJ_NAME}-gnu%{gnu_major_ver}-python-libs
+%package -n %{PROJ_NAME}-%{compiler_family}-python-libs
 Summary:   OpenHPC python libraries for GNU
-Requires:  %{PROJ_NAME}-gnu%{gnu_major_ver}-python2-libs
-Requires:  %{PROJ_NAME}-gnu%{gnu_major_ver}-python3-libs
-%description -n %{PROJ_NAME}-gnu%{gnu_major_ver}-python-libs
+Requires:  %{PROJ_NAME}-%{compiler_family}-python3-libs
+%description -n %{PROJ_NAME}-%{compiler_family}-python-libs
 Collection of python related library builds for use with GNU compiler toolchain
 
-%package -n %{PROJ_NAME}-gnu%{gnu_major_ver}-python2-libs
-Summary:   OpenHPC python2 libraries for GNU
-Requires:  python-mpi4py-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  python-mpi4py-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  python-numpy-gnu%{gnu_major_ver}%{PROJ_DELIM}
-Requires:  python-scipy-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  python-scipy-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-%ifnarch aarch64
-Requires:  python-mpi4py-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  python-scipy-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-%endif
-%description -n %{PROJ_NAME}-gnu%{gnu_major_ver}-python2-libs
-Collection of python2 related library builds for use with GNU compiler toolchain
-
-%package -n %{PROJ_NAME}-gnu%{gnu_major_ver}-python3-libs
+%package -n %{PROJ_NAME}-%{compiler_family}-python3-libs
 Summary:   OpenHPC python3 libraries for GNU
-Requires:  %{python3_prefix}-mpi4py-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  %{python3_prefix}-mpi4py-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  %{python3_prefix}-numpy-gnu%{gnu_major_ver}%{PROJ_DELIM}
-Requires:  %{python3_prefix}-scipy-gnu%{gnu_major_ver}-mpich%{PROJ_DELIM}
-Requires:  %{python3_prefix}-scipy-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
+Requires:  %{python_prefix}-mpi4py-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  %{python_prefix}-mpi4py-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  %{python_prefix}-numpy-%{compiler_family}%{PROJ_DELIM}
+Requires:  %{python_prefix}-scipy-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  %{python_prefix}-scipy-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 %ifnarch aarch64
-Requires:  %{python3_prefix}-mpi4py-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  %{python3_prefix}-scipy-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
+Requires:  %{python_prefix}-mpi4py-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  %{python_prefix}-scipy-%{compiler_family}-mvapich2%{PROJ_DELIM}
 %endif
-%description -n %{PROJ_NAME}-gnu%{gnu_major_ver}-python3-libs
+%description -n %{PROJ_NAME}-%{compiler_family}-python3-libs
 Collection of python3 related library builds for use with GNU compiler toolchain
 
-%package -n %{PROJ_NAME}-gnu%{gnu_major_ver}-runtimes
+%package -n %{PROJ_NAME}-%{compiler_family}-runtimes
 Summary:   OpenHPC runtimes for GNU
-Requires:  ocr-gnu%{gnu_major_ver}%{PROJ_DELIM}
+Requires:  ocr-%{compiler_family}%{PROJ_DELIM}
 Requires:  charliecloud%{PROJ_DELIM}
 Requires:  singularity%{PROJ_DELIM}
-%description -n %{PROJ_NAME}-gnu%{gnu_major_ver}-runtimes
+%description -n %{PROJ_NAME}-%{compiler_family}-runtimes
 Collection of runtimes for use with GNU compiler toolchain
 
-%package -n %{PROJ_NAME}-gnu%{gnu_major_ver}-serial-libs
+%package -n %{PROJ_NAME}-%{compiler_family}-serial-libs
 Summary:   OpenHPC serial libraries for GNU
-Requires:  gsl-gnu%{gnu_major_ver}%{PROJ_DELIM}
-Requires:  metis-gnu%{gnu_major_ver}%{PROJ_DELIM}
-Requires:  openblas-gnu%{gnu_major_ver}%{PROJ_DELIM}
-Requires:  plasma-gnu%{gnu_major_ver}%{PROJ_DELIM}
-Requires:  R-gnu%{gnu_major_ver}%{PROJ_DELIM}
-Requires:  scotch-gnu%{gnu_major_ver}%{PROJ_DELIM}
-Requires:  superlu-gnu%{gnu_major_ver}%{PROJ_DELIM}
-%description -n %{PROJ_NAME}-gnu%{gnu_major_ver}-serial-libs
+Requires:  gsl-%{compiler_family}%{PROJ_DELIM}
+Requires:  metis-%{compiler_family}%{PROJ_DELIM}
+Requires:  openblas-%{compiler_family}%{PROJ_DELIM}
+Requires:  plasma-%{compiler_family}%{PROJ_DELIM}
+Requires:  R-%{compiler_family}%{PROJ_DELIM}
+Requires:  scotch-%{compiler_family}%{PROJ_DELIM}
+Requires:  superlu-%{compiler_family}%{PROJ_DELIM}
+%description -n %{PROJ_NAME}-%{compiler_family}-serial-libs
 Collection of serial library builds for use with GNU compiler toolchain
 
 %package -n %{PROJ_NAME}-slurm-client
@@ -398,10 +385,10 @@ Requires:  slurm-slurmd%{PROJ_DELIM}
 Requires:  slurm-contribs%{PROJ_DELIM}
 Requires:  slurm-example-configs%{PROJ_DELIM}
 Requires:  slurm-pam_slurm%{PROJ_DELIM}
-%if 0%{?centos_version} || 0%{?rhel_version}
+%if 0%{?rhel_version}
 Requires:  hwloc-libs
 %endif
-%if 0%{?sles_version} || 0%{?suse_version}
+%if 0%{?sle_version} || 0%{?suse_version}
 Requires:  libhwloc5
 %endif
 %description -n %{PROJ_NAME}-slurm-client
@@ -426,11 +413,13 @@ Collection of server packages for SLURM
 Summary:   OpenHPC base packages for Warewulf
 Requires:  warewulf-cluster%{PROJ_DELIM}
 Requires:  warewulf-common%{PROJ_DELIM}
+Requires:  warewulf-common%{PROJ_DELIM}-localdb
 Requires:  warewulf-ipmi%{PROJ_DELIM}
-Requires:  warewulf-provision-initramfs-%{_arch}%{PROJ_DELIM}
+Requires:  warewulf-ipmi%{PROJ_DELIM}-initramfs-%{_arch}
+Requires:  warewulf-provision%{PROJ_DELIM}-initramfs-%{_arch}
 Requires:  warewulf-provision%{PROJ_DELIM}
-Requires:  warewulf-provision-server%{PROJ_DELIM}
-Requires:  warewulf-provision-server-ipxe-%{_arch}%{PROJ_DELIM}
+Requires:  warewulf-provision%{PROJ_DELIM}-server
+Requires:  warewulf-provision%{PROJ_DELIM}-server-ipxe-%{_arch}
 Requires:  warewulf-vnfs%{PROJ_DELIM}
 %description -n %{PROJ_NAME}-warewulf
 Collection of base packages for Warewulf provisioning
@@ -439,47 +428,47 @@ Collection of base packages for Warewulf provisioning
 %ifnarch aarch64
 %package -n %{PROJ_NAME}-intel-geopm
 Summary:   OpenHPC GEOPM power management for Intel(R) Parallel Studio XE
-Requires:  geopm-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
+Requires:  geopm-%{compiler_family}-impi%{PROJ_DELIM}
 Requires:  geopm-intel-impi%{PROJ_DELIM}
 Requires:  geopm-intel-mpich%{PROJ_DELIM}
 Requires:  geopm-intel-mvapich2%{PROJ_DELIM}
-Requires:  geopm-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
+Requires:  geopm-intel-%{mpi_family}%{PROJ_DELIM}
 %description -n %{PROJ_NAME}-intel-geopm
 Global Extensible Open Power Manager for use with Intel(R) Parallel Studio XE software suite
 
 %package -n %{PROJ_NAME}-intel-io-libs
 Summary:   OpenHPC IO libraries for Intel(R) Parallel Studio XE
-Requires:  adios-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
+Requires:  adios-%{compiler_family}-impi%{PROJ_DELIM}
 Requires:  adios-intel-impi%{PROJ_DELIM}
 Requires:  adios-intel-mpich%{PROJ_DELIM}
 Requires:  adios-intel-mvapich2%{PROJ_DELIM}
-Requires:  adios-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
+Requires:  adios-intel-%{mpi_family}%{PROJ_DELIM}
 Requires:  hdf5-intel%{PROJ_DELIM}
-Requires:  netcdf-cxx-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
+Requires:  netcdf-cxx-%{compiler_family}-impi%{PROJ_DELIM}
 Requires:  netcdf-cxx-intel-impi%{PROJ_DELIM}
 Requires:  netcdf-cxx-intel-mpich%{PROJ_DELIM}
 Requires:  netcdf-cxx-intel-mvapich2%{PROJ_DELIM}
-Requires:  netcdf-cxx-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  netcdf-fortran-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
+Requires:  netcdf-cxx-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  netcdf-fortran-%{compiler_family}-impi%{PROJ_DELIM}
 Requires:  netcdf-fortran-intel-impi%{PROJ_DELIM}
 Requires:  netcdf-fortran-intel-mpich%{PROJ_DELIM}
 Requires:  netcdf-fortran-intel-mvapich2%{PROJ_DELIM}
-Requires:  netcdf-fortran-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  netcdf-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
+Requires:  netcdf-fortran-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  netcdf-%{compiler_family}-impi%{PROJ_DELIM}
 Requires:  netcdf-intel-impi%{PROJ_DELIM}
 Requires:  netcdf-intel-mpich%{PROJ_DELIM}
 Requires:  netcdf-intel-mvapich2%{PROJ_DELIM}
-Requires:  netcdf-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  pnetcdf-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
+Requires:  netcdf-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  pnetcdf-%{compiler_family}-impi%{PROJ_DELIM}
 Requires:  pnetcdf-intel-impi%{PROJ_DELIM}
 Requires:  pnetcdf-intel-mpich%{PROJ_DELIM}
 Requires:  pnetcdf-intel-mvapich2%{PROJ_DELIM}
-Requires:  pnetcdf-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  phdf5-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
+Requires:  pnetcdf-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  phdf5-%{compiler_family}-impi%{PROJ_DELIM}
 Requires:  phdf5-intel-impi%{PROJ_DELIM}
 Requires:  phdf5-intel-mpich%{PROJ_DELIM}
 Requires:  phdf5-intel-mvapich2%{PROJ_DELIM}
-Requires:  phdf5-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
+Requires:  phdf5-intel-%{mpi_family}%{PROJ_DELIM}
 %description -n %{PROJ_NAME}-intel-io-libs
 Collection of IO library builds for use with Intel(R) Parallel Studio XE software suite
 
@@ -519,57 +508,57 @@ Requires:  pnetcdf-intel-mvapich2%{PROJ_DELIM}
 %description -n %{PROJ_NAME}-intel-mvapich2-io-libs
 Collection of IO library builds for use with Intel(R) Parallel Studio XE software suite and MVAPICH2 runtime
 
-%package -n %{PROJ_NAME}-intel-openmpi%{openmpi_major_ver}-io-libs
+%package -n %{PROJ_NAME}-intel-%{mpi_family}-io-libs
 Summary:   OpenHPC IO libraries for Intel(R) Parallel Studio XE and OpenMPI
-Requires:  adios-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
+Requires:  adios-intel-%{mpi_family}%{PROJ_DELIM}
 Requires:  hdf5-intel%{PROJ_DELIM}
-Requires:  netcdf-cxx-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  netcdf-fortran-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  netcdf-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  phdf5-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  pnetcdf-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-%description -n %{PROJ_NAME}-intel-openmpi%{openmpi_major_ver}-io-libs
+Requires:  netcdf-cxx-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  netcdf-fortran-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  netcdf-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  phdf5-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  pnetcdf-intel-%{mpi_family}%{PROJ_DELIM}
+%description -n %{PROJ_NAME}-intel-%{mpi_family}-io-libs
 Collection of IO library builds for use with Intel(R) Parallel Studio XE software suite and OpenMPI runtime
 
-%package -n %{PROJ_NAME}-gnu%{gnu_major_ver}-mvapich2-parallel-libs
+%package -n %{PROJ_NAME}-%{compiler_family}-mvapich2-parallel-libs
 Summary:   OpenHPC parallel libraries for GNU and MVAPICH2
-Requires:  boost-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  fftw-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  hypre-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  mfem-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  mumps-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  petsc-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  opencoarrays-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  scalapack-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  slepc-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  ptscotch-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  superlu_dist-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-Requires:  trilinos-gnu%{gnu_major_ver}-mvapich2%{PROJ_DELIM}
-%description -n %{PROJ_NAME}-gnu%{gnu_major_ver}-mvapich2-parallel-libs
+Requires:  boost-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  fftw-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  hypre-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  mfem-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  mumps-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  petsc-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  opencoarrays-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  scalapack-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  slepc-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  ptscotch-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  superlu_dist-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  trilinos-%{compiler_family}-mvapich2%{PROJ_DELIM}
+%description -n %{PROJ_NAME}-%{compiler_family}-mvapich2-parallel-libs
 Collection of parallel library builds for use with GNU compiler toolchain and the MVAPICH2 runtime
 
 %package -n %{PROJ_NAME}-intel-impi-parallel-libs
 Summary:   OpenHPC parallel libraries for Intel(R) Parallel Studio XE and Intel(R) MPI Library
-Requires:  boost-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
+Requires:  boost-%{compiler_family}-impi%{PROJ_DELIM}
 Requires:  boost-intel-impi%{PROJ_DELIM}
-Requires:  hypre-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
+Requires:  hypre-%{compiler_family}-impi%{PROJ_DELIM}
 Requires:  hypre-intel-impi%{PROJ_DELIM}
-Requires:  mfem-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
+Requires:  mfem-%{compiler_family}-impi%{PROJ_DELIM}
 Requires:  mfem-intel-impi%{PROJ_DELIM}
-Requires:  mumps-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
+Requires:  mumps-%{compiler_family}-impi%{PROJ_DELIM}
 Requires:  mumps-intel-impi%{PROJ_DELIM}
-Requires:  opencoarrays-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
-Requires:  petsc-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
+Requires:  opencoarrays-%{compiler_family}-impi%{PROJ_DELIM}
+Requires:  petsc-%{compiler_family}-impi%{PROJ_DELIM}
 Requires:  petsc-intel-impi%{PROJ_DELIM}
-Requires:  scalapack-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
+Requires:  scalapack-%{compiler_family}-impi%{PROJ_DELIM}
 Requires:  scalapack-intel-impi%{PROJ_DELIM}
-Requires:  slepc-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
+Requires:  slepc-%{compiler_family}-impi%{PROJ_DELIM}
 Requires:  slepc-intel-impi%{PROJ_DELIM}
-Requires:  ptscotch-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
+Requires:  ptscotch-%{compiler_family}-impi%{PROJ_DELIM}
 Requires:  ptscotch-intel-impi%{PROJ_DELIM}
-Requires:  superlu_dist-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
+Requires:  superlu_dist-%{compiler_family}-impi%{PROJ_DELIM}
 Requires:  superlu_dist-intel-impi%{PROJ_DELIM}
-Requires:  trilinos-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
+Requires:  trilinos-%{compiler_family}-impi%{PROJ_DELIM}
 Requires:  trilinos-intel-impi%{PROJ_DELIM}
 %description -n %{PROJ_NAME}-intel-impi-parallel-libs
 Collection of parallel library builds for use with Intel(R) Parallel Studio XE toolchain and the Intel(R) MPI Library
@@ -604,61 +593,61 @@ Requires:  trilinos-intel-mvapich2%{PROJ_DELIM}
 %description -n %{PROJ_NAME}-intel-mvapich2-parallel-libs
 Collection of parallel library builds for use with Intel(R) Parallel Studio XE toolchain and the MVAPICH2 runtime
 
-%package -n %{PROJ_NAME}-intel-openmpi%{openmpi_major_ver}-parallel-libs
+%package -n %{PROJ_NAME}-intel-%{mpi_family}-parallel-libs
 Summary:   OpenHPC parallel libraries for Intel(R) Parallel Studio XE and OpenMPI
-Requires:  boost-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  hypre-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  mfem-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  mumps-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  petsc-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  scalapack-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  slepc-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  ptscotch-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  superlu_dist-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  trilinos-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-%description -n %{PROJ_NAME}-intel-openmpi%{openmpi_major_ver}-parallel-libs
+Requires:  boost-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  hypre-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  mfem-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  mumps-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  petsc-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  scalapack-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  slepc-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  ptscotch-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  superlu_dist-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  trilinos-intel-%{mpi_family}%{PROJ_DELIM}
+%description -n %{PROJ_NAME}-intel-%{mpi_family}-parallel-libs
 Collection of parallel library builds for use with Intel(R) Parallel Studio XE toolchain and the OpenMPI runtime
 
 %package -n %{PROJ_NAME}-intel-perf-tools
 Summary:   OpenHPC performance tools for Intel(R) Parallel Studio XE
-Requires:  dimemas-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
+Requires:  dimemas-%{compiler_family}-impi%{PROJ_DELIM}
 Requires:  dimemas-intel-impi%{PROJ_DELIM}
 Requires:  dimemas-intel-mpich%{PROJ_DELIM}
 Requires:  dimemas-intel-mvapich2%{PROJ_DELIM}
-Requires:  dimemas-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  extrae-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
+Requires:  dimemas-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  extrae-%{compiler_family}-impi%{PROJ_DELIM}
 Requires:  extrae-intel-impi%{PROJ_DELIM}
 Requires:  extrae-intel-mpich%{PROJ_DELIM}
 Requires:  extrae-intel-mvapich2%{PROJ_DELIM}
-Requires:  extrae-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  imb-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
+Requires:  extrae-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  imb-%{compiler_family}-impi%{PROJ_DELIM}
 Requires:  imb-intel-impi%{PROJ_DELIM}
 Requires:  imb-intel-mpich%{PROJ_DELIM}
 Requires:  imb-intel-mvapich2%{PROJ_DELIM}
-Requires:  imb-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
+Requires:  imb-intel-%{mpi_family}%{PROJ_DELIM}
 Requires:  likwid-intel%{PROJ_DELIM}
-Requires:  mpiP-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
-Requires:  omb-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
+Requires:  mpiP-%{compiler_family}-impi%{PROJ_DELIM}
+Requires:  omb-%{compiler_family}-impi%{PROJ_DELIM}
 Requires:  omb-intel-impi%{PROJ_DELIM}
 Requires:  omb-intel-mpich%{PROJ_DELIM}
 Requires:  omb-intel-mvapich2%{PROJ_DELIM}
-Requires:  omb-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
+Requires:  omb-intel-%{mpi_family}%{PROJ_DELIM}
 Requires:  papi%{PROJ_DELIM}
-Requires:  tau-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
+Requires:  tau-%{compiler_family}-impi%{PROJ_DELIM}
 Requires:  tau-intel-impi%{PROJ_DELIM}
 Requires:  tau-intel-mpich%{PROJ_DELIM}
 Requires:  tau-intel-mvapich2%{PROJ_DELIM}
-Requires:  tau-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  scalasca-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
+Requires:  tau-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  scalasca-%{compiler_family}-impi%{PROJ_DELIM}
 Requires:  scalasca-intel-impi%{PROJ_DELIM}
 Requires:  scalasca-intel-mpich%{PROJ_DELIM}
 Requires:  scalasca-intel-mvapich2%{PROJ_DELIM}
-Requires:  scalasca-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  scorep-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
+Requires:  scalasca-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  scorep-%{compiler_family}-impi%{PROJ_DELIM}
 Requires:  scorep-intel-impi%{PROJ_DELIM}
 Requires:  scorep-intel-mpich%{PROJ_DELIM}
 Requires:  scorep-intel-mvapich2%{PROJ_DELIM}
-Requires:  scorep-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
+Requires:  scorep-intel-%{mpi_family}%{PROJ_DELIM}
 %description -n %{PROJ_NAME}-intel-perf-tools
 Collection of performance tool builds for use with Intel(R) Parallel Studio XE toolchain
 
@@ -701,45 +690,33 @@ Requires:  papi%{PROJ_DELIM}
 %description -n %{PROJ_NAME}-intel-mvapich2-perf-tools
 Collection of performance tool builds for use with Intel(R) Parallel Studio XE compiler toolchain and the MVAPICH2 runtime
 
-%package -n %{PROJ_NAME}-intel-openmpi%{openmpi_major_ver}-perf-tools
+%package -n %{PROJ_NAME}-intel-%{mpi_family}-perf-tools
 Summary:   OpenHPC performance tools for Intel(R) Parallel Studio XE and OpenMPI
-Requires:  imb-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
+Requires:  imb-intel-%{mpi_family}%{PROJ_DELIM}
 Requires:  likwid-intel%{PROJ_DELIM}
-Requires:  mpiP-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  omb-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  tau-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  scalasca-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-Requires:  scorep-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
+Requires:  mpiP-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  omb-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  tau-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  scalasca-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  scorep-intel-%{mpi_family}%{PROJ_DELIM}
 Requires:  papi%{PROJ_DELIM}
-%description -n %{PROJ_NAME}-intel-openmpi%{openmpi_major_ver}-perf-tools
+%description -n %{PROJ_NAME}-intel-%{mpi_family}-perf-tools
 Collection of performance tool builds for use with Intel(R) Parallel Studio XE compiler toolchain and the OpenMPI runtime
 
 %package -n %{PROJ_NAME}-intel-python-libs
 Summary:   OpenHPC python libraries for Intel(R) Parallel Studio XE
-Requires:  %{PROJ_NAME}-intel-python2-libs
 Requires:  %{PROJ_NAME}-intel-python3-libs
 %description -n %{PROJ_NAME}-intel-python-libs
 Collection of python related library builds for use with Intel(R) Parallel Studio XE toolchain
 
-%package -n %{PROJ_NAME}-intel-python2-libs
-Summary:   OpenHPC python2 libraries for Intel(R) Parallel Studio XE
-Requires:  python-numpy-intel%{PROJ_DELIM}
-Requires:  python-mpi4py-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
-Requires:  python-mpi4py-intel-impi%{PROJ_DELIM}
-Requires:  python-mpi4py-intel-mpich%{PROJ_DELIM}
-Requires:  python-mpi4py-intel-mvapich2%{PROJ_DELIM}
-Requires:  python-mpi4py-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
-%description -n %{PROJ_NAME}-intel-python2-libs
-Collection of python2 related library builds for use with Intel(R) Parallel Studio XE toolchain
-
 %package -n %{PROJ_NAME}-intel-python3-libs
 Summary:   OpenHPC python3 libraries for Intel(R) Parallel Studio XE
-Requires:  %{python3_prefix}-numpy-intel%{PROJ_DELIM}
-Requires:  %{python3_prefix}-mpi4py-gnu%{gnu_major_ver}-impi%{PROJ_DELIM}
-Requires:  %{python3_prefix}-mpi4py-intel-impi%{PROJ_DELIM}
-Requires:  %{python3_prefix}-mpi4py-intel-mpich%{PROJ_DELIM}
-Requires:  %{python3_prefix}-mpi4py-intel-mvapich2%{PROJ_DELIM}
-Requires:  %{python3_prefix}-mpi4py-intel-openmpi%{openmpi_major_ver}%{PROJ_DELIM}
+Requires:  %{python_prefix}-numpy-intel%{PROJ_DELIM}
+Requires:  %{python_prefix}-mpi4py-%{compiler_family}-impi%{PROJ_DELIM}
+Requires:  %{python_prefix}-mpi4py-intel-impi%{PROJ_DELIM}
+Requires:  %{python_prefix}-mpi4py-intel-mpich%{PROJ_DELIM}
+Requires:  %{python_prefix}-mpi4py-intel-mvapich2%{PROJ_DELIM}
+Requires:  %{python_prefix}-mpi4py-intel-%{mpi_family}%{PROJ_DELIM}
 %description -n %{PROJ_NAME}-intel-python3-libs
 Collection of python3 related library builds for use with Intel(R) Parallel Studio XE toolchain
 
@@ -778,47 +755,45 @@ Collection of serial library builds for use with Intel(R) Parallel Studio XE too
 %files -n %{PROJ_NAME}-base
 %files -n %{PROJ_NAME}-base-compute
 %files -n %{PROJ_NAME}-ganglia
-%files -n %{PROJ_NAME}-gnu%{gnu_major_ver}-geopm
-%files -n %{PROJ_NAME}-gnu%{gnu_major_ver}-io-libs
-%files -n %{PROJ_NAME}-gnu%{gnu_major_ver}-mpich-io-libs
-%files -n %{PROJ_NAME}-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}-io-libs
-%files -n %{PROJ_NAME}-gnu%{gnu_major_ver}-parallel-libs
-%files -n %{PROJ_NAME}-gnu%{gnu_major_ver}-mpich-parallel-libs
-%files -n %{PROJ_NAME}-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}-parallel-libs
-%files -n %{PROJ_NAME}-gnu%{gnu_major_ver}-perf-tools
-%files -n %{PROJ_NAME}-gnu%{gnu_major_ver}-mpich-perf-tools
-%files -n %{PROJ_NAME}-gnu%{gnu_major_ver}-openmpi%{openmpi_major_ver}-perf-tools
-%files -n %{PROJ_NAME}-gnu%{gnu_major_ver}-python-libs
-%files -n %{PROJ_NAME}-gnu%{gnu_major_ver}-python2-libs
-%files -n %{PROJ_NAME}-gnu%{gnu_major_ver}-python3-libs
-%files -n %{PROJ_NAME}-gnu%{gnu_major_ver}-runtimes
-%files -n %{PROJ_NAME}-gnu%{gnu_major_ver}-serial-libs
+%files -n %{PROJ_NAME}-%{compiler_family}-geopm
+%files -n %{PROJ_NAME}-%{compiler_family}-io-libs
+%files -n %{PROJ_NAME}-%{compiler_family}-mpich-io-libs
+%files -n %{PROJ_NAME}-%{compiler_family}-%{mpi_family}-io-libs
+%files -n %{PROJ_NAME}-%{compiler_family}-parallel-libs
+%files -n %{PROJ_NAME}-%{compiler_family}-mpich-parallel-libs
+%files -n %{PROJ_NAME}-%{compiler_family}-%{mpi_family}-parallel-libs
+%files -n %{PROJ_NAME}-%{compiler_family}-perf-tools
+%files -n %{PROJ_NAME}-%{compiler_family}-mpich-perf-tools
+%files -n %{PROJ_NAME}-%{compiler_family}-%{mpi_family}-perf-tools
+%files -n %{PROJ_NAME}-%{compiler_family}-python-libs
+%files -n %{PROJ_NAME}-%{compiler_family}-python3-libs
+%files -n %{PROJ_NAME}-%{compiler_family}-runtimes
+%files -n %{PROJ_NAME}-%{compiler_family}-serial-libs
 %files -n %{PROJ_NAME}-nagios
 %files -n %{PROJ_NAME}-slurm-client
 %files -n %{PROJ_NAME}-slurm-server
 %files -n %{PROJ_NAME}-warewulf
 # x86_64 specific groups
 %ifnarch aarch64
-%files -n %{PROJ_NAME}-gnu%{gnu_major_ver}-mvapich2-io-libs
-%files -n %{PROJ_NAME}-gnu%{gnu_major_ver}-mvapich2-perf-tools
-%files -n %{PROJ_NAME}-gnu%{gnu_major_ver}-mvapich2-parallel-libs
+%files -n %{PROJ_NAME}-%{compiler_family}-mvapich2-io-libs
+%files -n %{PROJ_NAME}-%{compiler_family}-mvapich2-perf-tools
+%files -n %{PROJ_NAME}-%{compiler_family}-mvapich2-parallel-libs
 %files -n %{PROJ_NAME}-intel-geopm
 %files -n %{PROJ_NAME}-intel-io-libs
 %files -n %{PROJ_NAME}-intel-impi-io-libs
 %files -n %{PROJ_NAME}-intel-mpich-io-libs
 %files -n %{PROJ_NAME}-intel-mvapich2-io-libs
-%files -n %{PROJ_NAME}-intel-openmpi%{openmpi_major_ver}-io-libs
+%files -n %{PROJ_NAME}-intel-%{mpi_family}-io-libs
 %files -n %{PROJ_NAME}-intel-impi-parallel-libs
 %files -n %{PROJ_NAME}-intel-mpich-parallel-libs
 %files -n %{PROJ_NAME}-intel-mvapich2-parallel-libs
-%files -n %{PROJ_NAME}-intel-openmpi%{openmpi_major_ver}-parallel-libs
+%files -n %{PROJ_NAME}-intel-%{mpi_family}-parallel-libs
 %files -n %{PROJ_NAME}-intel-perf-tools
 %files -n %{PROJ_NAME}-intel-impi-perf-tools
 %files -n %{PROJ_NAME}-intel-mpich-perf-tools
 %files -n %{PROJ_NAME}-intel-mvapich2-perf-tools
-%files -n %{PROJ_NAME}-intel-openmpi%{openmpi_major_ver}-perf-tools
+%files -n %{PROJ_NAME}-intel-%{mpi_family}-perf-tools
 %files -n %{PROJ_NAME}-intel-python-libs
-%files -n %{PROJ_NAME}-intel-python2-libs
 %files -n %{PROJ_NAME}-intel-python3-libs
 %files -n %{PROJ_NAME}-intel-runtimes
 %files -n %{PROJ_NAME}-intel-serial-libs


### PR DESCRIPTION
Signed-off-by: jcsiadal <jeremy.c.siadal@intel.com>

We're internally testing OpenHPC 2.0 on CentOS 8. This update allows us to install the ohpc-(base, base-compute, and warewulf) meta-packages.

Instead of updating this meta-package independently and duplicating work, I modified the macros to grab default values from OHPC_macros.

The losf was updated to bypass a CentOS7 yum requirement.