### PR TITLE
Avoid killing user sessions on slurm.epilog

### DIFF
--- a/components/rms/slurm/SOURCES/slurm.epilog.clean
+++ b/components/rms/slurm/SOURCES/slurm.epilog.clean
@@ -12,13 +12,13 @@ if [ x$SLURM_UID = "x" ] ; then
 	exit 0
 fi
 if [ x$SLURM_JOB_ID = "x" ] ; then 
-        exit 0
+	exit 0
 fi
 
 #
 # Don't try to kill user root or system daemon jobs
 #
-if [ $SLURM_UID -lt 100 ] ; then
+if [ $SLURM_UID -lt 1000 ] ; then
 	exit 0
 fi
 
@@ -31,7 +31,11 @@ do
 done
 
 #
-# No other SLURM jobs, purge all remaining processes of this user
+# No other SLURM jobs, purge all remaining processes of this user if and only
+# if the SLURM controller is not running on the same server as the running job,
+# to avoid killing the login session
 #
-pkill -KILL -U $SLURM_UID
+if ! pgrep -x slurmctld > /dev/null ; then
+	pkill -KILL -U $SLURM_UID
+fi
 exit 0


### PR DESCRIPTION
This PR fixes two issues and a cosmetic issue on
`slurm.epilog.clean` script:

* The cosmetic one is trivial, tab vs spaces.

* The script should not run for UIDs lower than 1000 instead of 100.
Every UID lower than 1000 is considered a system account, this PR
fixes the comparison on the guard clause.

* The last one is a special case when the HPC environment uses the
headnode also as a compute node, or on HPC systems where nodes
aren't available and a single big server takes care of everything.
To avoid killing legitimate user sessions, like graphical login or
ssh login, we check if `slurmctld` is running on the same machine
as the epilogue script. If it's not running them we just kill
everything as the old behavior. If `slurmctld` is running just exit
without killing the remaining processes.

Signed-off-by: Vinícius Ferrão <vinicius@ferrao.net.br>