### PR TITLE
Update LLVM to 10.

### DIFF
--- a/components/compiler-families/llvm-compilers/SPECS/llvm-compilers.spec
+++ b/components/compiler-families/llvm-compilers/SPECS/llvm-compilers.spec
@@ -8,6 +8,11 @@
 #
 #----------------------------------------------------------------------------eh-
 
+# Simple check for other active LLVM versions; they will break this build
+%if 0%(which clang llvm-ar >/dev/null 2>&1; echo $?) == 0
+%{error: "LLVM found in PATH; cannot build LLVM with with another LLVM available"}
+%endif
+
 %include %{_sourcedir}/OHPC_macros
 
 %ifarch aarch64 
@@ -18,37 +23,42 @@
 %global build_target X86
 %endif
 
-%global major_ver 9
+# Limit the number of parallel build processes to avoid race conditions
+%global _smp_ncpus_max 8
+
+%global major_ver 10
 %global pname llvm%{major_ver}-compilers
 
 Summary:   LLVM (An Optimizing Compiler Infrastructure)
 Name:      %{pname}%{PROJ_DELIM}
-Version:   9.0.0
+Version:   10.0.1
 Release:   1%{?dist}
 License:   Apache-2.0 with LLVM exception
 Group:     %{PROJ_NAME}/compiler-families
 URL:       http://www.llvm.org
-Source0:   http://releases.llvm.org/%{version}/llvm-%{version}.src.tar.xz
-Source1:   http://releases.llvm.org/%{version}/cfe-%{version}.src.tar.xz
-Source2:   http://releases.llvm.org/%{version}/compiler-rt-%{version}.src.tar.xz
-Source3:   http://releases.llvm.org/%{version}/libcxx-%{version}.src.tar.xz
-Source4:   http://releases.llvm.org/%{version}/libcxxabi-%{version}.src.tar.xz
-Source5:   http://releases.llvm.org/%{version}/libunwind-%{version}.src.tar.xz
-Source6:   http://releases.llvm.org/%{version}/lld-%{version}.src.tar.xz
-Source7:   http://releases.llvm.org/%{version}/openmp-%{version}.src.tar.xz
-Source8:   http://releases.llvm.org/%{version}/clang-tools-extra-%{version}.src.tar.xz
+Source0:   https://github.com/llvm/llvm-project/releases/download/llvmorg-%{version}/llvm-project-%{version}.tar.xz
 
 BuildRequires: cmake%{PROJ_DELIM}
-BuildRequires: gnu9-compilers%{PROJ_DELIM}
-BuildRequires: python
+BuildRequires: gcc
+BuildRequires: gcc-c++
+BuildRequires: python3
 BuildRequires: zlib-devel
 BuildRequires: pkgconfig
 BuildRequires: binutils-devel
-BuildRequires: perl
-BuildRequires: perl(Data::Dumper)
-BuildRequires: zlib-devel
 BuildRequires: glibc >= 2.26
+BuildRequires: libffi-devel
+%if 0%{?sle_version}
+BuildRequires: ninja
+BuildRequires: libelf-devel
+%endif
+%if 0%{?rhel}
+BuildRequires: ninja-build
+BuildRequires: elfutils-libelf-devel
+%endif
+
 Requires:      binutils
+Requires:      python3
+Conflicts:     libunwind-devel
 
 
 %define install_path %{OHPC_COMPILERS}/llvm/%{version}
@@ -61,153 +71,158 @@ Illinois and Apple. It currently supports compilation of C and C++ programs,
 using front-ends derived from GCC 4.0.1. The compiler infrastructure
 includes mirror sets of programming tools as well as libraries with equivalent
 functionality.
-This package includes: clang, clang-tools-extra, libcxx, libcxxabi, compiler-rt,
-                       openmp, libunwind, and lld
+This package includes: clang, libcxx, libcxxabi, compiler-rt, openmp,
+                       libunwind, lld, clang-tools-extra, libclc, and polly 
   
 
 %prep
-%setup -q -c -a1 -a2 -a3 -a4 -a5 -a6 -a7 -a8 
+%setup -q -n llvm-project-%{version} 
+%{__mkdir_p} stage1
+%{__mkdir_p} stage2
 
-%{__ln_s} llvm-%{version}.src llvm
-%{__ln_s} cfe-%{version}.src clang
-%{__ln_s} lld-%{version}.src lld
-%{__mv} clang-tools-extra-%{version}.src clang/tools/extra
-%{__ln_s} clang/tools/extra clang-tools-extra
-%{__ln_s} compiler-rt-%{version}.src compiler-rt
-%{__ln_s} libcxx-%{version}.src libcxx
-%{__ln_s} libcxxabi-%{version}.src libcxxabi
-%{__ln_s} libunwind-%{version}.src libunwind
-%{__ln_s} openmp-%{version}.src openmp
+# Replace any ambiguous python shebangs or rpmbuild will fail
+find . -type f -exec sed -i '1s@#! */usr/bin/env python\($\| \)@#!/usr/bin/python2@' "{}" \;
 
 
-%install
+%build
 module load cmake
-module load gnu9
-
-GNU8=$(command -v g++ | sed s#/bin.*##)
 
 MAIN=$(pwd)
-%{__mkdir} bootstrap
-BOOTSTRAP=$MAIN/bootstrap
-%{__mkdir} build
+BOOTSTRAP=$MAIN/stage1
+STAGE2=$MAIN/stage2
 
 # STAGE 1
-# Bootstrap clang with gcc
-# Then (re)build all components in stage 2
-# This is done manually as the BOOTSTRAP cmake option wouldn't
-#    build libc++ in stage 1 when needed for stage 2 build [JCS 13NOV19]
-cd build
-cmake --enable-optimise -Wno-dev -G"Unix Makefiles" ../llvm \
-      -DCMAKE_INSTALL_PREFIX="/" \
+# Bootstrap llvm with the distro llvm
+# Lots of options; the goal is to disable as much as possible
+#    to reduce build time, but keep all of the required components
+#    needed to rebuild LLVM10 with LLVM10
+# ZLib support required for OpenSUSE15
+cd $BOOTSTRAP
+cmake -DCMAKE_INSTALL_PREFIX="/" \
       -DCMAKE_C_COMPILER=gcc \
       -DCMAKE_CXX_COMPILER=g++ \
-      -DCMAKE_C_FLAGS=-Wl,-rpath,${GNU8}/lib64 \
-      -DCMAKE_CXX_FLAGS=-Wl,-rpath,${GNU8}/lib64 \
       -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_CXX_LINK_FLAGS="-Wl,-rpath,$BOOTSTRAP/lib -L$BOOTSTRAP/lib" \
       -DLLVM_DEFAULT_TARGET_TRIPLE=%{triple} \
-      -DLLVM_ENABLE_PROJECTS="clang;lld" \
-      -DLLVM_ENABLE_RUNTIMES="compiler-rt;libunwind;libcxxabi;libcxx" \
-      -DLLVM_BUILD_TOOLS=llvm-config \
-      -DLLVM_BINUTILS_INCDIR=/usr/include \
+      -DLLVM_ENABLE_PROJECTS="clang;lld;compiler-rt;libunwind;libcxxabi;libcxx" \
+      -DLLVM_BUILD_TOOLS=On \
       -DLLVM_TARGETS_TO_BUILD=%{build_target} \
+      -DLLVM_INCLUDE_TESTS=Off \
+      -DLLVM_INCLUDE_EXAMPLES=Off \
+      -DLLVM_INCLUDE_UTILS=Off \
+      -DLLVM_INCLUDE_DOCS=Off \
+      -DLLVM_INCLUDE_BENCHMARKS=Off \
+      -DLLVM_ENABLE_ZLIB=On \
+      -DLLVM_ENABLE_Z3_SOLVER=Off \
+      -DLLVM_ENABLE_BACKTRACES=Off \
+      -DLLVM_LINK_LLVM_DYLIB=On \
+      -DLLVM_ENABLE_LTO=Off \
+      -DLLVM_PARALLEL_LINK_JOBS=1 \
+      -DLLVM_STATIC_LINK_CXX_STDLIB=On \
+      -DCLANG_INCLUDE_TESTS=Off \
+      -DCLANG_ENABLE_STATIC_ANALYZER=Off \
+      -DCLANG_ENABLE_ARCMT=Off \
+      -DCOMPILER_RT_INCLUDE_TESTS=Off \
       -DCOMPILER_RT_BUILD_BUILTINS=On \
       -DCOMPILER_RT_BUILD_SANITIZERS=Off \
       -DCOMPILER_RT_BUILD_XRAY=Off \
       -DCOMPILER_RT_BUILD_LIBFUZZER=Off \
       -DCOMPILER_RT_BUILD_PROFILE=Off \
-      -DBUILD_SHARED_LIBS=On
+      -DLIBCXX_INCLUDE_BENCHMARKS=Off \
+      -DLIBCXX_INCLUDE_TESTS=Off \
+      -DLIBCXX_ENABLE_EXPERIMENTAL_LIBRARY=Off \
+      --enable-optimise -Wno-dev -G Ninja ../llvm 
 
-# Occasional failure when using make all. Appears to be race condition [JCS 13NOV19]
-# Compliation takes a long time if the -j option is removed [JCS 13NOV19]
-%{__make} %{?_smp_mflags} VERBOSE=1 clang
-%{__make} %{?_smp_mflags} VERBOSE=1 lld
-%{__make} %{?_smp_mflags} VERBOSE=1 cxxabi
-%{__make} %{?_smp_mflags} VERBOSE=1 cxx
-%{__make} %{?_smp_mflags} VERBOSE=1 
-%{__make} DESTDIR=$MAIN/bootstrap INSTALL="%{__install} -p" install
-cd $MAIN
+ninja %{?_smp_mflags} -v 
 # End Stage 1
 
-module unload gnu9
-
 # STAGE 2
-# Rebuild all components with clang
-# Swtich to LLVM libc++, compiler-rt, and libunwind
-# The gnu8 stack isn't needed after rebuild
+# Rebuild all components with new clang.
+# Swtich to using libc++, compiler-rt, and libunwind only.
+# Several settings appear redundant. Configuration options are 
+#   inconsistent between projects. Setting all possible variables for each
+#   option appears to work.
+# To use ninja check-all, reenable all static libraries before building.
 
-# Rebuild llvm+clang
-%{__mkdir_p} llvm/build/lib
-%{__cp} $BOOTSTRAP/lib/%{triple}/c++/* $MAIN/llvm/build/lib
-cd llvm/build
-cmake --enable-optimise -Wno-dev -G"Unix Makefiles" .. \
+%{__mkdir_p} $STAGE2/lib
+
+cd $STAGE2
+cmake -DPYTHON_EXECUTABLE=/usr/bin/python3 \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PREFIX="%{install_path}" \
       -DCMAKE_C_COMPILER=$BOOTSTRAP/bin/clang \
       -DCMAKE_CXX_COMPILER=$BOOTSTRAP/bin/clang++ \
+      -DCMAKE_C_FLAGS="-fuse-ld=lld -fPIC -stdlib=libc++ -Qunused-arguments" \
+      -DCMAKE_CXX_FLAGS="-fuse-ld=lld -fPIC -stdlib=libc++ -Qunused-arguments" \
       -DCMAKE_ASM_COMPILER=$BOOTSTRAP/bin/clang \
       -DCMAKE_AR=$BOOTSTRAP/bin/llvm-ar \
       -DCMAKE_RANLIB=$BOOTSTRAP/bin/llvm-ranlib \
-      -DCMAKE_C_FLAGS="-I$BOOTSTRAP/include/c++/v1" \
-      -DCMAKE_CXX_FLAGS="-I$BOOTSTRAP/include/c++/v1" \
-      -DCMAKE_EXE_LINKER_FLAGS="-rtlib=compiler-rt -L$MAIN/llvm/build/lib -lunwind" \
-      -DCMAKE_SHARED_LINKER_FLAGS="-rtlib=compiler-rt -L$MAIN/llvm/build/lib -lunwind" \
+      -DCMAKE_LINKER=$BOOTSTRAP/bin/ld.lld \
+      -DCMAKE_EXE_LINKER_FLAGS="-rtlib=compiler-rt -L$STAGE2/lib -Wl,-thinlto-jobs=4" \
+      -DCMAKE_SHARED_LINKER_FLAGS="-rtlib=compiler-rt -L$STAGE2/lib -Wl,-thinlto-jobs=4" \
+      -DLLVM_TABLEGEN=$BOOTSTRAP/bin/llvm-tblgen \
+      -DLLVM_OPTIMIZED_TABLEGEN=On \
+      -DLLVM_CONFIG_PATH=$BOOTSTRAP/bin/llvm-config \
       -DLLVM_ENABLE_LIBCXX=On \
-      -DLLVM_ENABLE_LIBCXXABI=On \
       -DLLVM_DEFAULT_TARGET_TRIPLE=%{triple} \
       -DLLVM_BINUTILS_INCDIR=/usr/include \
       -DLLVM_ENABLE_LLD=On \
-      -DLLVM_ENABLE_FPIC=On \
-      -DLLVM_CONFIG_PATH=$BOOTSTRAP/bin/llvm-config \
-      -DLLVM_ENABLE_PROJECTS="clang;lld;clang-tools-extra;openmp" \
-      -DLLVM_ENABLE_RUNTIMES="compiler-rt;libcxxabi;libcxx;libunwind" \
+      -DLLVM_ENABLE_PROJECTS="clang;lld;openmp;libclc;clang-tools-extra;polly;compiler-rt;libunwind;libcxxabi;libcxx" \
       -DLLVM_ENABLE_LTO=Thin \
       -DLLVM_TARGETS_TO_BUILD=%{build_target} \
       -DLLVM_LINK_LLVM_DYLIB=On \
-      -DLLVM_DYLIB_COMPONENTS=all \
+      -DLLVM_BUILD_LLVM_DYLIB=On \
+      -DLLVM_BUILD_STATIC=Off \
+      -DLLVM_DYLIB_COMPONENTS=all\
+      -DLLVM_INCLUDE_DOCS=Off \
+      -DLLVM_INCLUDE_BENCHMARKS=Off \
+      -DLLVM_ENABLE_Z3_SOLVER=Off \
+      -DLLVM_INSTALL_UTILS=On \
+      -DLLVM_ENABLE_ZLIB=On \
+      -DLLVM_ENABLE_MODULES=On \
+      -DLLVM_ENABLE_RTTI=On \
+      -DLLVM_ENABLE_FFI=On \
+      -DLLVM_USE_INTEL_JITEVENTS=On \
+      -DLLVM_USE_PERF=On \
+      -DLLVM_BUILD_TESTS=Off \
+      -DLLVM_ENABLE_PIC=On \
       -DLLVM_INSTALL_TOOLCHAIN_ONLY=On \
+      -DLLVM_PARALLEL_LINK_JOBS=1 \
       -DCLANG_DEFAULT_LINKER=lld \
+      -DCLANG_PLUGIN_SUPPORT=On \
       -DCLANG_DEFAULT_RTLIB=compiler-rt \
       -DCLANG_DEFAULT_UNWINDLIB=libunwind \
       -DCLANG_DEFAULT_CXX_STDLIB=libc++ \
+      -DLIBUNWIND_USE_COMPILER_RT=On \
+      -DLIBUNWIND_ENABLE_STATIC=Off \
+      -DCOMPILER_RT_USE_LIBCXX=On \
+      -DCOMPILER_RT_BUILD_BUILTINS=On \
+      -DLIBCXXABI_USE_LLVM_UNWINDER=On \
+      -DLIBCXXABI_USE_COMPILER_RT=On \
+      -DLIBCXXABI_ENABLE_STATIC=Off \
+      -DLIBCXX_CXX_ABI=libcxxabi \
+      -DLIBCXX_USE_COMPILER_RT=On \
+      -DLIBCXX_ENABLE_SHARED=On \
+      -DLIBCXX_ENABLE_STATIC=Off \
+      -DLIBCXX_CXX_ABI_INCLUDE_PATHS="$MAIN/libcxxabi/include" \
+      -DLIBOMP_ENABLE_SHARED=On \
+      -DLIBOMP_ENABLE_STATIC=Off \
+      -DLIBOMP_LIBFLAGS="-lm" \
       -DLIBOMP_FORTRAN_MODULES=Off \
       -DLIBOMP_COPY_EXPORTS=Off \
       -DLIBOMP_USE_HWLOC=Off \
       -DLIBOMP_OMPT_SUPPORT=On \
-      -DLIBOMP_ENABLE_SHARED=On \
-      -DLIBOMP_CFLAGS="-fuse-ld=lld -stdlib=libc++" \
-      -DLIBOMP_CPPFLAGS="-fuse-ld=lld -stdlib=libc++" \
-      -DLIBOMP_CXXFLAGS="-fuse-ld=lld -stdlib=libc++" \
-      -DLIBOMP_LDFLAGS="-rtlib=compiler-rt" \
-      -DLIBOMP_LLVM_TOOLS_DIR="$BOOTSTRAP/bin" \
-      -DLIBOMP_LIBFLAGS="-lm" \
-      -DLIBUNWIND_USE_COMPILER_RT=On \
-      -DCOMPILER_RT_USE_LIBCXX=On \
-      -DCOMPILER_RT_BUILD_BUILTINS=On \
-      -DCOMPILER_RT_USE_BUILTINS_LIBRARY=On \
-      -DLIBCXXABI_USE_LLVM_UNWINDER=On \
-      -DLIBCXXABI_USE_COMPILER_RT=On \
-      -DLIBCXX_CXX_ABI_INCLUDE_PATHS=$MAIN/libcxxabi/include \
-      -DLIBCXX_CXX_ABI_LIBRARY_PATH=$MAIN/llvm/build/lib/%{triple}/c++ \
-      -DLIBCXX_CXX_ABI=libcxxabi \
-      -DLIBCXX_USE_COMPILER_RT=On \
-      -DLIBCXX_ENABLE_SHARED=On \
-      -DLIBCXX_ENABLE_STATIC=Off 
+      --enable-optimized -Wno-dev -G Ninja ../llvm
 
-%{__make} %{?_smp_mflags} VERBOSE=1 clang
-%{__make} %{?_smp_mflags} VERBOSE=1 lld
-%{__make} %{?_smp_mflags} VERBOSE=1 compiler-rt
-%{__make} %{?_smp_mflags} VERBOSE=1 unwind
-%{__make} %{?_smp_mflags} VERBOSE=1 cxxabi
-%{__make} %{?_smp_mflags} VERBOSE=1 cxx
-%{__make} %{?_smp_mflags} VERBOSE=1 omp
-# Race condition persists with remaining components; remove -j option
-%{__make} VERBOSE=1
-%{__make} DESTDIR=%{buildroot} INSTALL="%{__install} -p" install
-%{__rm} %{buildroot}/%{install_path}/lib/%{triple}/c++/*.a
-cd $MAIN
+ninja %{?_smp_mflags} -v
 # End stage 2
 
-# OpenHPC module file
+
+%install
+cd stage2
+DESTDIR=%{buildroot} INSTALL="%{__install} -p" ninja install
+
+# OpenHPC module files
 %{__mkdir_p} %{buildroot}/%{OHPC_MODULES}/llvm%{major_ver}
 %{__cat} << EOF > %{buildroot}/%{OHPC_MODULES}/llvm%{major_ver}/%{version}
 #%Module1.0#####################################################################
@@ -232,9 +247,9 @@ set     version           %{version}
 setenv         LLVM%{major_ver}_PATH         %{install_path}
 prepend-path   PATH               %{install_path}/bin
 prepend-path   MANPATH            %{install_path}/share/man
-prepend-path   LD_LIBRARY_PATH    %{install_path}/lib:%{install_path}/lib/%{triple}/c++
-prepend-path   MODULEPATH         %{OHPC_MODULEDEPS}/llvm
-
+prepend-path   INCLUDE            %{install_path}/include/c++/v1
+prepend-path   LD_LIBRARY_PATH    %{install_path}/lib
+prepend-path   MODULEPATH         %{OHPC_MODULEDEPS}/llvm%{major_ver}
 
 family "compiler"
 EOF
@@ -247,12 +262,13 @@ EOF
 set     ModulesVersion      "%{version}"
 EOF
 
+
 %files
 %{OHPC_MODULES}/llvm%{major_ver}
 %dir %{OHPC_COMPILERS}/llvm
 %{install_path}
 %doc llvm/CODE_OWNERS.TXT
 %doc llvm/CREDITS.TXT
-%doc llvm/LICENSE.TXT
 %doc llvm/README.txt
 %doc llvm/RELEASE_TESTERS.TXT
+%license llvm/LICENSE.TXT

--- a/tests/m4/compiler_family.m4
+++ b/tests/m4/compiler_family.m4
@@ -24,12 +24,6 @@ if test "x$LMOD_FAMILY_COMPILER" = "xgnu"; then
    CXX=g++
    FC=gfortran
    AC_MSG_RESULT([gnu])
-elif test "x$LMOD_FAMILY_COMPILER" = "xgnu7"; then
-   CC=gcc
-   CXX=g++
-   FC=gfortran
-   AC_MSG_RESULT([gnu7])
-   AC_SUBST(OHPC_BLAS,[-L${OPENBLAS_LIB} -lopenblas])
 elif test "x$LMOD_FAMILY_COMPILER" = "xgnu8"; then
    CC=gcc
    CXX=g++
@@ -42,17 +36,18 @@ elif test "x$LMOD_FAMILY_COMPILER" = "xgnu9"; then
    FC=gfortran
    AC_MSG_RESULT([gnu9])
    OHPC_BLAS="-L${OPENBLAS_LIB} -lopenblas"
+elif test "x$LMOD_FAMILY_COMPILER" = "xllvm10"; then
+   CC=clang
+   CXX=clang++
+   # Use placeholder again; flang(f18) added to LLVM11 [JCS 9/15/20]
+   FC=gfortran
+   AC_MSG_RESULT([llvm10])
 elif test "x$LMOD_FAMILY_COMPILER" = "xllvm9"; then
    CC=clang
    CXX=clang++
-# Use placeholder until F18 is added to LLVM [JCS 11/19/19]
+   # Use placeholder until F18 is added to LLVM [JCS 11/19/19]
    FC=gfortran
    AC_MSG_RESULT([llvm9])
-elif test "x$LMOD_FAMILY_COMPILER" = "xllvm5"; then
-   CC=clang
-   CXX=clang++
-   FC=flang
-   AC_MSG_RESULT([llvm5])
 elif test "x$LMOD_FAMILY_COMPILER" = "xintel"; then
    CC=icc
    CXX=icpc


### PR DESCRIPTION
Signed-off-by: jcsiadal <jeremy.c.siadal@intel.com>

Updates LLVM/Clang to version 10. Both distros have current versions of clang available; this build is different because it implements a 2-stage build with bootstrap. This should completely eliminate most GCC libs from the runtime toolchain.

I added a conflict to distro-provided libunwind-devel. The lld linker searches /usr/lib64 before its local llvm lib directory and it breaks if it finds libunwind.so. Not sure where to fix this other than forcing the user to implement command line options for lld, so I added a conflict. SCOREp requires the distro libunwind-devel, but only during build.

Tested on CentOS 8.2 and OpenSUSE 15.2. Built a few test C++ apps with the resulting RPMs. Successful builds on OBS.

Build takes approximately 90 minutes on a fast, dedicated build system.

Other notes:

- Moved to ninja build system; this is what the llvm developers use
- Included more  llvm tools
- Leaving some static libs in place as they seem to be required by clang/lld at runtime
- Fixed the Python ambiguity problem with a global search/replace; not sure if any of the Python 2 stuff is even used, but keeping it to be safe.
