### PR TITLE
Match spack-ohpc dependencies to published system requirements

### DIFF
--- a/components/dev-tools/spack/SPECS/spack.spec
+++ b/components/dev-tools/spack/SPECS/spack.spec
@@ -39,6 +39,7 @@ Requires: tar
 Requires: gzip
 Requires: unzip
 Requires: bzip2
+Requires: xz
 Requires: zstd
 Requires: file
 Requires: gnupg2

--- a/components/dev-tools/spack/SPECS/spack.spec
+++ b/components/dev-tools/spack/SPECS/spack.spec
@@ -44,7 +44,6 @@ Requires: file
 Requires: gnupg2
 Requires: git
 
-
 %global install_path %{OHPC_ADMIN}/%{pname}/%version
 # Turn off the brp-python-bytecompile script
 %global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')

--- a/components/dev-tools/spack/SPECS/spack.spec
+++ b/components/dev-tools/spack/SPECS/spack.spec
@@ -44,6 +44,7 @@ Requires: zstd
 Requires: file
 Requires: gnupg2
 Requires: git
+Requires: curl
 
 %global install_path %{OHPC_ADMIN}/%{pname}/%version
 # Turn off the brp-python-bytecompile script

--- a/components/dev-tools/spack/SPECS/spack.spec
+++ b/components/dev-tools/spack/SPECS/spack.spec
@@ -32,6 +32,18 @@ Requires: subversion
 Requires: hg
 Requires: patch
 Requires: python3-mock
+Requires: gcc
+Requires: gcc-c++
+Requires: make
+Requires: tar
+Requires: gzip
+Requires: unzip
+Requires: bzip2
+Requires: zstd
+Requires: file
+Requires: gnupg2
+Requires: git
+
 
 %global install_path %{OHPC_ADMIN}/%{pname}/%version
 # Turn off the brp-python-bytecompile script


### PR DESCRIPTION
From discussion with @adrianreber on Slack this morning, we noticed on a fresh install of OHPC with Spack, that we were unable to run some `spack install` commands out of the box, due to us not yet having `g++` installed, nor had we run `spack compiler find` after installing OHPC-packaged compilers to fix root's `compilers.yaml`.

This PR ensures all the [system prerequisites](https://spack.readthedocs.io/en/latest/getting_started.html#system-prerequisites) are dependencies of the Spack package. It may not provide optimized compilations, but should work better out of the box.