### PR TITLE
docs: Remove reference to nonexistent package

### DIFF
--- a/docs/recipes/install/centos8/x86_64/xcat/slurm/steps.tex
+++ b/docs/recipes/install/centos8/x86_64/xcat/slurm/steps.tex
@@ -181,7 +181,6 @@ repository, which is shipped with CentOS and is enabled by default.
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true]
 # Optionally add IB support and enable
 [sms](*\#*) (*\groupchrootinstall*) "InfiniBand Support"
-[sms](*\#*) (*\chrootinstall*) infinipath-psm
 [sms](*\#*) chroot $CHROOT systemctl enable rdma
 \end{lstlisting}
 % ohpc_indent 0

--- a/docs/recipes/install/centos8/x86_64/xcat_stateful/slurm/steps.tex
+++ b/docs/recipes/install/centos8/x86_64/xcat_stateful/slurm/steps.tex
@@ -222,7 +222,6 @@ issue the following
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true]
 # Optionally add IB support and enable
 [sms](*\#*) (*\groupchrootinstall*) "InfiniBand Support"
-[sms](*\#*) (*\chrootinstall*) infinipath-psm
 [sms](*\#*) psh compute systemctl enable rdma
 [sms](*\#*) psh compute systemctl start rdma
 \end{lstlisting}

--- a/docs/recipes/install/common/ibsupport_compute_centos.tex
+++ b/docs/recipes/install/common/ibsupport_compute_centos.tex
@@ -11,7 +11,6 @@ image.
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true]
 # Add IB support and enable
 [sms](*\#*) (*\groupchrootinstall*) "InfiniBand Support"
-[sms](*\#*) (*\chrootinstall*) infinipath-psm
 [sms](*\#*) chroot $CHROOT systemctl enable rdma
 \end{lstlisting}
 % ohpc_indent 0

--- a/docs/recipes/install/common/ibsupport_sms_centos.tex
+++ b/docs/recipes/install/common/ibsupport_sms_centos.tex
@@ -7,7 +7,6 @@ to the chosen {\em master} host.
 % ohpc_indent 5
 \begin{lstlisting}[language=bash,keywords={}]
 [sms](*\#*) (*\groupinstall*) "InfiniBand Support"
-[sms](*\#*) (*\install*) infinipath-psm
 
 # Load IB drivers
 [sms](*\#*) systemctl start rdma


### PR DESCRIPTION
I don't claim to know much about this package or why it's not in centos8. I was just going through the documentation to install openhpc and this package doesn't exist anymore.

There is no branch for centos8: https://git.centos.org/rpms/infinipath-psm/branches