### PR TITLE
containers: small fixups

### DIFF
--- a/containers/Dockerfile.ohpc-gnu9
+++ b/containers/Dockerfile.ohpc-gnu9
@@ -1,4 +1,4 @@
-FROM registry.centos.org/centos/centos:8
+FROM registry.centos.org/centos/centos:centos8
 
 MAINTAINER The OpenHPC Project
 
@@ -15,6 +15,7 @@ RUN yum -y install http://repos.openhpc.community/OpenHPC/2/CentOS_8/x86_64/ohpc
 RUN yum install -y 'dnf-command(config-manager)' && \
     yum config-manager --set-enabled PowerTools && \
     yum upgrade -y && \
+    yum -y install openssh-clients && \
     yum -y install gnu9-compilers-ohpc lmod-ohpc && \
     yum clean all
 


### PR DESCRIPTION
Base the container on the tag `centos8` (8.2.2004). This, in contrast to `8` (8.0.1905) or `latest` (7.8.2003), seems to be based on CentOS 8.2.

Also install openssh-clients in the container which is needed for MPI runtime on remote nodes.