### PR TITLE
Fixed wwbootstrap kernel file check problem

### DIFF
--- a/components/provisioning/warewulf-vnfs/SOURCES/warewulf-vnfs.sle.bootstrap_kernel.patch
+++ b/components/provisioning/warewulf-vnfs/SOURCES/warewulf-vnfs.sle.bootstrap_kernel.patch
@@ -6,7 +6,7 @@
  
 -if (! -f "$opt_chroot/boot/vmlinuz-$opt_kversion") {
 -    &eprint("Can't locate the boot kernel: ". $opt_chroot ."/boot/vmlinuz-$opt_kversion\n");
-+if (! -f "$opt_chroot/boot/vmlinuz-$opt_kversion" && -f "$opt_chroot/boot/vmlinux-$opt_kversion.gz") {
++if (! -f "$opt_chroot/boot/vmlinuz-$opt_kversion" && ! -f "$opt_chroot/boot/vmlinux-$opt_kversion.gz") {
 +    &eprint("Can't locate the boot kernel\n");
      exit 1;
  }


### PR DESCRIPTION
This patch fixed kernel file check condition so that wwbootstrap can
exit if and only if neither vmlinuz-$opt_kversion nor
vmlinux-$opt_kversion.gz exist.
Without this fix, wwbootstrap doesn't stop even though /boot is
empty.

Signed-off-by: Naohiro Tamura <naohirot@jp.fujitsu.com>