### PR TITLE
Added links to gcc and gfortran

### DIFF
--- a/components/compiler-families/gnu-compilers/SPECS/gnu-compilers.spec
+++ b/components/compiler-families/gnu-compilers/SPECS/gnu-compilers.spec
@@ -81,6 +81,35 @@ make %{?_smp_mflags} DESTDIR=$RPM_BUILD_ROOT install
 %fdupes -s $RPM_BUILD_ROOT/%{install_path}/share
 %endif
 
+# Based on https://git.centos.org/rpms/gcc/blob/c8/f/SPECS/gcc.spec
+ln -sf gcc %{buildroot}%{install_path}/bin/cc
+ln -sf gfortran %{buildroot}%{install_path}/bin/f95
+
+cat > %{buildroot}%{install_path}/bin/c89 <<"EOF"
+#!/bin/sh
+fl="-std=c89"
+for opt; do
+  case "$opt" in
+    -ansi|-std=c89|-std=iso9899:1990) fl="";;
+    -std=*) echo "`basename $0` called with non ANSI/ISO C option $opt" >&2
+	    exit 1;;
+  esac
+done
+exec gcc $fl ${1+"$@"}
+EOF
+cat > %{buildroot}%{install_path}/bin/c99 <<"EOF"
+#!/bin/sh
+fl="-std=c99"
+for opt; do
+  case "$opt" in
+    -std=c99|-std=iso9899:1999) fl="";;
+    -std=*) echo "`basename $0` called with non ISO C99 option $opt" >&2
+	    exit 1;;
+  esac
+done
+exec gcc $fl ${1+"$@"}
+EOF
+chmod 755 %{buildroot}%{install_path}/bin/c?9
 
 # OpenHPC module file
 %{__mkdir_p} %{buildroot}/%{OHPC_MODULES}/gnu%{gnu_major_ver}


### PR DESCRIPTION
This commit fixes missing symbolic links and wrapper scripts for gcc
and gfortran. Fixes #328 and add new functionality.

cc -> gcc
c89 -> wrapper
c99 -> wrapper
f95 -> gfrotran

Those files are needed on some software that hardcode those binaries
on it's code during runtime. Since compute nodes don't usually have
"Development Tools" installed from default system packages, it's
execution fails with command not found.

As a real world example, ANSYS Fluent would fail to execute:

```
-I/opt/ohpc/pub/apps/ansys_inc/v211/fluent/include -I. -c udf_names.c
/bin/sh: cc: command not found
make[3]: *** [udf_names.o] Error 127
```

Providing `cc`, `c89`, `c99` and `f95` will solve those specific
issues during execution. Patching and testing was done in a running
production OpenHPC cluster and it worked as expected:

```
$ which {cc,c89,c99,f95}
/opt/ohpc/pub/compiler/gcc/9.4.0/bin/cc
/opt/ohpc/pub/compiler/gcc/9.4.0/bin/c89
/opt/ohpc/pub/compiler/gcc/9.4.0/bin/c99
/opt/ohpc/pub/compiler/gcc/9.4.0/bin/f95
```

Code is based heavily on EL8 gcc package:
https://git.centos.org/rpms/gcc/blob/c8/f/SPECS/gcc.spec

Signed-off-by: Vinícius Ferrão <vinicius@ferrao.net.br>