### PR TITLE
components: Proper fix for #520

### DIFF
--- a/components/provisioning/warewulf-provision/SOURCES/warewulf-provision.pxe_file_modes.patch
+++ b/components/provisioning/warewulf-provision/SOURCES/warewulf-provision.pxe_file_modes.patch
@@ -1,28 +1,37 @@
---- a/lib/Warewulf/Bootstrap.pm	2019-06-17 14:01:40.000000000 -0700
-+++ b/lib/Warewulf/Bootstrap.pm	2019-06-25 14:42:31.410866655 -0700
-@@ -210,7 +210,9 @@
-             my $dirname = dirname($file);
+diff --git a/lib/Warewulf/Bootstrap.pm b/lib/Warewulf/Bootstrap.pm
+index ff2ad21..3b4ded0 100644
+--- a/lib/Warewulf/Bootstrap.pm
++++ b/lib/Warewulf/Bootstrap.pm
+@@ -16,6 +16,7 @@ use Warewulf::DataStore;
+ use Warewulf::Util;
+ use File::Basename;
+ use File::Path;
++use File::Path qw(make_path);
+ use Digest::MD5 qw(md5_hex);
+ use POSIX qw(uname);
+ 
+@@ -211,6 +212,9 @@ bootstrap_export()
  
              if (! -d $dirname) {
--                mkpath($dirname);
-+                mkpath($dirname, {
-+                    mode => 0755,
+                 mkpath($dirname);
++                make_path($dirname, {
++                    chmod => 0755,
 +                });
              }
          }
  
-@@ -350,7 +352,9 @@
+@@ -350,7 +354,9 @@ build_local_bootstrap()
              }
  
              mkpath($tmpdir);
 -            mkpath($bootstrapdir);
-+            mkpath($bootstrapdir, {
-+                mode => 0755,
++            make_path($bootstrapdir, {
++                chmod => 0755,
 +            });
              chdir($tmpdir);
  
              &dprint("Opening gunzip/cpio pipe\n");
-@@ -381,10 +385,13 @@
+@@ -381,10 +387,13 @@ build_local_bootstrap()
              system("cd $tmpdir/initramfs; find . | cpio -o --quiet -H newc -F $bootstrapdir/initfs");
              &nprint("Compressing the initramfs\n");
              system("gzip -f -9 $bootstrapdir/initfs");
@@ -36,35 +45,64 @@
              print COOKIE $self->checksum();
              close COOKIE;
              &nprint("Bootstrap image '$bootstrap_name' is ready\n");
---- a/lib/Warewulf/Provision/Pxe.pm	2019-06-17 14:01:40.000000000 -0700
-+++ b/lib/Warewulf/Provision/Pxe.pm	2019-06-25 14:42:31.414866655 -0700
-@@ -94,8 +94,11 @@
+diff --git a/lib/Warewulf/Provision/Pxe.pm b/lib/Warewulf/Provision/Pxe.pm
+index c9f6a7b..c843206 100644
+--- a/lib/Warewulf/Provision/Pxe.pm
++++ b/lib/Warewulf/Provision/Pxe.pm
+@@ -19,6 +19,7 @@ use Warewulf::DataStore;
+ use Warewulf::Provision::Tftp;
+ use File::Basename;
+ use File::Path;
++use File::Path qw(make_path);
+ use POSIX qw(uname);
+ 
+ our @ISA = ('Warewulf::Object');
+@@ -94,8 +95,11 @@ setup()
                  if (-f "$datadir/warewulf/ipxe/$f") {
                      &iprint("Copying $f to the tftp root\n");
                      my $dirname = dirname("$tftpdir/warewulf/ipxe/$f");
 -                    mkpath($dirname);
-+                    mkpath($dirname, {
-+                        mode => 0755,
++                    make_path($dirname, {
++                        chmod => 0755,
 +                    });
                      system("cp $datadir/warewulf/ipxe/$f $tftpdir/warewulf/ipxe/$f");
 +                    chmod 0644, "$tftpdir/warewulf/ipxe/$f";
                  } elsif ($arch eq "x86_64") {
                      &eprint("Could not locate Warewulf's internal $datadir/warewulf/ipxe/$f! Things might be broken!\n");
                  }
-@@ -106,8 +109,11 @@
+@@ -106,8 +110,11 @@ setup()
                  if (-f "$datadir/warewulf/ipxe/$f") {
                      &iprint("Copying $f to the tftp root\n");
                      my $dirname = dirname("$tftpdir/warewulf/ipxe/$f");
 -                    mkpath($dirname);
-+                    mkpath($dirname, {
-+                        mode => 0755,
++                    make_path($dirname, {
++                        chmod => 0755,
 +                    });
                      system("cp $datadir/warewulf/ipxe/$f $tftpdir/warewulf/ipxe/$f");
 +                    chmod 0644, "$tftpdir/warewulf/ipxe/$f";
                  } elsif ($arch eq "aarch64") {
                      &eprint("Could not locate Warewulf's internal $datadir/warewulf/ipxe/$f! Things might be broken!\n");
                  }
-@@ -372,6 +380,9 @@
+@@ -154,7 +161,9 @@ update()
+ 
+     if (! -d "$statedir/warewulf/ipxe/cfg") {
+         &iprint("Creating ipxe configuration directory: $statedir/warewulf/ipxe/cfg");
+-        mkpath("$statedir/warewulf/ipxe/cfg");
++        make_path("$statedir/warewulf/ipxe/cfg", {
++            chmod => 0755,
++        });
+     }
+ 
+     foreach my $nodeobj (@nodeobjs) {
+@@ -322,6 +331,7 @@ update()
+                     if (! close IPXE) {
+                         &eprint("Could not write iPXE configuration file: $!\n");
+                     }
++		    chmod 0644, "$statedir/warewulf/ipxe/cfg/$config";
+                 } else {
+                     &eprint("Node: $nodename-$devname: Bad characters in hwaddr: '$hwaddr'\n");
+                 }
+@@ -372,6 +382,9 @@ delete()
                  if (-f "$statedir/warewulf/ipxe/cfg/$config") {
                      unlink("$statedir/warewulf/ipxe/cfg/$config");
                  }
@@ -74,4 +112,3 @@
              } else {
                  &eprint("Bad characters in hwaddr: $hwaddr\n");
              }
-

--- a/components/provisioning/warewulf-provision/SOURCES/warewulf-provision.pxe_file_modes.patch
+++ b/components/provisioning/warewulf-provision/SOURCES/warewulf-provision.pxe_file_modes.patch
@@ -1,16 +1,17 @@
 diff --git a/lib/Warewulf/Bootstrap.pm b/lib/Warewulf/Bootstrap.pm
-index ff2ad21..3b4ded0 100644
+index ff2ad21..daf794a 100644
 --- a/lib/Warewulf/Bootstrap.pm
 +++ b/lib/Warewulf/Bootstrap.pm
-@@ -16,6 +16,7 @@ use Warewulf::DataStore;
+@@ -15,7 +15,7 @@ use Warewulf::Logger;
+ use Warewulf::DataStore;
  use Warewulf::Util;
  use File::Basename;
- use File::Path;
+-use File::Path;
 +use File::Path qw(make_path);
  use Digest::MD5 qw(md5_hex);
  use POSIX qw(uname);
  
-@@ -211,6 +212,9 @@ bootstrap_export()
+@@ -211,6 +211,9 @@ bootstrap_export()
  
              if (! -d $dirname) {
                  mkpath($dirname);
@@ -20,7 +21,7 @@ index ff2ad21..3b4ded0 100644
              }
          }
  
-@@ -350,7 +354,9 @@ build_local_bootstrap()
+@@ -350,7 +353,9 @@ build_local_bootstrap()
              }
  
              mkpath($tmpdir);
@@ -31,33 +32,34 @@ index ff2ad21..3b4ded0 100644
              chdir($tmpdir);
  
              &dprint("Opening gunzip/cpio pipe\n");
-@@ -381,10 +387,13 @@ build_local_bootstrap()
+@@ -381,10 +386,13 @@ build_local_bootstrap()
              system("cd $tmpdir/initramfs; find . | cpio -o --quiet -H newc -F $bootstrapdir/initfs");
              &nprint("Compressing the initramfs\n");
              system("gzip -f -9 $bootstrapdir/initfs");
-+            chmod 0644, "$bootstrapdir/initfs.gz";
++            chmod(0644, "$bootstrapdir/initfs.gz");
              &nprint("Locating the kernel object\n");
              system("cp $tmpdir/kernel $bootstrapdir/kernel");
-+            chmod 0644, "$bootstrapdir/kernel";
++            chmod(0644, "$bootstrapdir/kernel");
              system("rm -rf $tmpdir");
              open(COOKIE, "> $bootstrapdir/cookie");
-+            chmod 0644, "$bootstrapdir/cookie";
++            chmod(0644, "$bootstrapdir/cookie");
              print COOKIE $self->checksum();
              close COOKIE;
              &nprint("Bootstrap image '$bootstrap_name' is ready\n");
 diff --git a/lib/Warewulf/Provision/Pxe.pm b/lib/Warewulf/Provision/Pxe.pm
-index c9f6a7b..c843206 100644
+index c9f6a7b..bd3e0ac 100644
 --- a/lib/Warewulf/Provision/Pxe.pm
 +++ b/lib/Warewulf/Provision/Pxe.pm
-@@ -19,6 +19,7 @@ use Warewulf::DataStore;
+@@ -18,7 +18,7 @@ use Warewulf::Network;
+ use Warewulf::DataStore;
  use Warewulf::Provision::Tftp;
  use File::Basename;
- use File::Path;
+-use File::Path;
 +use File::Path qw(make_path);
  use POSIX qw(uname);
  
  our @ISA = ('Warewulf::Object');
-@@ -94,8 +95,11 @@ setup()
+@@ -94,8 +94,11 @@ setup()
                  if (-f "$datadir/warewulf/ipxe/$f") {
                      &iprint("Copying $f to the tftp root\n");
                      my $dirname = dirname("$tftpdir/warewulf/ipxe/$f");
@@ -66,11 +68,11 @@ index c9f6a7b..c843206 100644
 +                        chmod => 0755,
 +                    });
                      system("cp $datadir/warewulf/ipxe/$f $tftpdir/warewulf/ipxe/$f");
-+                    chmod 0644, "$tftpdir/warewulf/ipxe/$f";
++                    chmod(0644, "$tftpdir/warewulf/ipxe/$f");
                  } elsif ($arch eq "x86_64") {
                      &eprint("Could not locate Warewulf's internal $datadir/warewulf/ipxe/$f! Things might be broken!\n");
                  }
-@@ -106,8 +110,11 @@ setup()
+@@ -106,8 +109,11 @@ setup()
                  if (-f "$datadir/warewulf/ipxe/$f") {
                      &iprint("Copying $f to the tftp root\n");
                      my $dirname = dirname("$tftpdir/warewulf/ipxe/$f");
@@ -79,11 +81,11 @@ index c9f6a7b..c843206 100644
 +                        chmod => 0755,
 +                    });
                      system("cp $datadir/warewulf/ipxe/$f $tftpdir/warewulf/ipxe/$f");
-+                    chmod 0644, "$tftpdir/warewulf/ipxe/$f";
++                    chmod(0644, "$tftpdir/warewulf/ipxe/$f");
                  } elsif ($arch eq "aarch64") {
                      &eprint("Could not locate Warewulf's internal $datadir/warewulf/ipxe/$f! Things might be broken!\n");
                  }
-@@ -154,7 +161,9 @@ update()
+@@ -154,7 +160,9 @@ update()
  
      if (! -d "$statedir/warewulf/ipxe/cfg") {
          &iprint("Creating ipxe configuration directory: $statedir/warewulf/ipxe/cfg");
@@ -94,15 +96,15 @@ index c9f6a7b..c843206 100644
      }
  
      foreach my $nodeobj (@nodeobjs) {
-@@ -322,6 +331,7 @@ update()
+@@ -322,6 +330,7 @@ update()
                      if (! close IPXE) {
                          &eprint("Could not write iPXE configuration file: $!\n");
                      }
-+		    chmod 0644, "$statedir/warewulf/ipxe/cfg/$config";
++		    chmod(0644, "$statedir/warewulf/ipxe/cfg/$config");
                  } else {
                      &eprint("Node: $nodename-$devname: Bad characters in hwaddr: '$hwaddr'\n");
                  }
-@@ -372,6 +382,9 @@ delete()
+@@ -372,6 +381,9 @@ delete()
                  if (-f "$statedir/warewulf/ipxe/cfg/$config") {
                      unlink("$statedir/warewulf/ipxe/cfg/$config");
                  }


### PR DESCRIPTION
The fix in 8744b043 doesn't actually resolve the issue with a
restrictive umask. Quoting the [mkpath](https://perldoc.perl.org/5.10.0/File/Path.html) page:

    mode

    The numeric permissions mode to apply to each created directory
    (defaults to 0777), to be modified by the current umask. If the
    directory already exists (and thus does not need to be created),
    the permissions will not be modified.

This means that the mode settings that were applied previously still
respected the restrictive umask and resulted in a nonworking pxeboot
configuration.

This commit modifies the previous fix to use make_path instead since the
`chmod` parameter does precisely what we want.

    chmod => $num

    Takes a numeric mode to apply to each created directory (not modified
    by the current umask). If the directory already exists (and thus
    does not need to be created), the permissions will not be modified.

Signed-off-by: Sol Jerome <solj@utdallas.edu>