### PR TITLE
fftw updates for Parallel Studio 2020

### DIFF
--- a/components/parallel-libs/fftw/SOURCES/fftw-icc_2020_fix.patch
+++ b/components/parallel-libs/fftw/SOURCES/fftw-icc_2020_fix.patch
@@ -1,0 +1,11 @@
+--- a/configure.ac	2018-05-24 05:03:22.000000000 -0700
++++ b/configure.ac	2020-03-23 00:30:02.353000000 -0700
+@@ -334,7 +334,7 @@
+         case "${host_os}" in
+             *darwin*) ;; # icc -no-gcc fails to compile some system headers
+             *) 
+-	       AX_CHECK_COMPILER_FLAGS([-no-gcc], [CC="$CC -no-gcc"])
++	       AX_CHECK_COMPILER_FLAGS([-no-gcc], [CC="$CC -gcc-sys"])
+                ;;
+         esac
+         ;;

--- a/components/parallel-libs/fftw/SPECS/fftw.spec
+++ b/components/parallel-libs/fftw/SPECS/fftw.spec
@@ -27,6 +27,7 @@ License:   GPLv2+
 Group:     %{PROJ_NAME}/parallel-libs
 URL:       http://www.fftw.org
 Source0:   http://www.fftw.org/fftw-%{version}.tar.gz
+Patch0:    fftw-icc_2020_fix.patch
 
 %define openmp        1
 %define mpi           1
@@ -46,6 +47,7 @@ data, and of arbitrary input size.
 
 %prep
 %setup -q -n %{pname}-%{version}
+%patch0 -p1 
 
 %build
 # OpenHPC compiler/mpi designation
@@ -59,6 +61,11 @@ BASEFLAGS="$BASEFLAGS --enable-openmp"
 BASEFLAGS="$BASEFLAGS --enable-mpi"
 %endif
 
+%if %{compiler_family} == "intel"
+rm -rf autom4te.cache
+autoreconf --verbose --install --symlink --force
+rm -f config.cache
+%endif
 
 for i in %{precision_list} ; do
 	LOOPBASEFLAGS=${BASEFLAGS}

--- a/components/parallel-libs/fftw/SPECS/fftw.spec
+++ b/components/parallel-libs/fftw/SPECS/fftw.spec
@@ -34,7 +34,10 @@ Patch0:    fftw-icc_2020_fix.patch
 
 BuildRequires:        perl
 BuildRequires:        util-linux
-
+BuildRequires:        make
+%if %{compiler_family} == "intel"
+BuildRequires:        autoconf, automake
+%endif
 
 # Default library install path
 %define install_path %{OHPC_LIBS}/%{compiler_family}/%{mpi_family}/%{pname}/%version


### PR DESCRIPTION
Update the build process to support FFTW 3.3.8 on CentOS8 when built with IntelR) Parallel Studio 2020.

Two changes:
1. The -no-gcc flag has been replaced with -gcc-sys, which avoids some header compilation errors. 
2. The pre-built configure file doesn't create working testfiles; rather than patch configure, run autoreconf.

Builds confirmed on LEAP 15.1 and CentOS 8.1.
