### PR TITLE
superlu_dist: correctly set flags for the Intel compiler

### DIFF
--- a/components/parallel-libs/superlu_dist/SPECS/superlu_dist.spec
+++ b/components/parallel-libs/superlu_dist/SPECS/superlu_dist.spec
@@ -102,7 +102,7 @@ module load openblas
 %define blas_lib -armpl
 %endif
 
-%if "%{compiler_family}" != "intel"
+%if "%{compiler_family}" == "intel"
 %define blas_lib  -L$MKLROOT/lib/intel64 -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lpthread -lm -ldl
 %endif
 


### PR DESCRIPTION
One of the previous commits wrongly re-arranged the compiler flag conditionals. This should fix it again, so that GCC does not get Intel flags.

Just saw this while looking over the failed gnu9 builds in obs:
```
[  169s] /usr/bin/ld: cannot find -lmkl_intel_ilp64
[  169s] /usr/bin/ld: cannot find -lmkl_sequential
[  169s] /usr/bin/ld: cannot find -lmkl_core
```
That looks wrong when using GCC. This PR should fix this. Last broken `gnu9` build.