### PR TITLE
perf-tools/dimemas: bump to v5.4.2. Also add local ohpc build of flex…

### DIFF
--- a/components/distro-packages/flex/SOURCES/COPYING
+++ b/components/distro-packages/flex/SOURCES/COPYING
@@ -1,0 +1,42 @@
+Flex carries the copyright used for BSD software, slightly modified
+because it originated at the Lawrence Berkeley (not Livermore!) Laboratory,
+which operates under a contract with the Department of Energy:
+
+Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007 The Flex Project.
+
+Copyright (c) 1990, 1997 The Regents of the University of California.
+All rights reserved.
+
+This code is derived from software contributed to Berkeley by
+Vern Paxson.
+
+The United States Government has rights in this work pursuant
+to contract no. DE-AC03-76SF00098 between the United States
+Department of Energy and the University of California.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+Neither the name of the University nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.
+
+This basically says "do whatever you please with this software except
+remove this notice or take advantage of the University's (or the flex
+authors') name".
+
+Note that the "flex.skl" scanner skeleton carries no copyright notice.
+You are free to do whatever you please with scanners generated using flex;
+for them, you are not even bound by the above copyright.

--- a/components/distro-packages/flex/SPECS/flex.spec
+++ b/components/distro-packages/flex/SPECS/flex.spec
@@ -1,0 +1,90 @@
+#----------------------------------------------------------------------------bh-
+# This RPM .spec file is part of the OpenHPC project.
+#
+# It may have been modified from the default version supplied by the underlying
+# release package (if available) in order to apply patches, perform customized
+# build/install configurations, and supply additional files to support
+# desired integration conventions.
+#
+#----------------------------------------------------------------------------eh-
+
+%include %{_sourcedir}/OHPC_macros
+
+%define pname flex
+
+Name:	  %{pname}%{PROJ_DELIM}
+Version:  2.6.4
+Release:  1%{?dist}
+Summary:  Fast Lexical Analyzer Generator
+Group:	  %{PROJ_NAME}/distro-packages
+License:  BSD-3-Clause
+URL:	  https://github.com/westes/flex
+Source0:  https://github.com/westes/flex/releases/download/v%{version}/flex-%{version}.tar.gz
+
+BuildRequires: gcc-c++
+BuildRequires: help2man
+BuildRequires: m4
+
+# Install path
+%define install_path %{OHPC_LIBS}/%{pname}%{OHPC_CUSTOM_PKG_DELIM}/%version
+
+%description
+FLEX is a tool for generating scanners: programs that recognize lexical
+patterns in text.
+
+%prep
+%setup -q -n %{pname}-%{version}
+
+%build
+./configure CFLAGS="-D_GNU_SOURCE" \
+       --prefix=%{install_path} \
+       --disable-shared
+
+make %{?_smp_mflags}
+
+%install
+make %{?_smp_mflags} DESTDIR=$RPM_BUILD_ROOT install
+
+%{__mkdir} -p %{buildroot}/%{OHPC_MODULES}/%{pname}
+%{__cat} << EOF > %{buildroot}/%{OHPC_MODULES}/%{pname}/%{version}
+#%Module1.0#####################################################################
+proc ModulesHelp { } {
+
+puts stderr " "
+puts stderr "This module loads the flex lexical scanner"
+puts stderr " "
+puts stderr "Version %{version}"
+puts stderr " "
+
+}
+
+module-whatis "Name: flex lexical scanner"
+module-whatis "Version: %{version}"
+module-whatis "Category: runtime library and tools"
+module-whatis "Description: tool and library for recognizing lexical patterns in text"
+module-whatis "%{url}"
+
+set     version                 %{version}
+
+
+prepend-path    PATH                %{install_path}/bin
+prepend-path    MANPATH             %{install_path}/share/man
+prepend-path    INCLUDE             %{install_path}/include
+prepend-path    LD_LIBRARY_PATH     %{install_path}/lib
+
+setenv          %{PNAME}_DIR        %{install_path}
+setenv          %{PNAME}_LIB        %{install_path}/lib
+setenv          %{PNAME}_INC        %{install_path}/include
+
+EOF
+
+%{__cat} << EOF > %{buildroot}/%{OHPC_MODULES}/%{pname}/.version.%{version}
+#%Module1.0#####################################################################
+set     ModulesVersion      "%{version}"
+EOF
+
+
+%files
+%{OHPC_PUB}
+%doc AUTHORS ChangeLog NEWS ONEWS README.md THANKS
+%license COPYING

--- a/components/perf-tools/dimemas/SPECS/dimemas.spec
+++ b/components/perf-tools/dimemas/SPECS/dimemas.spec
@@ -18,7 +18,7 @@
 
 Summary:	Dimemas tool
 Name:		%{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-Version:	5.4.1
+Version:	5.4.2
 Release:	1
 License:	GNU
 Group:		%{PROJ_NAME}/perf-tools
@@ -28,11 +28,13 @@ Source0:	https://ftp.tools.bsc.es/dimemas/dimemas-%{version}-src.tar.bz2
 BuildRequires: boost-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:      boost-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 BuildRequires: bison
-BuildRequires: flex
 %if 0%{?rhel}
 BuildRequires: flex-devel
-%else
+BuildRequires: flex
+%endif
+%if 0%{?suse_version}
 BuildRequires: libfl-devel
+BuildRequires: flex%{PROJ_DELIM}
 %endif
 BuildRequires: autoconf
 BuildRequires: automake
@@ -61,8 +63,15 @@ systems.
 %ohpc_setup_compiler
 module load boost
 
-./bootstrap
-CFLAGS="-std=c99" LDFLAGS="-lstdc++" ./configure --prefix=%{install_path} --with-boost=$BOOST_DIR || cat config.log
+#./bootstrap
+
+%if 0%{?suse_version}
+module load flex
+export LDFLAGS="-L$FLEX_LIB"
+%endif
+
+./configure --prefix=%{install_path} \
+            --with-boost=$BOOST_DIR || cat config.log
 
 make %{?_smp_mflags}
 


### PR DESCRIPTION
… to fix

issues observed on Leap15. dimemas will not build against dynamic flex lib
introduced in leap 15, so update to leverage local build which mimics previous
flex packaging that provides static lib.

Signed-off-by: Karl W. Schulz <karl@oden.utexas.edu>