### PR TITLE
armpl is working for blas/lapack for aarch64

### DIFF
--- a/components/parallel-libs/hypre/SPECS/hypre.spec
+++ b/components/parallel-libs/hypre/SPECS/hypre.spec
@@ -62,12 +62,8 @@ module load superlu
 module load openblas
 %endif
 
-%if "%{compiler_family}" == "arm1"
-  optflags="-O3 -fsimdmath"
-%endif
 
-
-FLAGS="%optflags -fPIC -Dhypre_dgesvd=dgesvd_ -Dhypre_dlamch=dlamch_  -Dhypre_blas_lsame=hypre_lapack_lsame -Dhypre_blas_xerbla=hypre_lapack_xerbla "
+FLAGS="-fPIC -Dhypre_dgesvd=dgesvd_ -Dhypre_dlamch=dlamch_  -Dhypre_blas_lsame=hypre_lapack_lsame -Dhypre_blas_xerbla=hypre_lapack_xerbla "
 cd src
 ./configure \
     --prefix=%{install_path} \


### PR DESCRIPTION
This should not break x86 compiler variants while building hypre w/ armpl for blas/lapack for ACFL aarch64. 