### PR TITLE
docs: Clean up extra step from c6a3e98c

### DIFF
--- a/docs/recipes/install/common/warewulf_setup_centos.tex
+++ b/docs/recipes/install/common/warewulf_setup_centos.tex
@@ -6,9 +6,6 @@
 # Configure Warewulf provisioning to use desired internal interface
 [sms](*\#*) perl -pi -e "s/device = eth1/device = ${sms_eth_internal}/" /etc/warewulf/provision.conf
 
-# Enable tftp service for compute node image distribution
-[sms](*\#*) perl -pi -e "s/^\s+disable\s+= yes/ disable = no/" /etc/xinetd.d/tftp
-
 # Enable internal interface for provisioning
 [sms](*\#*) ip link set dev ${sms_eth_internal} up
 [sms](*\#*) ip address add ${sms_ip}/${internal_netmask} broadcast + dev ${sms_eth_internal}


### PR DESCRIPTION
This updates the documentation to reflect the upstream CentOS switch to
using systemd for managing the tftp service.

Signed-off-by: Sol Jerome <solj@utdallas.edu>