### PR TITLE
Added grub2-common to centos8.tmpl

### DIFF
--- a/components/provisioning/warewulf-vnfs/SOURCES/warewulf-vnfs.centos8.patch
+++ b/components/provisioning/warewulf-vnfs/SOURCES/warewulf-vnfs.centos8.patch
@@ -14,6 +14,6 @@
      zlib tar less gzip which util-linux openssh-clients 
      openssh-server dhclient pciutils vim-minimal shadow-utils
 -    strace cronie crontabs cpio wget redhat-release"
-+    strace cronie crontabs cpio wget redhat-release hostname"
++    strace cronie crontabs cpio wget redhat-release hostname grub2-common"
  
  # vim:filetype=sh:syntax=sh:expandtab:ts=4:sw=4:


### PR DESCRIPTION
If "wwmkchroot centos-8 $CHROOT" doesn't install grub2-common package,
"yum -y --installroot=$CHROOT install kernel" doesn't create
/boot/vmlinuz and /boot/initramfs which files "wwbootstrap" requires.

Signed-off-by: Naohiro Tamura <naohirot@jp.fujitsu.com>