### PR TITLE
Update Warewulf initrd to include firmware symlinks

### DIFF
--- a/components/provisioning/warewulf-vnfs/SOURCES/warewulf-vnfs.boot_fw_symlink.patch
+++ b/components/provisioning/warewulf-vnfs/SOURCES/warewulf-vnfs.boot_fw_symlink.patch
@@ -1,0 +1,12 @@
+--- a/bin/wwbootstrap    2020-10-13 03:52:07.305832400 -0500
++++ b/bin/wwbootstrap  2020-10-13 03:52:18.631290013 -0500
+@@ -282,7 +282,7 @@
+     foreach my $f ($config->get("firmware")) {
+         if ($f and $f =~ /^([a-zA-Z0-9\/\*_\-\.]+)/) {
+             my $f_clean = $1;
+-            open(FIND, "cd $opt_chroot; find lib/firmware/$f_clean -type f 2>/dev/null |");
++            open(FIND, "cd $opt_chroot; find lib/firmware/$f_clean -type f -o -type l 2>/dev/null |");
+             while(my $firmware = <FIND>) {
+                 chomp($firmware);
+                 if ($firmware =~ /([a-zA-Z0-9\/_\-\.]+)/) {
+

--- a/components/provisioning/warewulf-vnfs/SPECS/warewulf-vnfs.spec
+++ b/components/provisioning/warewulf-vnfs/SPECS/warewulf-vnfs.spec
@@ -40,6 +40,7 @@ Patch12: warewulf-vnfs.bootstrap_qlogic.patch
 Patch13: warewulf-vnfs.leap.patch
 Patch14: warewulf-vnfs.bootstrap_drivers.patch
 Patch15: warewulf-vnfs.hybridize.patch
+Patch16: warewulf-vnfs.boot_fw_symlink.patch
 Group:   %{PROJ_NAME}/provisioning
 ExclusiveOS: linux
 Requires: warewulf-common%{PROJ_DELIM}
@@ -88,6 +89,7 @@ cd %{_builddir}
 %patch13 -p2
 %patch14 -p1
 %patch15 -p1
+%patch16 -p1
 
 %build
 ./autogen.sh


### PR DESCRIPTION
Signed-off-by: jcsiadal <jeremy.c.siadal@intel.com>

New Intel NIC drivers load firmware using a symlink under /lib/firmware pointing to the canonical file in the same directory. The wwbootstrap utility adds only true files to the initrd. This update also adds symlinks matching the bootstrap.conf list.

I plan to also upstream this to WW.
