### PR TITLE
Valgrind 3.15 update for OpenSUSE 15

### DIFF
--- a/components/dev-tools/valgrind/SPECS/valgrind.spec
+++ b/components/dev-tools/valgrind/SPECS/valgrind.spec
@@ -21,7 +21,8 @@ URL:       http://www.valgrind.org/
 Group:     %{PROJ_NAME}/dev-tools
 Source:    https://sourceware.org/pub/%{pname}/%{pname}-%{version}.tar.bz2
 
-BuildRequires: make
+BuildRequires: gcc, make
+
 # Default library install path
 %define install_path %{OHPC_UTILS}/%{pname}/%version
 
@@ -39,7 +40,7 @@ AMD64/MacOSX.
 
 %build
 ./configure --prefix=%{install_path} \
-          --libdir=%{install_path}/lib || { cat config.log && exit 1; }
+            --libdir=%{install_path}/lib || { cat config.log && exit 1; }
 make %{?_smp_mflags}
 
 %install

--- a/components/dev-tools/valgrind/SPECS/valgrind.spec
+++ b/components/dev-tools/valgrind/SPECS/valgrind.spec
@@ -21,6 +21,7 @@ URL:       http://www.valgrind.org/
 Group:     %{PROJ_NAME}/dev-tools
 Source:    https://sourceware.org/pub/%{pname}/%{pname}-%{version}.tar.bz2
 
+BuildRequires: make
 # Default library install path
 %define install_path %{OHPC_UTILS}/%{pname}/%version
 
@@ -37,7 +38,8 @@ AMD64/MacOSX.
 %setup -q -n %{pname}-%{version}
 
 %build
-./configure --prefix=%{install_path} || { cat config.log && exit 1; }
+./configure --prefix=%{install_path} \
+          --libdir=%{install_path}/lib || { cat config.log && exit 1; }
 make %{?_smp_mflags}
 
 %install
@@ -85,9 +87,10 @@ EOF
 %doc AUTHORS
 %doc README_DEVELOPERS
 %doc README
-%doc COPYING.DOCS
+%license COPYING
+%license COPYING.DOCS
 %doc README_PACKAGERS
 %doc README_MISSING_SYSCALL_OR_IOCTL
 %doc FAQ.txt
 %doc NEWS
-%doc COPYING
+

--- a/components/dev-tools/valgrind/SPECS/valgrind.spec
+++ b/components/dev-tools/valgrind/SPECS/valgrind.spec
@@ -7,7 +7,6 @@
 # desired integration conventions.
 #
 #----------------------------------------------------------------------------eh-
-
 %include %{_sourcedir}/OHPC_macros
 
 %define pname valgrind
@@ -35,13 +34,17 @@ can also use Valgrind to build new tools.  Valgrind runs on the following
 platforms: x86/Linux, AMD64/Linux, PPC32/Linux, PPC64/Linux, x86/MacOSX,
 AMD64/MacOSX.
 
+
 %prep
 %setup -q -n %{pname}-%{version}
 
+
 %build
 ./configure --prefix=%{install_path} \
-            --libdir=%{install_path}/lib || { cat config.log && exit 1; }
+            --libdir=%{install_path}/lib \
+            --enable-only64bit || { cat config.log && exit 1; }
 make %{?_smp_mflags}
+
 
 %install
 make install DESTDIR=$RPM_BUILD_ROOT
@@ -83,15 +86,11 @@ EOF
 
 %{__mkdir_p} ${RPM_BUILD_ROOT}/%{_docdir}
 
-%files
-%{OHPC_HOME}
-%doc AUTHORS
-%doc README_DEVELOPERS
-%doc README
-%license COPYING
-%license COPYING.DOCS
-%doc README_PACKAGERS
-%doc README_MISSING_SYSCALL_OR_IOCTL
-%doc FAQ.txt
-%doc NEWS
 
+%files
+%{install_path}
+%defattr(-,root,root)
+%doc AUTHORS FAQ.txt NEWS NEWS.old README*
+%doc %{install_path}/share/doc/*
+%license COPYING COPYING.DOCS
+%{OHPC_MODULES}/%{pname}


### PR DESCRIPTION
FIx library location on OpenSUSE 15 local build to match OBS build, plus minor RPM tune-up.