### PR TITLE
Update WW IPoIB example

### DIFF
--- a/components/admin/examples/SOURCES/ifcfg-ib0.centos.ww
+++ b/components/admin/examples/SOURCES/ifcfg-ib0.centos.ww
@@ -1,7 +1,12 @@
+NAME=ib0
+TYPE=Infiniband
 DEVICE=ib0
 BOOTPROTO=static
 IPADDR=%{NETDEVS::IB0::IPADDR}
 NETMASK=%{NETDEVS::IB0::NETMASK}
 ONBOOT=yes
-NM_CONTROLLED=no
+NM_CONTROLLED=yes
 DEVTIMEOUT=5
+MTU=%{NETDEVS::IB0::MTU}
+# Uncomment the next line to enable MTU settings on Intel(R) Omni-Path HFIs
+#CONNECTED_MODE=yes

--- a/components/admin/examples/SPECS/examples.spec
+++ b/components/admin/examples/SPECS/examples.spec
@@ -47,7 +47,6 @@ OpenHPC development environment.
 install -D -m 0644 %SOURCE1 %{buildroot}%{OHPC_HOME}/pub/examples/mpi/hello.c
 install -D -m 0644 %SOURCE2 %{buildroot}%{OHPC_HOME}/pub/examples/network/sles/ifcfg-ib0
 install -D -m 0644 %SOURCE2 %{buildroot}%{OHPC_HOME}/pub/examples/network/centos/ifcfg-ib0
-
 install -D -m 0644 %SOURCE3 %{buildroot}%{OHPC_HOME}/pub/examples/network/sles/ifcfg-ib0.ww
 install -D -m 0644 %SOURCE4 %{buildroot}%{OHPC_HOME}/pub/examples/network/centos/ifcfg-ib0.ww
 install -D -m 0644 %SOURCE5 %{buildroot}%{OHPC_HOME}/pub/examples/slurm/job.mpi
@@ -61,5 +60,5 @@ install -D -m 0644 %SOURCE11 %{buildroot}%{OHPC_HOME}/pub/examples/example-mpi-d
 
 %files
 %dir %{OHPC_HOME}
-%doc LICENSE
+%license LICENSE
 %{OHPC_PUB}


### PR DESCRIPTION
Signed-off-by: jcsiadal <jeremy.c.siadal@intel.com>

Internally, this is the file we use  now for CentOS 8 builds, as the new release requires the use of Network Manager. It also adds MTU settings set through WW.

