### PR TITLE
Fixed wwbootstrap for Leap 15.1 aarch64

### DIFF
--- a/components/provisioning/warewulf-vnfs/SOURCES/warewulf-vnfs.sle.bootstrap_kernel.patch
+++ b/components/provisioning/warewulf-vnfs/SOURCES/warewulf-vnfs.sle.bootstrap_kernel.patch
@@ -6,20 +6,20 @@
  
 -if (! -f "$opt_chroot/boot/vmlinuz-$opt_kversion") {
 -    &eprint("Can't locate the boot kernel: ". $opt_chroot ."/boot/vmlinuz-$opt_kversion\n");
-+if (! -f "$opt_chroot/boot/vmlinuz-$opt_kversion" && ! -f "$opt_chroot/boot/vmlinux-$opt_kversion.gz") {
++if (! -f "$opt_chroot/boot/vmlinuz-$opt_kversion" && ! -f "$opt_chroot/boot/Image-$opt_kversion") {
 +    &eprint("Can't locate the boot kernel\n");
      exit 1;
  }
  
 @@ -321,7 +321,11 @@
  
- # Attempt to gunzip the kernel, aarch64 kernels are compressed and iPXE can't boot gzip compressed kernels.
+ # Attempt to gunzip the kernel, aarch64 kernels are compressed ELF and iPXE can't boot gunzipped ELF kernels, but Image.
  # Note, if the kernel isn't a gzip, IO::Uncompress::Gunzip makes a direct copy of the file.
 -gunzip "$opt_chroot/boot/vmlinuz-$opt_kversion" => "$tmpdir/kernel" or die "gunzip of kernel failed: $GunzipError\n";
 +if (-e "$opt_chroot/boot/vmlinuz-$opt_kversion") {
 +    gunzip "$opt_chroot/boot/vmlinuz-$opt_kversion" => "$tmpdir/kernel" or die "gunzip of kernel failed: $GunzipError\n";
-+} elsif (-e "$opt_chroot/boot/vmlinux-$opt_kversion.gz") {
-+    gunzip "$opt_chroot/boot/vmlinux-$opt_kversion.gz" => "$tmpdir/kernel" or die "gunzip of kernel failed: $GunzipError\n";
++} elsif (-e "$opt_chroot/boot/Image-$opt_kversion") {
++    gunzip "$opt_chroot/boot/Image-$opt_kversion" => "$tmpdir/kernel" or die "gunzip of kernel failed: $GunzipError\n";
 +}
  
  &nprint("Building and compressing bootstrap\n");


### PR DESCRIPTION
Leap 15.1 aarch64 kernel is gzipped ELF, and iPXE can boot neither
gzipped ELF nor gunzipped ELF, but Image.

Signed-off-by: Naohiro Tamura <naohirot@jp.fujitsu.com>