### PR TITLE
MPI setup scripts configure correct compiler environment

### DIFF
--- a/components/OHPC_setup_mpi
+++ b/components/OHPC_setup_mpi
@@ -31,16 +31,47 @@ if [ -z "$MODULEPATH" ]; then
 fi
 
 if [ "$OHPC_MPI_FAMILY" = "openmpi" ]; then
+    export ICC=mpicc
+    export CXX=mpicxx
+    export FC=mpifort
+    export F77=mpif77   
     module load openmpi
 elif [ "$OHPC_MPI_FAMILY" = "openmpi3" ]; then
+    export ICC=mpicc
+    export CXX=mpicxx
+    export FC=mpifort
+    export F77=mpifort    
     module load openmpi3
 elif [ "$OHPC_MPI_FAMILY" = "openmpi4" ]; then
+    export ICC=mpicc
+    export CXX=mpicxx
+    export FC=mpifort
+    export F77=mpifort
     module load openmpi4
 elif [ "$OHPC_MPI_FAMILY" = "impi" ]; then
-    module load impi
+    if [ "$OHPC_COMPILER_FAMILY" = "intel" ]; then
+       export CC=mpiicc
+       export CXX=mpiicpc
+       export FC=mpiifort
+       export F77=mpiifort
+    else
+       export CC=mpicc
+       export CXX=mpicxx
+       export FC=mpifort
+       export F77=mpifort
+    fi 
+       module load impi
 elif [ "$OHPC_MPI_FAMILY" = "mvapich2" ]; then
+    export CC=mpicc
+    export CXX=mpicxx
+    export FC=mpifort
+    export F77=mpif77
     module load mvapich2
 elif [ "$OHPC_MPI_FAMILY" = "mpich" ]; then
+    export CC=mpicc
+    export CXX=mpicxx
+    export FC=mpifort
+    export F77=mpif77
     module load mpich
 else
     echo "Unsupported OHPC_MPI_FAMILY -> $OHPC_MPI_FAMILY"

--- a/components/mpi-families/impi-devel/SPECS/intel-mpi.spec
+++ b/components/mpi-families/impi-devel/SPECS/intel-mpi.spec
@@ -106,30 +106,6 @@ for file in ${versions}; do
     topDir=`echo $file | sed "s|$mpicc_subpath||"`
     echo "--> Installing modulefile for MPI version=${version}"
 	    
-    # Create soft links for standard MPI wrapper usage
-
-    ohpc_path=${topDir}/linux/mpi/intel64/bin_ohpc
-
-    %{__mkdir_p} ${ohpc_path} || exit 1
-    if [ -e ${topDir}/linux/mpi/intel64/bin/mpiicc ];then
-	if [ ! -e ${ohpc_path}/mpicc ];then
-	    %{__ln_s} ${topDir}/linux/mpi/intel64/bin/mpiicc ${ohpc_path}/mpicc
-	fi
-    fi
-    if [ -e ${topDir}/linux/mpi/intel64/bin/mpiicpc ];then
-	if [ ! -e ${ohpc_path}/mpicxx ];then
-	    %{__ln_s} ${topDir}/linux/mpi/intel64/bin/mpiicpc ${ohpc_path}/mpicxx
-	fi
-    fi
-    if [ -e ${topDir}/linux/mpi/intel64/bin/mpiifort ];then
-	if [ ! -e ${ohpc_path}/mpif90 ];then
-	    %{__ln_s} ${topDir}/linux/mpi/intel64/bin/mpiifort ${ohpc_path}/mpif90
-	fi
-	if [ ! -e ${ohpc_path}/mpif77 ];then
-	    %{__ln_s} ${topDir}/linux/mpi/intel64/bin/mpiifort ${ohpc_path}/mpif77
-	fi
-    fi
-	    
     # Module header
 
     %{__cat} << EOF > %{OHPC_MODULEDEPS}/intel/impi/${version}
@@ -163,15 +139,6 @@ EOF
 
     # Append with environment vars parsed directlry from mpivars.sh
     ${scanner} ${topDir}/linux/mpi/intel64/bin/mpivars.sh  >> %{OHPC_MODULEDEPS}/intel/impi/${version} || exit 1
-
-    # Prepend bin_ohpc
-    %{__cat} << EOF >> %{OHPC_MODULEDEPS}/intel/impi/${version}
-#
-# Prefer bin_ohpc to allow developers to use standard mpicc, mpif90,
-# etc to access Intel toolchain.
- 
-prepend-path    PATH            ${topDir}/${dir}/linux/mpi/intel64/bin_ohpc
-EOF
 
     # Also define MPI_DIR based on $I_MPI_ROOT
     IMPI_DIR=`egrep "^setenv\s+I_MPI_ROOT"  %{OHPC_MODULEDEPS}/intel/impi/${version} | awk '{print $3}'`
@@ -256,10 +223,6 @@ if [ "$1" = 0 ]; then
     for file in ${versions}; do
 	version=`rpm -q --qf '%%{VERSION}.%%{RELEASE}\n' -f ${file}`
 	topDir=`echo $file | sed "s|$mpicc_subpath||"`
-
-	if [ -d ${topDir}/linux/mpi/intel64/bin_ohpc ];then
-	    rm -rf ${topDir}/linux/mpi/intel64/bin_ohpc
-	fi
     done
 
     if [ -s %{OHPC_MODULEDEPS}/intel/impi/.manifest ];then

--- a/components/mpi-families/impi-devel/SPECS/intel-mpi.spec
+++ b/components/mpi-families/impi-devel/SPECS/intel-mpi.spec
@@ -146,6 +146,16 @@ EOF
 	echo "setenv          MPI_DIR        $IMPI_DIR/intel64" >> %{OHPC_MODULEDEPS}/intel/impi/${version}
     fi
 
+    # Change typical MPI compiler commands to use the Intel compilers by default
+
+    %{__cat} << EOF >> %{OHPC_MODULEDEPS}/intel/impi/${version}
+setenv          I_MPI_CC        "icc"
+setenv          I_MPI_CXX       "icpc"
+setenv          I_MPI_FC        "ifort"
+setenv          I_MPI_F77       "ifort"
+setenv          I_MPI_F90       "ifort"
+EOF
+
     # Version file
     %{__cat} << EOF > %{OHPC_MODULEDEPS}/intel/impi/.version.${version}
 #%Module1.0#####################################################################


### PR DESCRIPTION
This updates the MPI setup so that compiler environment points to the correct MPI wrapper for the preferred compiler chain. It makes more sense to centralize the logic tree to one place instead of requiring each MPI-based component to repeat the same steps, especially for the Intel MPI Library.

Secondly, it updates the impi environment module.  OpenHPC should not be modifying the installation of Parallel Studio or changing binary file operation. I confirmed with our developer consulting team that setting the environment is correct method to accomplish the end goal. 

You can verify which compiler is called using "mpicc -compile-info".