### PR TITLE
tests: Update travis-ci tests

### DIFF
--- a/tests/travis/Dockerfile.check_spec
+++ b/tests/travis/Dockerfile.check_spec
@@ -1,10 +1,10 @@
-FROM centos:7
+FROM centos:8
 
 ARG TRAVIS_COMMIT_RANGE
 ENV TRAVIS_COMMIT_RANGE=$TRAVIS_COMMIT_RANGE
 ENV PYTHON_BINARY=python3
 
-RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 RUN yum install -y git ${PYTHON_BINARY}
 
 COPY . /ohpc


### PR DESCRIPTION
This updates the travis-ci tests to run on CentOS 8 instead of 7.

Signed-off-by: Sol Jerome <solj@utdallas.edu>