### PR TITLE
containers: update containers to 2.3.0

### DIFF
--- a/containers/Dockerfile.ohpc-gnu9
+++ b/containers/Dockerfile.ohpc-gnu9
@@ -1,6 +1,8 @@
-FROM registry.centos.org/centos/centos:centos8
+FROM quay.io/centos/centos:centos8
 
 MAINTAINER The OpenHPC Project
+
+ARG arch
 
 # This is based on https://gist.github.com/chuckatkins/994c8d88fb88f15433b08539162e8ac6
 # Put these in the OpenHPC base image:
@@ -10,10 +12,10 @@ MAINTAINER The OpenHPC Project
 COPY z01_lmod_load_default.sh /etc/profile.d/
 COPY bash-login-wrapper.sh /usr/bin/
 
-RUN yum -y install http://repos.openhpc.community/OpenHPC/2/CentOS_8/x86_64/ohpc-release-2-1.el8.x86_64.rpm
+RUN yum -y install http://repos.openhpc.community/OpenHPC/2/CentOS_8/$arch/ohpc-release-2-1.el8.$arch.rpm
 
 RUN yum install -y 'dnf-command(config-manager)' && \
-    yum config-manager --set-enabled PowerTools && \
+    yum config-manager --set-enabled powertools && \
     yum upgrade -y && \
     yum -y install openssh-clients && \
     yum -y install gnu9-compilers-ohpc lmod-ohpc && \

--- a/containers/Dockerfile.ohpc-gnu9-mpich
+++ b/containers/Dockerfile.ohpc-gnu9-mpich
@@ -1,4 +1,4 @@
-FROM ohpc-gnu9:2.0.0
+FROM ohpc-gnu9:2.3.0
 
 MAINTAINER The OpenHPC Project
 

--- a/containers/Dockerfile.ohpc-gnu9-mvapich2
+++ b/containers/Dockerfile.ohpc-gnu9-mvapich2
@@ -1,4 +1,4 @@
-FROM ohpc-gnu9:2.0.0
+FROM ohpc-gnu9:2.3.0
 
 MAINTAINER The OpenHPC Project
 

--- a/containers/Dockerfile.ohpc-gnu9-openmpi4
+++ b/containers/Dockerfile.ohpc-gnu9-openmpi4
@@ -1,4 +1,4 @@
-FROM ohpc-gnu9:2.0.0
+FROM ohpc-gnu9:2.3.0
 
 MAINTAINER The OpenHPC Project
 

--- a/containers/Makefile
+++ b/containers/Makefile
@@ -3,27 +3,55 @@ MPIS := openmpi4 mpich mvapich2
 CONTAINERS := $(COMPILER) $(addprefix $(COMPILER)-,$(MPIS))
 CONTAINER_RUNTIME := podman
 CONTAINERS_PUSH := $(addsuffix -push,$(CONTAINERS))
+CONTAINERS_MANIFEST_PUSH := $(addsuffix -manifest-push,$(CONTAINERS))
 COMPILER_CHECK := $(addsuffix -check,$(COMPILER))
 MPIS_CHECK := $(addsuffix -check,$(addprefix $(COMPILER)-,$(MPIS)))
+BUILD_ARCH := $(shell uname -m)
+# During build we need the arches returned by uname -m
+# For multiarch container images we need the arches as defined by the CONTAINER_RUNTIME
+ARCHES := arm64v8 amd64
+
+ifeq ($(BUILD_ARCH), aarch64)
+	TAG_ARCH = arm64v8
+endif
+ifeq ($(BUILD_ARCH), x86_64)
+	TAG_ARCH = amd64
+endif
 
 DEST ?= quay.io/ohpc/
-VERSION ?= 2.0.0
+VERSION ?= 2.3.0
 
 .PHONY: all $(CONTAINERS) push $(CONTAINERS_PUSH) $(COMPILER_CHECK) $(MPIS_CHECK) clean
 
 all: $(CONTAINERS)
 
 $(CONTAINERS):
-	$(CONTAINER_RUNTIME) build . -f Dockerfile.ohpc-$@ --tag=ohpc-$@:$(VERSION)
+	$(CONTAINER_RUNTIME) build . -f Dockerfile.ohpc-$@ --tag=ohpc-$@:$(VERSION) --build-arg arch=$(BUILD_ARCH)
 
 define PUSH
 $(1)-push: $(1)
-	$(CONTAINER_RUNTIME) push ohpc-$(1):$(VERSION) $(DEST)ohpc-$(1):$(VERSION)
-	$(CONTAINER_RUNTIME) push ohpc-$(1):$(VERSION) $(DEST)ohpc-$(1):latest
+	$(CONTAINER_RUNTIME) push ohpc-$(1):$(VERSION) $(DEST)$(TAG_ARCH)-ohpc-$(1):$(VERSION)
+	$(CONTAINER_RUNTIME) push ohpc-$(1):$(VERSION) $(DEST)$(TAG_ARCH)-ohpc-$(1):latest
 endef
 $(foreach c,$(CONTAINERS),$(eval $(call PUSH,$(c))))
 
 push: $(CONTAINERS_PUSH)
+
+define MANIFEST_PUSH
+$(1)-manifest-push: $(1)
+	$(CONTAINER_RUNTIME) rmi $(DEST)ohpc-$(1):$(VERSION) ||:
+	$(CONTAINER_RUNTIME) rmi $(DEST)ohpc-$(1):latest ||:
+	$(CONTAINER_RUNTIME) manifest create $(DEST)ohpc-$(1):$(VERSION)
+	$(CONTAINER_RUNTIME) manifest create $(DEST)ohpc-$(1):latest
+	$(foreach a,$(ARCHES), $(call touch /tmp/$(a)))
+	$(foreach a,$(ARCHES), $(CONTAINER_RUNTIME) manifest add $(DEST)ohpc-$(1):$(VERSION) docker://$(DEST)$(a)-ohpc-$(1):$(VERSION);)
+	$(foreach a,$(ARCHES), $(CONTAINER_RUNTIME) manifest add $(DEST)ohpc-$(1):latest docker://$(DEST)$(a)-ohpc-$(1):latest;)
+	$(CONTAINER_RUNTIME) manifest push -f v2s2 --purge --all $(DEST)ohpc-$(1):$(VERSION) docker://$(DEST)ohpc-$(1):$(VERSION)
+	$(CONTAINER_RUNTIME) manifest push -f v2s2 --purge --all $(DEST)ohpc-$(1):latest docker://$(DEST)ohpc-$(1):latest
+endef
+$(foreach c,$(CONTAINERS),$(eval $(call MANIFEST_PUSH,$(c))))
+
+manifest-push: $(CONTAINERS_MANIFEST_PUSH)
 
 $(COMPILER_CHECK): $(COMPILER)
 	rm -f test/hello


### PR DESCRIPTION
This updates the container Dockerfiles to 2.3.0 and enables multiarch images using 'make manifest-push'.