### PR TITLE
Increase reliability of chronyd for compute nodes

### DIFF
--- a/docs/recipes/install/centos8/x86_64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/centos8/x86_64/warewulf/slurm/steps.tex
@@ -149,7 +149,7 @@
 # Add Network Time Protocol (NTP) support
 [sms](*\#*) (*\chrootinstall*) chrony
 # Identify master host as local NTP server
-[sms](*\#*) echo "server ${sms_ip}" >> $CHROOT/etc/chrony.conf
+[sms](*\#*) echo "server ${sms_ip} iburst" >> $CHROOT/etc/chrony.conf
 
 # Add kernel drivers (matching kernel version on SMS node)
 [sms](*\#*) (*\chrootinstall*) kernel-`uname -r`

--- a/docs/recipes/install/common/time.tex
+++ b/docs/recipes/install/common/time.tex
@@ -8,6 +8,7 @@ issue the following:
 % ohpc_validation_comment Enable NTP services on SMS host
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true,keepspaces]
 [sms](*\#*) systemctl enable chronyd.service
+[sms](*\#*) echo "local stratum 10" >> /etc/chrony.conf
 [sms](*\#*) echo "server ${ntp_server}" >> /etc/chrony.conf
 [sms](*\#*) echo "allow all" >> /etc/chrony.conf
 [sms](*\#*) systemctl restart chronyd

--- a/docs/recipes/install/leap15/aarch64/warewulf/openpbs/steps.tex
+++ b/docs/recipes/install/leap15/aarch64/warewulf/openpbs/steps.tex
@@ -139,7 +139,7 @@
 [sms](*\#*) (*\chrootinstall*) chrony
 [sms](*\#*) chroot $CHROOT systemctl enable chronyd
 # Identify master host as local NTP server
-[sms](*\#*) echo "server ${sms_ip}" >> $CHROOT/etc/chrony.conf
+[sms](*\#*) echo "server ${sms_ip} iburst" >> $CHROOT/etc/chrony.conf
 
 # Add kernel drivers
 [sms](*\#*) (*\chrootinstall*) kernel-default

--- a/docs/recipes/install/leap15/aarch64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/leap15/aarch64/warewulf/slurm/steps.tex
@@ -141,7 +141,7 @@
 [sms](*\#*) (*\chrootinstall*) chrony
 [sms](*\#*) chroot $CHROOT systemctl enable chronyd
 # Identify master host as local NTP server
-[sms](*\#*) echo "server ${sms_ip}" >> $CHROOT/etc/chrony.conf
+[sms](*\#*) echo "server ${sms_ip} iburst" >> $CHROOT/etc/chrony.conf
 
 # Add kernel drivers
 [sms](*\#*) (*\chrootinstall*) kernel-default

--- a/docs/recipes/install/leap15/x86_64/warewulf/openpbs/steps.tex
+++ b/docs/recipes/install/leap15/x86_64/warewulf/openpbs/steps.tex
@@ -138,7 +138,7 @@
 [sms](*\#*) (*\chrootinstall*) chrony
 [sms](*\#*) chroot $CHROOT systemctl enable chronyd
 # Identify master host as local NTP server
-[sms](*\#*) echo "server ${sms_ip}" >> $CHROOT/etc/chrony.conf
+[sms](*\#*) echo "server ${sms_ip} iburst" >> $CHROOT/etc/chrony.conf
 
 # Add kernel drivers
 [sms](*\#*) (*\chrootinstall*) kernel-default

--- a/docs/recipes/install/leap15/x86_64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/leap15/x86_64/warewulf/slurm/steps.tex
@@ -141,7 +141,7 @@
 [sms](*\#*) (*\chrootinstall*) chrony
 [sms](*\#*) chroot $CHROOT systemctl enable chronyd
 # Identify master host as local NTP server
-[sms](*\#*) echo "server ${sms_ip}" >> $CHROOT/etc/chrony.conf
+[sms](*\#*) echo "server ${sms_ip} iburst" >> $CHROOT/etc/chrony.conf
 
 # Add kernel drivers
 [sms](*\#*) (*\chrootinstall*) kernel-default

--- a/docs/recipes/install/rocky8/aarch64/warewulf/openpbs/steps.tex
+++ b/docs/recipes/install/rocky8/aarch64/warewulf/openpbs/steps.tex
@@ -138,7 +138,7 @@
 
 # Add Network Time Protocol (NTP) support
 [sms](*\#*) (*\chrootinstall*) chrony
-[sms](*\#*) echo "server ${sms_ip}" >> $CHROOT/etc/chrony.conf
+[sms](*\#*) echo "server ${sms_ip} iburst" >> $CHROOT/etc/chrony.conf
 
 # Add kernel drivers (matching kernel version on SMS node)
 [sms](*\#*) (*\chrootinstall*) kernel-`uname -r`

--- a/docs/recipes/install/rocky8/aarch64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/rocky8/aarch64/warewulf/slurm/steps.tex
@@ -142,7 +142,7 @@
 # Add Network Time Protocol (NTP) support
 [sms](*\#*) (*\chrootinstall*) chrony
 # Identify master host as local NTP server
-[sms](*\#*) echo "server ${sms_ip}" >> $CHROOT/etc/chrony.conf
+[sms](*\#*) echo "server ${sms_ip} iburst" >> $CHROOT/etc/chrony.conf
 
 # Add kernel drivers (matching kernel version on SMS node)
 [sms](*\#*) (*\chrootinstall*) kernel-`uname -r`

--- a/docs/recipes/install/rocky8/x86_64/warewulf/openpbs/steps.tex
+++ b/docs/recipes/install/rocky8/x86_64/warewulf/openpbs/steps.tex
@@ -144,7 +144,7 @@
 # Add Network Time Protocol (NTP) support
 [sms](*\#*) (*\chrootinstall*) chrony
 # Identify master host as local NTP server
-[sms](*\#*) echo "server ${sms_ip}" >> $CHROOT/etc/chrony.conf
+[sms](*\#*) echo "server ${sms_ip} iburst" >> $CHROOT/etc/chrony.conf
 
 # Add kernel drivers (matching kernel version on SMS node)
 [sms](*\#*) (*\chrootinstall*) kernel-`uname -r`

--- a/docs/recipes/install/rocky8/x86_64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/rocky8/x86_64/warewulf/slurm/steps.tex
@@ -149,7 +149,7 @@
 # Add Network Time Protocol (NTP) support
 [sms](*\#*) (*\chrootinstall*) chrony
 # Identify master host as local NTP server
-[sms](*\#*) echo "server ${sms_ip}" >> $CHROOT/etc/chrony.conf
+[sms](*\#*) echo "server ${sms_ip} iburst" >> $CHROOT/etc/chrony.conf
 
 # Add kernel drivers (matching kernel version on SMS node)
 [sms](*\#*) (*\chrootinstall*) kernel-`uname -r`

--- a/docs/recipes/install/rocky8/x86_64/xcat/slurm/steps.tex
+++ b/docs/recipes/install/rocky8/x86_64/xcat/slurm/steps.tex
@@ -159,7 +159,7 @@ distributions. To enable additional repositories for local use, issue the follow
 # Add Network Time Protocol (NTP) support
 [sms](*\#*) (*\chrootinstall*) chrony
 # Identify master host as local NTP server
-[sms](*\#*) echo "server ${sms_ip}" >> $CHROOT/etc/chrony.conf
+[sms](*\#*) echo "server ${sms_ip} iburst" >> $CHROOT/etc/chrony.conf
 # Add kernel
 [sms](*\#*) (*\chrootinstall*) kernel
 # Include matching kernel from head node into compute image


### PR DESCRIPTION
This commit will enhance the reliability of time synchronization on compute
nodes if there's a preexisting clock difference.

By enabling the compute nodes to "iburst" on the server, it will synchronize
it's clock with headnode imediatelly after chrony (as a client) started.

To further enhance it's reliability we also mark the headnode chronyd server
as a local stratum. In an event of unproper time fetch from upstream time
servers the headnode will be the default timekeeper for it's compute nodes.

This changes modifies the behavior of software like munge, that refuses to
work if there's a significant clock skew between the server and the client.
Avoiding the cluster to be offline due to clock synchronization issues.

Signed-off-by: Vinícius Ferrão <vinicius@ferrao.net.br>