### PR TITLE
Remove leftover references to RDMA service on EL8

### DIFF
--- a/docs/recipes/install/common/ibsupport_compute_centos.tex
+++ b/docs/recipes/install/common/ibsupport_compute_centos.tex
@@ -11,7 +11,6 @@ image.
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true]
 # Add IB support and enable
 [sms](*\#*) (*\groupchrootinstall*) "InfiniBand Support"
-[sms](*\#*) chroot $CHROOT systemctl enable rdma
 \end{lstlisting}
 % ohpc_indent 0
 % ohpc_command fi

--- a/docs/recipes/install/common/opasupport_compute_centos.tex
+++ b/docs/recipes/install/common/opasupport_compute_centos.tex
@@ -9,7 +9,6 @@ support using base distro-provided drivers to the compute image.
 # Add OPA support and enable
 [sms](*\#*) (*\chrootinstall*) opa-basic-tools
 [sms](*\#*) (*\chrootinstall*) libpsm2
-[sms](*\#*) chroot $CHROOT systemctl enable rdma
 \end{lstlisting}
 % ohpc_indent 0
 % ohpc_command fi

--- a/docs/recipes/install/rocky8/x86_64/xcat/slurm/steps.tex
+++ b/docs/recipes/install/rocky8/x86_64/xcat/slurm/steps.tex
@@ -176,7 +176,6 @@ distributions. To enable additional repositories for local use, issue the follow
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true]
 # Optionally add IB support and enable
 [sms](*\#*) (*\groupchrootinstall*) "InfiniBand Support"
-[sms](*\#*) chroot $CHROOT systemctl enable rdma
 \end{lstlisting}
 % ohpc_indent 0
 % ohpc_command fi

--- a/docs/recipes/install/rocky8/x86_64/xcat_stateful/slurm/steps.tex
+++ b/docs/recipes/install/rocky8/x86_64/xcat_stateful/slurm/steps.tex
@@ -227,8 +227,6 @@ issue the following
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true]
 # Optionally add IB support and enable
 [sms](*\#*) (*\groupchrootinstall*) "InfiniBand Support"
-[sms](*\#*) psh compute systemctl enable rdma
-[sms](*\#*) psh compute systemctl start rdma
 \end{lstlisting}
 % ohpc_indent 0
 % ohpc_command fi


### PR DESCRIPTION
Additional fixes for #1347

There are still leftover references for rdma.service on EL8 for
Rocky8 and CentOS 8 on the documentation. Mainly on xCAT guides.

This commit removes those commands from documentation.

Signed-off-by: Vinícius Ferrão <vinicius@ferrao.net.br>