### PR TITLE
Compatability layer for Arm 21 compiler release.

### DIFF
--- a/components/compiler-families/arm-compilers-devel/SPECS/arm-compilers-devel.spec
+++ b/components/compiler-families/arm-compilers-devel/SPECS/arm-compilers-devel.spec
@@ -9,12 +9,23 @@
 #----------------------------------------------------------------------------eh-
 
 %include %{_sourcedir}/OHPC_macros
-%global pname arm1-compilers-devel
+%global arm_compt_version arm2
+%global pname %{arm_compt_version}-compilers-devel
+# Currently, the Arm compiler version number is included in the Arm compiler
+# package name. 
+# Arm include the version number to easily allow multiple versions of the 
+# compiler to be installed simultaneously. However, a version number in the 
+# package name is undesirable for integration with OpenHPC.
+# This compatibility layer avoids the problem of a version number in the package
+# name by discovering latest_installed_ver here and uses it throughtout
+# to mitigate the problem of including the version in the package name.
+%global latest_installed_ver %(rpm -qa --queryformat "%%{VERSION} %%{NAME}\\n" | grep " arm-linux-compiler" | sort -rn | cut -d " " -f 1)
+%global major_version() $(echo %1 | cut -d '.' -f 1)
 
 Summary:   OpenHPC compatibility package for Arm HPC compiler
 Name:      %{pname}%{PROJ_DELIM}
 Version:   2.0
-Release:   1
+Release:   13.1.ohpc.2.0
 License:   Apache-2.0
 URL:       https://github.com/openhpc/ohpc
 Group:     %{PROJ_NAME}/compiler-families
@@ -23,7 +34,8 @@ BuildArch: aarch64
 #!BuildIgnore: brp-check-suse
 #!BuildIgnore: post-build-checks
 
-Requires: arm-compiler-for-linux >= 20.2.1
+# We need to ensure the installed version is >=21.0
+Requires: arm-linux-compiler-%{latest_installed_ver}-Generic-AArch64-RHEL-8-aarch64-linux >= 21.0
 Requires: lmod%{PROJ_DELIM}
 
 %description
@@ -32,7 +44,7 @@ Provides OpenHPC-style module compatibility for use with the Arm HPC compiler su
 
 %install
 
-%{__mkdir} -p %{buildroot}/%{OHPC_MODULES}/arm1
+%{__mkdir} -p %{buildroot}/%{OHPC_MODULES}/%{arm_compt_version}
 
 %post
 
@@ -40,8 +52,8 @@ echo "Creating OpenHPC compatibility modulefile for local Arm compiler installat
 
 # Create a top-level arm/compat module which appends the lmod modulepath to see
 # modulefiles provided by Arm installation
-
-modpath=`rpm -ql arm-compiler-for-linux | grep modulefiles$`
+echo "Using latest installed version: %{latest_installed_ver}"
+modpath=`rpm -qa | grep -i arm-linux-compiler-%{latest_installed_ver} | xargs rpm -ql | grep \/modulefiles$`
 
 if [ ! -n "${modpath}" ];then
     echo ""
@@ -49,28 +61,12 @@ if [ ! -n "${modpath}" ];then
     exit 1
 fi
 
-# cache path to generic compiler modulename
-generic=`find $modpath/Generic-AArch64/ -name arm-linux-compiler | awk -F "$modpath/" '{print $2}'`
-if [ ! -n "${generic}" ];then
-    echo ""
-    echo "Error: Unable to determine path to Generic modulefiles provided by Arm compiler toolchain"
-    exit 1
-else
-    echo "--> Setting generic variant path to: $generic"
-fi
-
-# cache path to generic armpl modulename
-armpl_generic=`find $modpath/Generic-AArch64/ -name armpl | grep arm-linux-compiler | awk -F "$modpath/" '{print $2}'`
-if [ ! -n "${generic}" ];then
-    echo ""
-    echo "Error: Unable to determine path to Generic Performance Library modulefile provided by Arm compiler toolchain"
-    exit 1
-else
-    echo "--> Setting ARM PL generic variant to: $armpl_generic"
-fi
+# path to generic compiler modulename
+generic=arm%{major_version %latest_installed_ver}/${latest_installed_ver}
 
 # Module header
-%{__cat} << EOF > %{OHPC_MODULES}/arm1/compat
+
+%{__cat} << EOF > %{OHPC_MODULES}/%{arm_compt_version}/compat
 #%Module1.0#####################################################################
 
 proc ModulesHelp { } {
@@ -90,11 +86,9 @@ set    ARM_GENERIC ${generic}
 setenv ARM_GENERIC \$ARM_GENERIC
 
 # update module path hierarchy
-prepend-path    MODULEPATH          ${modpath}:%{OHPC_MODULEDEPS}/arm1
+prepend-path    MODULEPATH          ${modpath}
 # load generic variant
 depends-on      \$ARM_GENERIC
-depends-on      ${armpl_generic}
-family "compiler"
 EOF
 
 
@@ -102,8 +96,8 @@ EOF
 
 if [ $1 -eq 0 ];then
 
-    if [ -s %{OHPC_MODULES}/arm1/compat ];then
-	rm -f %{OHPC_MODULES}/arm1/compat
+    if [ -s %{OHPC_MODULES}/%{arm_compt_version}/compat ];then
+	rm -f %{OHPC_MODULES}/%{arm_compt_version}/compat
     fi
 fi
 


### PR DESCRIPTION
The current Arm compiler release is 21. Update the compatibility spec file to use this release.

Signed-off-by: Richard Henwood <richard.henwood@arm.com>