### PR TITLE
Updates to allow mpich/mvapich to build locally on OpenSUSE 15

### DIFF
--- a/components/mpi-families/mpich/SPECS/mpich.spec
+++ b/components/mpi-families/mpich/SPECS/mpich.spec
@@ -99,6 +99,7 @@ module load libfabric
 %endif
 
 ./configure --prefix=%{install_path} \
+            --libdir=%{install_path}/lib \
 %if 0%{with_slurm}
             --with-pm=no --with-pmi=slurm \
 %endif

--- a/components/mpi-families/mvapich2/SPECS/mvapich2.spec
+++ b/components/mpi-families/mvapich2/SPECS/mvapich2.spec
@@ -91,6 +91,7 @@ across multiple networks.
 %build
 %ohpc_setup_compiler
 ./configure --prefix=%{install_path} \
+            --libdir=%{install_path}/lib \
 	    --enable-cxx \
 	    --enable-g=dbg \
             --with-device=ch3:mrail \


### PR DESCRIPTION
Updates the configure options so that the specfiles will build locally on OpenSUSE 15. On OpenSUSE, configure sets libdir to lib64 (normally correct), and the build fails when rpmbuild tries to operate on files under lib.

This problem doesn't happen on CentOS 8.
