### PR TITLE
components/runtimes/singularity: Add build dependency

### DIFF
--- a/components/runtimes/singularity/SPECS/singularity.spec
+++ b/components/runtimes/singularity/SPECS/singularity.spec
@@ -53,6 +53,7 @@ BuildRequires: git
 BuildRequires: openssl-devel
 BuildRequires: libuuid-devel
 BuildRequires: libseccomp-devel
+BuildRequires: make
 Requires: file
 %if 0%{?suse_version}
 BuildRequires: go1.14


### PR DESCRIPTION
Singularity requires `make` in order to build.

Signed-off-by: Sol Jerome <solj@utdallas.edu>