### PR TITLE
intel-compiler/mpi-devel package update to oneAPI

### DIFF
--- a/components/compiler-families/intel-compilers-devel/SOURCES/mod_generator.sh
+++ b/components/compiler-families/intel-compilers-devel/SOURCES/mod_generator.sh
@@ -77,7 +77,6 @@ done
 
 echo " "
 echo "# OpenHPC machine generated from `basename $inFile`"
-echo " "
 
 while read var ; do 
     varName=`echo $var | awk -F = '{print $1}'` || exit 1
@@ -99,7 +98,6 @@ while read var ; do
     fi
 done < $OUTFILE
 
-echo " "
 echo "# end of machine generated"
 echo " "
 

--- a/components/compiler-families/intel-compilers-devel/SOURCES/oneAPI.repo
+++ b/components/compiler-families/intel-compilers-devel/SOURCES/oneAPI.repo
@@ -1,0 +1,8 @@
+[oneAPI]
+name=Intel(R) oneAPI repository
+baseurl=https://yum.repos.intel.com/oneapi
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+

--- a/components/compiler-families/intel-compilers-devel/SPECS/intel-compilers-devel.spec
+++ b/components/compiler-families/intel-compilers-devel/SPECS/intel-compilers-devel.spec
@@ -11,68 +11,236 @@
 %include %{_sourcedir}/OHPC_macros
 
 %define pname intel-compilers-devel
-%define year 2020
+%define keyname GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+%define oneapi_manifest %{OHPC_MODULES}/intel/.rpm-manifest
+%define psxe_manifest %{OHPC_MODULES}/intel/.manifest
 
-Summary:   OpenHPC compatibility package for Intel(R) Parallel Studio XE
+Summary:   OpenHPC integration package for Intel(R) oneAPI HPC Toolkit
 Name:      %{pname}%{PROJ_DELIM}
-Version:   %{year}
+Version:   2021.3.0
 Release:   1
 License:   Apache-2.0
 URL:       https://github.com/openhpc/ohpc
 Group:     %{PROJ_NAME}/compiler-families
 BuildArch: x86_64
-Source1:   mod_generator.sh
+AutoReq:   no
 
-#!BuildIgnore: brp-check-suse
+Source0: https://yum.repos.intel.com/intel-gpg-keys/%{keyname}
+Source1: mod_generator.sh
+Source2: oneAPI.repo
+
 #!BuildIgnore: post-build-checks
 
-Requires: gcc-c++
-Requires: grep
-Requires: rpm
+Requires: gcc libstdc++-devel cmake
+Requires(pre): intel-hpckit >= %{version}
+Requires: intel-hpckit = %{version}
 
 %description
+Integrates oneAPI HPC Toolkit modulefiles into OpenHPC.
 
+
+%prep
+%build
+
+
+%install
+%if 0%{?suse_version} || 0%{?sle_version}
+%global repodir %{_sysconfdir}/zypp/repos.d
+%else
+%global repodir %{_sysconfdir}/yum.repos.d
+%endif
+
+# Install RPM key and yum repo
+install -Dp -m644 %{SOURCE0} %{buildroot}%{_sysconfdir}/pki/rpm-gpg/%{keyname}
+install -D -m644 %{SOURCE2} -t %{buildroot}%{repodir}/
+
+# Mod generator for PSXE support
+install -D -m755 %{SOURCE1} %{buildroot}/%{OHPC_ADMIN}/compat/modulegen/mod_generator.sh
+
+# Module directories
+mkdir -p %{buildroot}/%{OHPC_MODULEDEPS}/oneapi
+mkdir -p %{buildroot}/%{OHPC_MODULES}/intel
+mkdir -p %{buildroot}/%{OHPC_MODULEDEPS}/gnu/mkl
+mkdir -p %{buildroot}/%{OHPC_MODULEDEPS}/intel
+
+
+%pre -p /bin/bash
+if ! [ -f /opt/intel/oneapi/modulefiles-setup.sh ]; then
+    echo " "
+    echo "Error: Unable to detect the oneAPI installation at /opt/intel."
+    echo " "
+    exit 1
+fi
+
+
+%post -p /bin/bash
+# Do not overwrite existing files
+# Write the new file as rpmnew
+testfile () {
+    if [ -e $1 ]; then
+       echo "$1.rpmnew"
+    else
+       echo "$1"
+    fi
+}
+
+rm -f %{oneapi_manifest}
+
+# Regenerate the oneAPI modules directory
+echo "Generating new oneAPI modulefiles"
+/opt/intel/oneapi/modulefiles-setup.sh --ignore-latest --force --output-dir=%{OHPC_MODULEDEPS}/oneapi/ > /dev/null
+
+# Create an OpenHPC module file for each version found in compilers
+echo "Creating OpenHPC-style modulefiles for local oneAPI compiler installation(s)."
+for compilers in %{OHPC_MODULEDEPS}/oneapi/compiler/2*; do
+    ver=$(basename "$compilers")
+    echo "--> Installing modulefile for version=${ver}"
+    # Do not overwrite existing files
+    # Write the new file as rpmnew
+    modname=$(testfile %{OHPC_MODULES}/intel/$ver)
+
+    cat << EOF > ${modname}
+#%Module1.0#####################################################################
+
+set version "$ver"
+
+proc ModulesHelp { } {
+global version
+puts stderr "\nThis module loads the oneAPI compiler environment.\n"
+puts stderr "\nSee the man pages for icc, icpc, and ifort for detailed information"
+puts stderr "on available compiler options and command-line syntax."
+puts stderr "\nVersion \$version\n"
+}
+
+module-whatis "Name: Intel(R) Compiler"
+module-whatis "Version: \$version"
+module-whatis "Category: compiler, runtime support"
+module-whatis "Description: Intel(R) Compiler Family (C/C++/Fortran for x86_64)"
+module-whatis "URL: http://software.intel.com/en-us/articles/intel-compilers/"
+
+# update module path hierarchy
+prepend-path    MODULEPATH          %{OHPC_MODULEDEPS}/intel
+prepend-path    MODULEPATH          %{OHPC_MODULEDEPS}/oneapi
+
+# Assume no PAC device; allow override on each node
+if { ![info exists ::env(ACL_SKIP_BSP_CONF)] } {
+    setenv          ACL_SKIP_BSP_CONF   1
+}
+
+module load "compiler/\$version"
+
+family "compiler"
+EOF
+
+    md5sum ${modname} >> %{oneapi_manifest} 
+
+    modname=$(testfile %{OHPC_MODULES}/intel/.version.$ver)
+
+
+    cat << EOF > ${modname}
+#%Module1.0#####################################################################
+set     ModulesVersion      "$ver"
+EOF
+
+    md5sum ${modname} >> %{oneapi_manifest} 
+
+    # Provide standalone module for use with GNU toolchain
+    modname=$(testfile  %{OHPC_MODULEDEPS}/gnu/mkl/$ver)
+
+    cat << EOF > ${modname}
+#%Module1.0#####################################################################
+
+set version "$ver"
+
+proc ModulesHelp { } {
+global version
+puts stderr "\nConfigures oneAPI MKL environment\n"
+puts stderr "\$version\n"
+}
+
+module-whatis "Name: Intel(R) Math Kernel Library"
+module-whatis "Version: \$version"
+module-whatis "Category: library, runtime support"
+module-whatis "Description: Intel(R) Math Kernel Library for C/C++ and Fortran"
+module-whatis "URL: https://software.intel.com/en-us/en-us/intel-mkl"
+
+prepend-path  MODULEPATH       %{OHPC_MODULEDEPS}/oneapi
+module load   "mkl/\$version"
+EOF
+
+    md5sum ${modname} >> %{oneapi_manifest} 
+done
+
+
+%preun -p /bin/bash
+# Check current files against the manifest
+# Remove files that match and backup files that don't
+if [ -s %{oneapi_manifest} ]; then
+    while IFS= read -r line; do
+       f=${line%:*}
+       s=${line#*:}
+       if [ "${s: -2}" = "OK" ]; then
+           rm -f $f
+       elif [ -f $f ]; then
+           mv -T -f $f $f.rpmsave
+       fi
+    done <<< $(md5sum --check %{oneapi_manifest})
+else
+    # Don't touch any generated files if there's no manifest
+    # On upgrade, expect lots of modulefiles created as .rpmnew
+    echo "WARNING: Manifest not found. Previously generated"
+    echo "         modulefiles will not be removed or moved."
+fi
+# Remove the generated oneAPI module links, remove directories if empty
+find %{OHPC_MODULEDEPS}/oneapi -type l -delete
+find %{OHPC_MODULEDEPS}/oneapi/* -empty -type d -delete
+
+
+%files
+%dir %{OHPC_MODULES}/intel
+%dir %{OHPC_MODULEDEPS}/oneapi
+%dir %{OHPC_MODULEDEPS}/intel
+%dir %{OHPC_MODULEDEPS}/gnu/mkl
+%ghost %{oneapi_manifest}
+
+################################################################################
+
+%package -n intel-compilers-release%{PROJ_DELIM}
+Summary:   Intel(R) oneAPI HPC Toolkit Respository Setup
+
+%description -n intel-compilers-release%{PROJ_DELIM}
+Installs and configures the online repository for the Intel(R) oneAPI Toolkit.
+
+
+%files -n intel-compilers-release%{PROJ_DELIM}
+%{_sysconfdir}/pki/rpm-gpg/%{keyname}
+%{repodir}/%{basename:%{SOURCE2}}
+
+################################################################################
+
+%define psxemod intel-psxe-compilers-devel%{PROJ_DELIM}
+
+%package -n %{psxemod}
+Summary: OpenHPC compatibility package for Intel(R) Parallel Studio XE
+
+Obsoletes: %pname%{PROJ_DELIM} < %{version}
+
+%description -n %{psxemod}
 Provides OpenHPC-style compatible modules for use with the Intel(R) Parallel
 Studio compiler suite.
 
-%prep
 
-%build
-
-%install
-
-install -D -m755 %{SOURCE1}  $RPM_BUILD_ROOT/%{OHPC_ADMIN}/compat/modulegen/mod_generator.sh
-%{__mkdir} -p %{buildroot}/%{OHPC_MODULES}/intel
-
-
-
-%pre
-
-
-# Special accommodation check for upgrades. Older versions of this
-# package incorrectly remove modulefiles during an upgrade. Check if
-# currently installed version is older than fixed version and flag so
-# we can fix after the fact.
-if [ $1 -gt 1 ];then
-
-    version=`rpm -q --qf '%%{VERSION}.%%{RELEASE}\n' %{name}`
-    minVerFix="2018.1.1"
-    result=`echo -e "${version}\n${minVerFix}" | sort -V | head -n 1`
-    if [ "$result" != "$minVerFix" ];then
-	touch %{_localstatedir}/lib/rpm-state/%{name}-needs-upgrade-fix
-    fi
-fi
+%pre -n %{psxemod} -p /bin/bash
+# Since OpenHPC 2.0 will not upgrade 1.x, there's no need for
+# older intel-compilers-devel upgrade patches
 
 # Verify psxe compilers are installed. Punt if not detected.
-
-icc_subpath="linux/bin/intel64/icc$"
-
 echo "Checking for local PSXE compiler installation(s)."
-
-versions_all=`rpm -qal | grep ${icc_subpath}`
+icc_subpath="linux/bin/intel64/icc$"
+versions_all=$(rpm -qal | grep "${icc_subpath}" | grep -v "oneapi")
 
 if [ $? -eq 1 ];then
-    echo ""
+    echo " "
     echo "Error: Unable to detect local Parallel Studio installation. The toolchain"
     echo "       providing ${icc_subpath} must be installed prior to this compatibility package"
     echo " "
@@ -80,19 +248,20 @@ if [ $? -eq 1 ];then
 fi
 
 # Verify min version expectations
-
 min_ver="19.1.0"
-versions=""
+declare -a versions=()
+declare -a topDirs=()
 for file in ${versions_all}; do
-    version=`rpm -q --qf '%%{VERSION}.%%{RELEASE}\n' -f ${file}`
+    version=$(rpm -q --qf '%%{VERSION}.%%{RELEASE}\n' -f ${file})
     echo "--> Version ${version} detected"
-    echo -e "${version}\n${min_ver}" | sort -V | head -n 1 | grep -q "^${min_ver}"
-    if [ $? -ne 0 ];then
-        echo "Warning: skipping version ${version}"
+    if [ "$min_ver" = "$(printf '${version}\n${min_ver}' | sort -V | head -n 1)" ]; then
+        echo "Warning: ${version} < $min_ver, skipping"
     else
-        versions="${versions} ${version}"
+        versions+="${version}"
+        topDirs+="$(echo $file | sed "s,/$icc_subpath,,")"
     fi
 done
+
 if [ -z "${versions}" ]; then
     echo ""
     echo "Error: local PSXE compatibility support is for versions > ${min_ver}"
@@ -100,162 +269,123 @@ if [ -z "${versions}" ]; then
     exit 1
 fi
 
-%post
+mkdir -p %{_localstatedir}/lib/rpm-state/%{name}/
+printf "%s\n" ${versions[@]} > %{_localstatedir}/lib/rpm-state/%{name}/rpm-install-versions
+printf "%s\n" ${topDirs[@]} > %{_localstatedir}/lib/rpm-state/%{name}/rpm-install-dirs
 
-icc_subpath="linux/bin/intel64/icc"
+
+%post -n %{psxemod}
 scanner=%{OHPC_ADMIN}/compat/modulegen/mod_generator.sh
-
-versions=`rpm -qal | grep ${icc_subpath}$`
-
-if [ $? -eq 1 ];then
-    echo ""
-    echo "Error: Unable to detect local Parallel Studio installation. The toolchain"
-    echo "       providing ${icc_subpath} must be installed prior to this compatibility package"
-    exit 1
-fi
+declare -a versions=()
+declare -a topDirs=()
+readarray -t versions < %{_localstatedir}/lib/rpm-state/%{name}/rpm-install-versions
+readarray -t topDirs < %{_localstatedir}/lib/rpm-state/%{name}/rpm-install-dirs
+rm -rf %{_localstatedir}/lib/rpm-state/%{name}/
 
 echo "Creating OpenHPC-style modulefiles for local PSXE compiler installation(s)."
 
 # initialize manifest to log files created during this process
-if [ -e %{OHPC_MODULES}/intel/.manifest ];then
-    rm -f %{OHPC_MODULES}/intel/.manifest
-fi
+rm -f %{psxe_manifest}
 
 # Create modulefiles for each locally detected installation.
-for file in ${versions}; do
-    version=`rpm -q --qf '%%{VERSION}.%%{RELEASE}\n' -f ${file}`
-    topDir=`echo $file | sed "s|$icc_subpath||"`
+for (( x=0; x < ${#versions[@]}; x++ )); do
+    topDir=${topDirs[$x]}
+    version=${versions[$x]}
     echo "--> Installing modulefile for version=${version}"
 
-    # Module header
-    %{__cat} << EOF > %{OHPC_MODULES}/intel/${version}
+    # Check for compilervars before writing a file
+    if [ ! -e ${topDir}/linux/bin/compilervars.sh ]; then
+	   echo "Error: Unable to access compilervars.sh"
+           echo "       Skipping modules for (${topDir})"
+	   break
+    fi
+
+    # Main module
+    cat << EOF > %{OHPC_MODULES}/intel/${version}
 #%Module1.0#####################################################################
 
+set version "${version}"
+
 proc ModulesHelp { } {
-
-puts stderr " "
-puts stderr "See the man pages for icc, icpc, and ifort for detailed information"
+global version
+puts stderr "\nSee the man pages for icc, icpc, and ifort for detailed information"
 puts stderr "on available compiler options and command-line syntax."
-
-puts stderr "\nVersion ${version}\n"
-
+puts stderr "\nVersion \$version\n"
 }
 
-module-whatis "Name: Intel Compiler"
-module-whatis "Version: ${version}"
+module-whatis "Name: Intel(R) Compiler"
+module-whatis "Version: \$version"
 module-whatis "Category: compiler, runtime support"
-module-whatis "Description: Intel Compiler Family (C/C++/Fortran for x86_64)"
+module-whatis "Description: Intel(R) Compiler Family (C/C++/Fortran for x86_64)"
 module-whatis "URL: http://software.intel.com/en-us/articles/intel-compilers/"
 
-set     version    ${version}
+set     version    \$version
 
 # update module path hierarchy
 prepend-path    MODULEPATH          %{OHPC_MODULEDEPS}/intel
 
 family "compiler"
 EOF
-    # Append with environment vars parsed directly from compilervars.sh
-    if [ ! -e ${topDir}/linux/bin/compilervars.sh ];then
-	echo "Error: unable to access compilervars.sh (${topDir})"
-	exit 1
-    fi
-    ${scanner} ${topDir}/linux/bin/compilervars.sh -arch intel64 -platform linux >> %{OHPC_MODULES}/intel/${version} || exit 1
+
+    echo "%{OHPC_MODULES}/intel/${version}" >> %{psxe_manifest}
+
+    # Append with environment vars parsed directlry from mpivars.sh
+    ${scanner} ${topDir}/linux/bin/compilervars.sh -arch intel64 -platform linux >> %{OHPC_MODULES}/intel/${version}
+        if [ $? -ne 0 ]; then
+           echo "ERROR: Could not generate content for %{OHPC_MODULES}/intel/${version}"
+           break
+        fi
 
     # .version file
-    %{__cat} << EOF > /%{OHPC_MODULES}/intel/.version.${version}
+    cat << EOF > %{OHPC_MODULES}/intel/.version.${version}
 #%Module1.0#####################################################################
 set     ModulesVersion      "${version}"
 EOF
 
-    # Provide standalone module for use with GNU toolchain
+    echo "%{OHPC_MODULES}/intel/.version.${version}" >> %{psxe_manifest}
 
-    %{__mkdir} -p %{OHPC_MODULEDEPS}/gnu/mkl
-    %{__cat} << EOF > %{OHPC_MODULEDEPS}/gnu/mkl/${version}
+    # Provide standalone module for use with GNU toolchain
+    mkdir -p %{OHPC_MODULEDEPS}/gnu/mkl
+
+    cat << EOF > %{OHPC_MODULEDEPS}/gnu/mkl/${version}
 #%Module1.0#####################################################################
 
+set version "${version}
+
 proc ModulesHelp { } {
-
-puts stderr " "
-puts stderr "Sets MKLROOT environment variable"
-puts stderr " "
-puts stderr "${version}"
-
+global version
+puts stderr "\nSets MKLROOT environment variable\n"
+puts stderr "\$version"
 }
 
-module-whatis "Name: Intel Math Kernel Library"
-module-whatis "Version: ${version}"
+module-whatis "Name: Intel(R) Math Kernel Library"
+module-whatis "Version: \$version"
 module-whatis "Category: library, runtime support"
 module-whatis "Description: Intel Math Kernel Library for C/C++ and Fortran"
 module-whatis "URL: https://software.intel.com/en-us/en-us/intel-mkl"
 
 setenv        MKLROOT            ${topDir}/linux/mkl
 prepend-path  LD_LIBRARY_PATH    ${topDir}/linux/mkl/lib/intel64
-
 EOF
 
-    # Inventory for later removal 
-
-    echo "%{OHPC_MODULES}/intel/${version}" >> %{OHPC_MODULES}/intel/.manifest
-    echo "%{OHPC_MODULES}/intel/.version.${version}" >> %{OHPC_MODULES}/intel/.manifest
-    echo "%{OHPC_MODULEDEPS}/gnu/mkl/${version}" >> %{OHPC_MODULES}/intel/.manifest
-
-    # special accommodation for older versions of this package which incorrectly remove
-    # modulefiles during a package upgrade. Cache the newly created modulefiles so we can 
-    # re-instantiate them in %posttrans
-    if [ -e %{_localstatedir}/lib/rpm-state/%{name}-needs-upgrade-fix ];then
-	compilerStateDir=%{_localstatedir}/lib/rpm-state/ohpc-intel-compiler-versions
-	mklStateDir=%{_localstatedir}/lib/rpm-state/ohpc-gnu-mkl-versions
-
-	[ -d "$compilerStateDir" ] || %{__mkdir} "$compilerStateDir"
-	[ -d "$mklStateDir" ] || %{__mkdir} "$mklStateDir"
-
-	%{__cp} -p "%{OHPC_MODULES}/intel/${version}" $compilerStateDir
-	%{__cp} -p "%{OHPC_MODULES}/intel/.version.${version}" $compilerStateDir
-	%{__cp} -p "%{OHPC_MODULEDEPS}/gnu/mkl/${version}" $mklStateDir
-    fi
+    echo "%{OHPC_MODULEDEPS}/gnu/mkl/${version}" >> %{psxe_manifest}
 
 done
 
-# special accomodation for older versions of this package which incorrectly remove
-# modulefiles during a package upgrade. Cache final .manifest file as well.
-if [ -e %{_localstatedir}/lib/rpm-state/%{name}-needs-upgrade-fix ];then
-    %{__cp} -p %{OHPC_MODULES}/intel/.manifest %{_localstatedir}/lib/rpm-state/ohpc-manifest
+
+%preun -n %{psxemod}
+if [ -s %{psxe_manifest} ]; then
+    while IFS= read -r file; do
+        if [ -e $file ]; then
+            rm -f $file
+        fi
+    done < %{psxe_manifest}
+else
+   echo "WARNING: Manifest not found"
 fi
 
-%postun
 
-if [ $1 -eq 0 ];then
-   if [ -s %{OHPC_MODULES}/intel/.manifest ];then
-       for file in `cat %{OHPC_MODULES}/intel/.manifest`; do
-	   if [ -e $file ];then
-               rm $file
-	   fi
-       done
-       rm -f %{OHPC_MODULES}/intel/.manifest
-   fi
-fi
-
-%posttrans
-
-# special accommodation for older versions of this package which incorrectly remove
-# modulefiles during a package upgrade.
-if [ -e %{_localstatedir}/lib/rpm-state/%{name}-needs-upgrade-fix ];then
-    echo "--> Applying upgrade fix to reinstate OpenHPC-style modulefiles"
-    for file in `find /var/lib/rpm-state/ohpc-intel-compiler-versions/ -type f`; do 
-	%{__mv} $file %{OHPC_MODULES}/intel/
-    done
-    rmdir /var/lib/rpm-state/ohpc-intel-compiler-versions/
-
-    for file in `find /var/lib/rpm-state/ohpc-gnu-mkl-versions/ -type f`; do 
-	%{__mv} $file %{OHPC_MODULEDEPS}/gnu/mkl/
-    done
-    rmdir /var/lib/rpm-state/ohpc-gnu-mkl-versions/
-
-    %{__mv} %{_localstatedir}/lib/rpm-state/ohpc-manifest %{OHPC_MODULES}/intel/.manifest
-    
-    rm -f %{_localstatedir}/lib/rpm-state/%{name}-needs-upgrade-fix 
-fi
-
-%files
+%files -n %{psxemod}
 %{OHPC_ADMIN}/compat/modulegen/mod_generator.sh
-%{OHPC_MODULES}
+%dir %{OHPC_MODULES}/intel
+%ghost %{psxe_manifest}

--- a/components/compiler-families/intel-compilers-devel/SPECS/intel-compilers-devel.spec
+++ b/components/compiler-families/intel-compilers-devel/SPECS/intel-compilers-devel.spec
@@ -17,7 +17,7 @@
 
 Summary:   OpenHPC integration package for Intel(R) oneAPI HPC Toolkit
 Name:      %{pname}%{PROJ_DELIM}
-Version:   2021.3.0
+Version:   2021.4.0
 Release:   1
 License:   Apache-2.0
 URL:       https://github.com/openhpc/ohpc
@@ -32,8 +32,9 @@ Source2: oneAPI.repo
 #!BuildIgnore: post-build-checks
 
 Requires: gcc libstdc++-devel cmake
-Requires(pre): intel-hpckit >= %{version}
-Requires: intel-hpckit = %{version}
+Requires(pre): intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic >= %{version}
+Requires: intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic = %{version}
+Recommends: intel-hpckit = %{version}
 
 %description
 Integrates oneAPI HPC Toolkit modulefiles into OpenHPC.

--- a/components/compiler-families/intel-compilers-devel/SPECS/intel-compilers-devel.spec
+++ b/components/compiler-families/intel-compilers-devel/SPECS/intel-compilers-devel.spec
@@ -205,14 +205,14 @@ find %{OHPC_MODULEDEPS}/oneapi/* -empty -type d -delete
 
 ################################################################################
 
-%package -n intel-compilers-release%{PROJ_DELIM}
+%package -n intel-oneapi-toolkit-release%{PROJ_DELIM}
 Summary:   Intel(R) oneAPI HPC Toolkit Respository Setup
 
-%description -n intel-compilers-release%{PROJ_DELIM}
+%description -n intel-oneapi-toolkit-release%{PROJ_DELIM}
 Installs and configures the online repository for the Intel(R) oneAPI Toolkit.
 
 
-%files -n intel-compilers-release%{PROJ_DELIM}
+%files -n intel-oneapi-toolkit-release%{PROJ_DELIM}
 %{_sysconfdir}/pki/rpm-gpg/%{keyname}
 %{repodir}/%{basename:%{SOURCE2}}
 

--- a/components/compiler-families/intel-compilers-devel/SPECS/intel-compilers-devel.spec
+++ b/components/compiler-families/intel-compilers-devel/SPECS/intel-compilers-devel.spec
@@ -128,6 +128,7 @@ if { ![info exists ::env(ACL_SKIP_BSP_CONF)] } {
 }
 
 module load "compiler/\$version"
+module load "mkl"
 
 family "compiler"
 EOF

--- a/components/mpi-families/impi-devel/SOURCES/mod_generator_impi.sh
+++ b/components/mpi-families/impi-devel/SOURCES/mod_generator_impi.sh
@@ -77,7 +77,6 @@ done
 
 echo " "
 echo "# OpenHPC machine generated from `basename $inFile`"
-echo " "
 
 while read var ; do 
     varName=`echo $var | awk -F = '{print $1}'` || exit 1
@@ -99,7 +98,6 @@ while read var ; do
     fi
 done < $OUTFILE
 
-echo " "
 echo "# end of machine generated"
 echo " "
 

--- a/components/mpi-families/impi-devel/SPECS/intel-mpi.spec
+++ b/components/mpi-families/impi-devel/SPECS/intel-mpi.spec
@@ -18,7 +18,7 @@
 
 Summary:   OpenHPC integration package for Intel(R) oneAPI MPI Library
 Name:      %{pname}%{PROJ_DELIM}
-Version:   2021.3.0
+Version:   2021.4.0
 Release:   1
 License:   Apache-2.0
 URL:       https://github.com/openhpc/ohpc
@@ -31,7 +31,10 @@ Source1:   mod_generator_impi.sh
 #!BuildIgnore: post-build-checks
 
 Requires: sed
+Requires(pre): intel-compilers-devel%{PROJ_DELIM} = %{version}
+Requires(pre): intel-oneapi-mpi-devel = %{version}
 Requires: intel-compilers-devel%{PROJ_DELIM} = %{version}
+Requires: intel-oneapi-mpi-devel = %{version}
 Requires: prun%{PROJ_DELIM}
 
 %description

--- a/components/mpi-families/impi-devel/SPECS/intel-mpi.spec
+++ b/components/mpi-families/impi-devel/SPECS/intel-mpi.spec
@@ -11,267 +11,451 @@
 %include %{_sourcedir}/OHPC_macros
 
 %define pname intel-mpi-devel
-%define year 2020
-%global gnu_major_ver 9
+%define gnu_major_ver 9
+%define oneapi_manifest %{OHPC_MODULEDEPS}/intel/impi/.rpm-manifest
+%define psxe_manifest %{OHPC_MODULEDEPS}/intel/impi/.manifest
 
-Summary:   OpenHPC compatibility package for Intel(R) MPI Library
+
+Summary:   OpenHPC integration package for Intel(R) oneAPI MPI Library
 Name:      %{pname}%{PROJ_DELIM}
-Version:   %{year}
+Version:   2021.3.0
 Release:   1
 License:   Apache-2.0
 URL:       https://github.com/openhpc/ohpc
 Group:     %{PROJ_NAME}/mpi-families
 BuildArch: x86_64
-Source1:   mod_generator_impi.sh
 AutoReq:   no
+
+Source1:   mod_generator_impi.sh
 
 #!BuildIgnore: post-build-checks
 
+Requires: sed
+Requires: intel-compilers-devel%{PROJ_DELIM} = %{version}
 Requires: prun%{PROJ_DELIM}
 
 %description
+Provides OpenHPC-style compatible modules for use with the oneAPI
+MPI Library.
 
-Provides OpenHPC-style compatible modules for use with the Intel(R) MPI Library
-suite.
 
 %prep
-
 %build
 
+
 %install
-install -D -m755 %{SOURCE1}  $RPM_BUILD_ROOT/%{OHPC_ADMIN}/compat/modulegen/mod_generator_impi.sh
-%{__mkdir} -p %{buildroot}/%{OHPC_MODULEDEPS}/intel/impi
-%{__mkdir} -p %{buildroot}/%{OHPC_MODULEDEPS}/gnu/impi
-%{__mkdir} -p %{buildroot}/%{OHPC_MODULEDEPS}/gnu%{gnu_major_ver}/impi
+# Mod generator for PSXE support
+install -D -m755 %{SOURCE1}  %{buildroot}/%{OHPC_ADMIN}/compat/modulegen/mod_generator_impi.sh
+
+# Module directories
+mkdir -p %{buildroot}/%{OHPC_MODULEDEPS}/intel/impi
+mkdir -p %{buildroot}/%{OHPC_MODULEDEPS}/gnu/impi
+mkdir -p %{buildroot}/%{OHPC_MODULEDEPS}/gnu%{gnu_major_ver}/impi
 
 %pre
+if ! [ -d /opt/intel/oneapi/mpi/latest/modulefiles ]; then
+    echo " "
+    echo "Error: Unable to detect the oneAPI MPI installation at /opt/intel."
+    echo " "
+    exit 1
+fi
 
+
+%post
+# Don't clobber/overwrite existing files
+# Write the new file .rpmnew
+testfile () {
+    if [ -e $1 ]; then
+       echo "$1.rpmnew"
+    else
+       echo "$1"
+    fi
+}
+
+# Create an OpenHPC module file for each version found in compilers
+rm -f %{oneapi_manifest}
+
+# Create an OpenHPC module file for each MPI version found
+echo "Creating OpenHPC-style modulefiles for local oneAPI MPI installation(s)."
+for mpis in %{OHPC_MODULEDEPS}/oneapi/mpi/2*; do
+    ver=$(basename "$mpis")
+    echo "--> Installing modulefile for version=${ver}"
+    modname=$(testfile %{OHPC_MODULEDEPS}/intel/impi/$ver)
+
+    # Get value for MPI_DIR
+    eval $(%{OHPC_ADMIN}/lmod/lmod/libexec/lmod --expert use %{OHPC_MODULEDEPS}/oneapi)
+    eval $(%{OHPC_ADMIN}/lmod/lmod/libexec/lmod --expert load mpi/$ver)
+    MPIDIR=$I_MPI_ROOT
+    eval $(%{OHPC_ADMIN}/lmod/lmod/libexec/lmod --expert unload mpi/$ver)
+    eval $(%{OHPC_ADMIN}/lmod/lmod/libexec/lmod --expert unuse %{OHPC_MODULEDEPS}/oneapi)
+
+    cat << EOF > ${modname}
+#%Module1.0#####################################################################
+
+set version "$ver"
+
+proc ModulesHelp { } {
+global version
+puts stderr "\nThis module loads the Intel MPI environment.\n"
+puts stderr "   mpiifort  (Fortran source)"
+puts stderr "   mpiicc    (C   source)"
+puts stderr "   mpiicpc   (C++ source)"
+puts stderr "\nVersion \$version\n"
+}
+
+module-whatis "Name: Intel MPI"
+module-whatis "Version: \$version"
+module-whatis "Category: library, runtime support"
+module-whatis "Description: Intel MPI Library (C/C++/Fortran for x86_64)"
+module-whatis "URL: http://software.intel.com/en-us/articles/intel-mpi-library"
+
+# For convenience, redirect standard mpicc/mpicxx/mpifort 
+# to use oneAPI icc/icpc/ifort instead of gcc/g++/gfortran
+setenv I_MPI_CC   icc
+setenv I_MPI_CXX  icpc
+setenv I_MPI_FC   ifort
+setenv I_MPI_F77  ifort
+setenv I_MPI_F90  ifort
+
+setenv MPI_DIR    "$MPIDIR"
+
+prepend-path      MODULEPATH       %{OHPC_MODULEDEPS}/oneapi
+prepend-path      MODULEPATH       %{OHPC_MODULEDEPS}/intel-impi
+
+module load "mpi/\$version"
+
+family "MPI"
+EOF
+
+    md5sum ${modname} >> %{oneapi_manifest} 
+
+    modname=$(testfile %{OHPC_MODULEDEPS}/intel/impi/.version.$ver)
+
+    cat << EOF > ${modname}
+#%Module1.0#####################################################################
+set     ModulesVersion      "$ver"
+EOF
+
+    md5sum ${modname} >> %{oneapi_manifest} 
+
+    modname=$(testfile %{OHPC_MODULEDEPS}/gnu/impi/$ver)
+
+    cat << EOF > ${modname}
+#%Module1.0#####################################################################
+
+set version "$ver"
+
+proc ModulesHelp { } {
+global version
+puts stderr "\nThis module loads the Intel MPI environment for use with the GNU"
+puts stderr "compiler toolchain\n"
+puts stderr "mpif90       (Fortran source)"
+puts stderr "mpicc        (C   source)"
+puts stderr "mpicxx       (C++ source)"
+puts stderr "\nVersion \$version\n"
+}
+
+module-whatis "Name: Intel MPI"
+module-whatis "Version: \$version"
+module-whatis "Category: library, runtime support"
+module-whatis "Description: Intel MPI Library (C/C++/Fortran for x86_64)"
+module-whatis "URL: http://software.intel.com/en-us/articles/intel-mpi-library/"
+
+prepend-path    MODULEPATH      %{OHPC_MODULEDEPS}/oneapi
+prepend-path    MODULEPATH      %{OHPC_MODULEDEPS}/gnu-impi
+
+module load "mpi/\$version"
+
+family "MPI"
+EOF
+
+    md5sum ${modname} >> %{oneapi_manifest} 
+
+    # support for gnu major version
+    orig_modname=$modname
+    modname=$(testfile  %{OHPC_MODULEDEPS}/gnu%{gnu_major_ver}/impi/$ver)
+    cp ${orig_modname} ${modname}
+    sed -i "s,%{OHPC_MODULEDEPS}/gnu-impi,%{OHPC_MODULEDEPS}/gnu%{gnu_major_ver}-impi," ${modname}
+    md5sum ${modname} >> %{oneapi_manifest} 
+
+    modname=$(testfile %{OHPC_MODULEDEPS}/gnu/impi/.version.$ver)
+
+    cat << EOF > ${modname}
+#%Module1.0#####################################################################
+set     ModulesVersion      "$ver"
+EOF
+
+    md5sum ${modname} >> %{oneapi_manifest} 
+
+    # support for gnu major version
+    orig_modname=$modname
+    modname=$(testfile  %{OHPC_MODULEDEPS}/gnu%{gnu_major_ver}/impi/.version.$ver)
+    cp ${orig_modname} ${modname}
+    md5sum ${modname} >> %{oneapi_manifest} 
+done
+
+
+%preun -p /bin/bash
+# Check current files against the manifest
+# Remove files that match and backup files that don't
+if [ -s %{oneapi_manifest} ]; then
+    while IFS= read -r line; do
+       f=${line%:*}
+       s=${line#*:}
+       if [ "${s: -2}" = "OK" ]; then
+           rm -f $f
+       elif [ -f $f ]; then
+           mv -T -f $f $f.rpmsave
+       fi
+    done <<< $(md5sum --check %{oneapi_manifest})
+else
+    # Don't touch any generated files if there's no manifest
+    echo "WARNING: Manifest not found. Previously generated"
+    echo "         modulefiles will not be removed or moved."
+fi
+
+
+%files
+%dir %{OHPC_MODULEDEPS}/intel/impi
+%dir %{OHPC_MODULEDEPS}/gnu/impi
+%dir %{OHPC_MODULEDEPS}/gnu%{gnu_major_ver}/impi
+%ghost %{oneapi_manifest}
+
+###############################################################################
+
+%define psxemod intel-psxe-mpi-devel%{PROJ_DELIM}
+
+%package -n %{psxemod}
+Summary: OpenHPC compatibility package for Intel(R) MPI Library
+
+Obsoletes: %pname%{PROJ_DELIM} < %{version}
+Requires: intel-psxe-compilers-devel%{PROJ_DELIM} = %{version}
+Requires: prun%{PROJ_DELIM}
+Requires: sed, gawk
+
+%description -n %{psxemod}
+Provides OpenHPC-style compatible modules for use with MPI Library in the
+Intel(R) Parallel Studio suite.
+
+
+%pre -n %{psxemod} -p /bin/bash
 # Verify psxe mpi stack is installed. Punt if not detected.
-
-mpicc_subpath="linux/mpi/intel64/bin/mpicc$"
-
 echo "Checking for local PSXE MPI installation(s)."
-
-versions_all=`rpm -qal | grep ${mpicc_subpath}`
+icc_subpath="linux/mpi/intel64/bin/mpicc$"
+versions_all=$(rpm -qal | grep "${icc_subpath}" | grep -v "oneapi")
 
 if [ $? -eq 1 ];then
     echo ""
-    echo "Error: Unable to detect local Parallel Studio installation. The toolchain"
-    echo "       providing ${mpicc_subpath} must be installed prior to this compatability package"
+    echo "Error: Unable to detect local Parallel Studio MPI installation. The toolchain"
+    echo "       providing ${icc_subpath} must be installed prior to this compatability package"
     echo " "
     exit 1
 fi
 
 # Verify min version expectations
 min_ver="2019"
-versions=""
-for file in ${versions_all}; do 
-    version=`rpm -q --qf '%%{VERSION}.%%{RELEASE}\n' -f ${file}`
+declare -a versions=()
+declare -a topDirs=()
+declare -a mpiDirs=()
+for file in ${versions_all}; do
+    version=$(rpm -q --qf '%%{VERSION}.%%{RELEASE}\n' -f ${file})
     echo "--> Version ${version} detected"
-    echo -e "${version}\n${min_ver}" | sort -V | head -n 1 | grep -q "^${min_ver}"
-    if [ $? -ne 0 ];then
-        echo "Warning: skipping version ${version}"
+    if [ "$min_ver" = "$(printf '${version}\n${min_ver}' | sort -V | head -n 1)" ]; then
+        echo "Warning: ${version} < $min_ver, skipping"
     else
-        versions="${versions} ${version}"
+        versions+="${version}"
+        topDirs+="$(echo $file | sed "s,/${icc_subpath},,")"
+        mpiDirs+="${file%/bin/*}"
     fi
 done
+
 if [ -z "${versions}" ]; then
     echo ""
-    echo "Error: local PSXE compatability support is for versions > ${min_ver}"
-    echo ""
+    echo "Error: local PSXE compatibility support is for versions > ${min_ver}"
+    echo " "
     exit 1
 fi
 
-%post
+rm -rf %{_localstatedir}/lib/rpm-state/%{name}
+mkdir -p %{_localstatedir}/lib/rpm-state/%{name}/
+printf "%s\n" ${versions[@]} > %{_localstatedir}/lib/rpm-state/%{name}/rpm-install-versions
+printf "%s\n" ${topDirs[@]} > %{_localstatedir}/lib/rpm-state/%{name}/rpm-install-dirs
+printf "%s\n" ${mpiDirs[@]} > %{_localstatedir}/lib/rpm-state/%{name}/rpm-install-mpis
 
-mpicc_subpath="linux/mpi/intel64/bin/mpicc"
+
+%post -n %{psxemod} -p /bin/bash
 scanner=%{OHPC_ADMIN}/compat/modulegen/mod_generator_impi.sh
-
-versions=`rpm -qal | grep ${mpicc_subpath}$`
-
-if [ $? -eq 1 ];then
-    echo ""
-    echo "Error: Unable to detect local Parallel Studio installation. The toolchain"
-    echo "       providing ${mpicc_subpath} must be installed prior to this compatability package"
-    exit 1
-fi
+declare -a versions=()
+declare -a topDirs=()
+declare -a mpiDirs=()
+readarray -t versions < %{_localstatedir}/lib/rpm-state/%{name}/rpm-install-versions
+readarray -t topDirs < %{_localstatedir}/lib/rpm-state/%{name}/rpm-install-dirs
+readarray -t mpiDirs < %{_localstatedir}/lib/rpm-state/%{name}/rpm-install-mpis
+rm -rf %{_localstatedir}/lib/rpm-state/%{name}
 
 echo "Creating OpenHPC-style modulefiles for local PSXE MPI installation(s)."
 
 # Create modulefiles for each locally detected installation.
+rm -f %{psxe_manifest}
 
-for file in ${versions}; do
+for (( x=0; x < ${#versions[@]}; x++ )); do
+    topDir=${topDirs[$x]}
+    mpiDir=${mpiDirs[$x]}
+    version=${versions[$x]}
+    echo "--> Installing modulefile for version=${version}"
 
-    version=`rpm -q --qf '%%{VERSION}.%%{RELEASE}\n' -f ${file}`
-    topDir=`echo $file | sed "s|$mpicc_subpath||"`
-    echo "--> Installing modulefile for MPI version=${version}"
+    # Check for compilervars before writing a file
+    if [ ! -e ${topDir}/linux/mpi/intel64/bin/mpivars.sh ]; then
+	   echo "Error: Unable to access mpivars.sh"
+           echo "       Skipping modules for (${topDir})"
+	   break
+    fi
+
+    # Create alternate bin directory links
+    ohpcDir=${mpiDir}/bin_ohpc
+    mkdir -p ${ohpcDir}
+    if [ -e ${mpiDir}/bin/mpiicc ]; then
+	    ln -sf ${mpiDir}/bin/mpiicc ${ohpcDir}/mpicc
+    fi
+    if [ -e ${mpiDir}/bin/mpiicpc ]; then
+	    ln -sf ${mpiDir}/bin/mpiicpc ${ohpcDir}/mpicxx
+    fi
+    if [ -e ${mpiDir}/bin/mpiifort ]; then
+	    ln -sf ${mpiDir}/bin/mpiifort ${ohpcDir}/mpif90
+	    ln -sf ${mpiDir}/bin/mpiifort ${ohpcDir}/mpif77
+    fi
+
+    echo "${ohpcDir}/" >> %{psxe_manifest}   
 	    
-    # Create soft links for standard MPI wrapper usage
-
-    ohpc_path=${topDir}/linux/mpi/intel64/bin_ohpc
-
-    %{__mkdir_p} ${ohpc_path} || exit 1
-    if [ -e ${topDir}/linux/mpi/intel64/bin/mpiicc ];then
-	if [ ! -e ${ohpc_path}/mpicc ];then
-	    %{__ln_s} ${topDir}/linux/mpi/intel64/bin/mpiicc ${ohpc_path}/mpicc
-	fi
-    fi
-    if [ -e ${topDir}/linux/mpi/intel64/bin/mpiicpc ];then
-	if [ ! -e ${ohpc_path}/mpicxx ];then
-	    %{__ln_s} ${topDir}/linux/mpi/intel64/bin/mpiicpc ${ohpc_path}/mpicxx
-	fi
-    fi
-    if [ -e ${topDir}/linux/mpi/intel64/bin/mpiifort ];then
-	if [ ! -e ${ohpc_path}/mpif90 ];then
-	    %{__ln_s} ${topDir}/linux/mpi/intel64/bin/mpiifort ${ohpc_path}/mpif90
-	fi
-	if [ ! -e ${ohpc_path}/mpif77 ];then
-	    %{__ln_s} ${topDir}/linux/mpi/intel64/bin/mpiifort ${ohpc_path}/mpif77
-	fi
-    fi
-	    
-    # Module header
-
-    %{__cat} << EOF > %{OHPC_MODULEDEPS}/intel/impi/${version}
+    # Main module
+    cat << EOF > %{OHPC_MODULEDEPS}/intel/impi/${version}
 #%Module1.0#####################################################################
-proc ModulesHelp { } {
 
-puts stderr " "
-puts stderr "This module loads the Intel MPI environment"
-puts stderr " "
+set version "${version}"
+
+proc ModulesHelp { } {
+global version
+puts stderr "\nThis module loads the Intel MPI environment\n"
 puts stderr "mpiifort     (Fortran source)"
 puts stderr "mpiicc       (C   source)"
 puts stderr "mpiicpc      (C++ source)"
-puts stderr " "
-puts stderr "Version ${version}"
-puts stderr " "
-
+puts stderr "\nVersion \$version\n"
 }
 
 module-whatis "Name: Intel MPI"
-module-whatis "Version: ${version}"
+module-whatis "Version: \$version"
 module-whatis "Category: library, runtime support"
 module-whatis "Description: Intel MPI Library (C/C++/Fortran for x86_64)"
 module-whatis "URL: http://software.intel.com/en-us/articles/intel-mpi-library/"
 
-set     version                 ${version}
+prepend-path   MODULEPATH      %{OHPC_MODULEDEPS}/intel-impi
 
-prepend-path    MODULEPATH      %{OHPC_MODULEDEPS}/intel-impi
+setenv         MPI_DIR         $mpiDir
 
 family "MPI"
 EOF
 
+    echo "%{OHPC_MODULEDEPS}/intel/impi/${version}" >> %{psxe_manifest}
+
     # Append with environment vars parsed directlry from mpivars.sh
-    ${scanner} ${topDir}/linux/mpi/intel64/bin/mpivars.sh  >> %{OHPC_MODULEDEPS}/intel/impi/${version} || exit 1
-
-    # Prepend bin_ohpc
-    %{__cat} << EOF >> %{OHPC_MODULEDEPS}/intel/impi/${version}
-#
-# Prefer bin_ohpc to allow developers to use standard mpicc, mpif90,
-# etc to access Intel toolchain.
- 
-prepend-path    PATH            ${topDir}/${dir}/linux/mpi/intel64/bin_ohpc
-EOF
-
-    # Also define MPI_DIR based on $I_MPI_ROOT
-    IMPI_DIR=`egrep "^setenv\s+I_MPI_ROOT"  %{OHPC_MODULEDEPS}/intel/impi/${version} | awk '{print $3}'`
-    if [ -d "$IMPI_DIR/intel64" ];then
-	echo "setenv          MPI_DIR        $IMPI_DIR/intel64" >> %{OHPC_MODULEDEPS}/intel/impi/${version}
+    ${scanner} ${topDir}/linux/mpi/intel64/bin/mpivars.sh  >> %{OHPC_MODULEDEPS}/intel/impi/${version}
+    if [ $? -ne 0 ]; then 
+        echo "ERROR: Could not generate content for %{OHPC_MODULEDEPS}/intel/impi/${version}"
+        break
     fi
 
+    # Prepend bin_ohpc
+    cat << EOF >> %{OHPC_MODULEDEPS}/intel/impi/${version}
+
+# Prefer bin_ohpc to allow developers to use standard mpicc, mpif90,
+# etc to access Intel toolchain.
+prepend-path    PATH            ${ohpcDir}
+
+EOF
+
     # Version file
-    %{__cat} << EOF > %{OHPC_MODULEDEPS}/intel/impi/.version.${version}
+    cat << EOF > %{OHPC_MODULEDEPS}/intel/impi/.version.$version
 #%Module1.0#####################################################################
 set     ModulesVersion      "${version}"
 EOF
+
+    echo "%{OHPC_MODULEDEPS}/intel/impi/.version.${version}" >> %{psxe_manifest}   
 	
     # OpenHPC module file for GNU compiler toolchain
-    %{__cat} << EOF > %{OHPC_MODULEDEPS}/gnu/impi/${version}
+    cat << EOF > %{OHPC_MODULEDEPS}/gnu/impi/${version}
 #%Module1.0#####################################################################
-proc ModulesHelp { } {
 
-puts stderr " "
-puts stderr "This module loads the Intel MPI environment for use with the GNU"
-puts stderr "compiler toolchain"
-puts stderr " "
+set version "${version}"
+
+proc ModulesHelp { } {
+global version
+puts stderr "\nThis module loads the Intel MPI environment for use with the GNU"
+puts stderr "compiler toolchain\n"
 puts stderr "mpif90       (Fortran source)"
 puts stderr "mpicc        (C   source)"
 puts stderr "mpicxx       (C++ source)"
-puts stderr " "
-puts stderr "Version ${version}"
-puts stderr " "
-
+puts stderr "\nVersion \$version\n"
 }
 
 module-whatis "Name: Intel MPI"
-module-whatis "Version: ${version}"
+module-whatis "Version: \$version"
 module-whatis "Category: library, runtime support"
 module-whatis "Description: Intel MPI Library (C/C++/Fortran for x86_64)"
 module-whatis "URL: http://software.intel.com/en-us/articles/intel-mpi-library/"
 
-set     version                 ${version}
-
-prepend-path    MODULEPATH      %{OHPC_MODULEDEPS}/gnu-impi
+prepend-path   MODULEPATH      %{OHPC_MODULEDEPS}/gnu-impi
+setenv         MPI_DIR         ${mpiDir}
 
 family "MPI"
 EOF
 
+    echo "%{OHPC_MODULEDEPS}/gnu/impi/${version}" >> %{psxe_manifest}
+
     # Append with environment vars parsed directly from mpivars.sh
-    ${scanner} ${topDir}/linux/mpi/intel64/bin/mpivars.sh  >> %{OHPC_MODULEDEPS}/gnu/impi/${version} || exit 1
+    ${scanner} ${topDir}/linux/mpi/intel64/bin/mpivars.sh  >> %{OHPC_MODULEDEPS}/gnu/impi/${version}
+    if [ $? -ne 0 ]; then 
+        echo "ERROR: Could not generate content for %{OHPC_MODULEDEPS}/gnu/impi/${version}"
+        break
+    fi
 
     # Version file
-    %{__cat} << EOF > %{OHPC_MODULEDEPS}/gnu/impi/.version.${version}
+    cat << EOF > %{OHPC_MODULEDEPS}/gnu/impi/.version.${version}
 #%Module1.0#####################################################################
 set     ModulesVersion      "${version}"
 EOF
 
-    # Also define MPI_DIR based on $I_MPI_ROOT
-    IMPI_DIR=`egrep "^setenv\s+I_MPI_ROOT"  %{OHPC_MODULEDEPS}/intel/impi/${version} | awk '{print $3}'`
-    if [ -d "$IMPI_DIR/intel64" ];then
-	echo "setenv          MPI_DIR        $IMPI_DIR/intel64" >> %{OHPC_MODULEDEPS}/gnu/impi/${version}
-    fi
+    echo "%{OHPC_MODULEDEPS}/gnu/impi/.version.${version}" >> %{psxe_manifest}
 
     # support for additional gnu variants
-    %{__cp} %{OHPC_MODULEDEPS}/gnu/impi/${version} %{OHPC_MODULEDEPS}/gnu%{gnu_major_ver}/impi/${version}
-    %{__cp} %{OHPC_MODULEDEPS}/gnu/impi/.version.${version} %{OHPC_MODULEDEPS}/gnu%{gnu_major_ver}/impi/.version.${version}
-    perl -pi -e 's!moduledeps/gnu-impi!moduledeps/gnu%{gnu_major_ver}-impi!' %{OHPC_MODULEDEPS}/gnu%{gnu_major_ver}/impi/${version}
+    cp %{OHPC_MODULEDEPS}/gnu/impi/${version} %{OHPC_MODULEDEPS}/gnu%{gnu_major_ver}/impi/${version}
+    cp %{OHPC_MODULEDEPS}/gnu/impi/.version.${version} %{OHPC_MODULEDEPS}/gnu%{gnu_major_ver}/impi/.version.${version}
+    sed -i "s,%{OHPC_MODULEDEPS}/gnu-impi,%{OHPC_MODULEDEPS}/gnu%{gnu_major_ver}-impi," %{OHPC_MODULEDEPS}/gnu%{gnu_major_ver}/impi/${version}
     
-    # Inventory for later removal
-    echo "%{OHPC_MODULEDEPS}/intel/impi/${version}" >> %{OHPC_MODULEDEPS}/intel/impi/.manifest
-    echo "%{OHPC_MODULEDEPS}/intel/impi/.version.${version}" >> %{OHPC_MODULEDEPS}/intel/impi/.manifest   
-    echo "%{OHPC_MODULEDEPS}/gnu/impi/${version}" >> %{OHPC_MODULEDEPS}/intel/impi/.manifest
-    echo "%{OHPC_MODULEDEPS}/gnu/impi/.version.${version}" >> %{OHPC_MODULEDEPS}/intel/impi/.manifest
-    echo "%{OHPC_MODULEDEPS}/gnu%{gnu_major_ver}/impi/${version}" >> %{OHPC_MODULEDEPS}/intel/impi/.manifest
-    echo "%{OHPC_MODULEDEPS}/gnu%{gnu_major_ver}/impi/.version.${version}" >> %{OHPC_MODULEDEPS}/intel/impi/.manifest   
+    echo "%{OHPC_MODULEDEPS}/gnu%{gnu_major_ver}/impi/${version}" >> %{psxe_manifest}
+    echo "%{OHPC_MODULEDEPS}/gnu%{gnu_major_ver}/impi/.version.${version}" >> %{psxe_manifest}
 
 done
 
 
-%postun
-if [ "$1" = 0 ]; then
-
-    mpicc_subpath="linux/mpi/intel64/bin/mpicc"
-    versions=`rpm -qal | grep ${mpicc_subpath}$`
-
-    for file in ${versions}; do
-	version=`rpm -q --qf '%%{VERSION}.%%{RELEASE}\n' -f ${file}`
-	topDir=`echo $file | sed "s|$mpicc_subpath||"`
-
-	if [ -d ${topDir}/linux/mpi/intel64/bin_ohpc ];then
-	    rm -rf ${topDir}/linux/mpi/intel64/bin_ohpc
-	fi
-    done
-
-    if [ -s %{OHPC_MODULEDEPS}/intel/impi/.manifest ];then
-	for file in `cat %{OHPC_MODULEDEPS}/intel/impi/.manifest`; do
-	   if [ -e $file ];then
-               rm $file
-	   fi
-	done
-	rm -f %{OHPC_MODULEDEPS}/intel/impi/.manifest
-    fi
+%preun -n %{psxemod} -p /bin/bash
+if [ -s %{psxe_manifest} ]; then
+    while IFS= read -r file; do
+        if [[ "$file" =~ "/bin_ohpc/" ]]; then
+            rm -f $file/*
+            rmdir $file
+        fi
+        if [ -e $file ]; then
+            rm -f $file
+        fi
+	done < %{psxe_manifest}
+else
+        echo "WARNING: Manifest not found"
 fi
 
-%files
+
+%files -n %{psxemod}
 %{OHPC_ADMIN}/compat/modulegen/mod_generator_impi.sh
-%{OHPC_MODULEDEPS}
+%dir %{OHPC_MODULEDEPS}/intel/impi
+%dir %{OHPC_MODULEDEPS}/gnu/impi
+%dir %{OHPC_MODULEDEPS}/gnu%{gnu_major_ver}/impi
+%ghost %{psxe_manifest}


### PR DESCRIPTION
This updates the intel-compiler-devel and intel-mpi-devel packages to use oneAPI. I'm interested in having others try this out and getting feedback. Given that oneAPI has been out for half-a-year, I'd like migrate before the next release. That said, I'll need some help with OBS Testing. it will require modifying the base images to install the toolkit release package instead of PSXE and I don't have experience with that.

Reference issue #1317 

This was tested on CentOS 8.4 and OpenSUSE 15.3 with the latest PSXE and two oneAPI releases. Tested builds of various package using the latest oneAPI HPC TK. Packages seem to be working, but there are a lot of warnings about unsupported command line options.

This is a short summary of changes:
 - The compiler package includes a oneAPI release package that configures the YUM repo. After this is installed, the compiler-devel package can be installed and will install the oneAPI HPC Toolkit as a dependency.
 - Included oneAPI modulefiles are used. OHPC intel/impi module names remain the the same, but are greatly simplified, prepending the oneAPI module directory only when needed.
 - The legacy compilers are used, to simplify initial migration.
 - A minimum version is set. Older oneAPI builds don't work with LMOD without patching oneAPI modulefiles.
 - Install/removal of the RPMs won't clobber any generated files that the user has modified.
 -  The previous PSXE package is renamed and works the same way it used to. I tried to simplify a lot of it, since the 1.x stuff isn't relevant any more.

I would ultimately like move the module generation to a utility and call it in pre and post. That way an admin could update their configuration without reinstalling the RPM.
