### PR TITLE
fftw.spec: fix typo & enable sse2/avx/avx2

### DIFF
--- a/components/parallel-libs/fftw/SPECS/fftw.spec
+++ b/components/parallel-libs/fftw/SPECS/fftw.spec
@@ -72,10 +72,10 @@ rm -f config.cache
 
 for i in %{precision_list} ; do
 	LOOPBASEFLAGS=${BASEFLAGS}
-	if [[ "${i} == "single" || "${i} == "double" ]]; then
+	if [[ "${i}" == "single" || "${i}" == "double" ]]; then
 		# taken from https://src.fedoraproject.org/rpms/fftw/blob/master/f/fftw.spec
 %ifarch x86_64
-		LOOPBASEFLAGS="${LOOPBASEFLAGS} --enable-sse2 --enable-avx"
+		LOOPBASEFLAGS="${LOOPBASEFLAGS} --enable-sse2 --enable-avx --enable-avx2"
 %endif
 %ifarch aarch64
 		LOOPBASEFLAGS="${LOOPBASEFLAGS} --enable-neon"


### PR DESCRIPTION
This fix openhpc/ohpc#1409. Fix a typo to support `sse2`/`avx` and in addition adds `avx2`/`avx512` SIMD extensions.

Tested on a machine with Intel Xeon E5-2696 v3 (has avx2 but not avx512) by following `Rebuilding Packages from Source` in the Install Guide Rocky 8.5/x86 64, rebuild and reinstall `fftw-gnu9-openmpi4-ohpc`.
```
[root@master lib]# strings /opt/ohpc/pub/libs/gnu9/openmpi4/fftw/3.3.8/lib/libfftw3.so | grep have
fftw_have_simd_sse2
fftw_have_simd_avx
fftw_have_simd_avx2
fftw_have_simd_avx2_128
fftw_have_simd_avx512
fftw_have_simd_sse2
fftw_have_simd_avx2
fftw_have_simd_avx512
fftw_have_simd_avx
fftw_have_simd_avx2_128
```

comparing with original `fftw-gnu9-mpich-ohpc`:
```
[root@master lib]# strings /opt/ohpc/pub/libs/gnu9/mpich/fftw/3.3.8/lib/libfftw3.so | grep have
[root@master lib]#
```

This shows the modified `fftw.spec` adds SIMD supports. 

EDIT: avx512 is removed because the upstream isn't ready. 
