### PR TITLE
Use dnf instead of yum and it's plugins

### DIFF
--- a/docs/recipes/install/centos8/x86_64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/centos8/x86_64/warewulf/slurm/steps.tex
@@ -20,18 +20,18 @@
 \newcommand{\arch}{x86\_64}
 
 % Define package manager commands
-\newcommand{\pkgmgr}{yum}
+\newcommand{\pkgmgr}{dnf}
 \newcommand{\addrepo}{wget -P /etc/yum.repos.d}
 \newcommand{\chrootaddrepo}{wget -P \$CHROOT/etc/yum.repos.d}
-\newcommand{\clean}{yum clean expire-cache}
-\newcommand{\chrootclean}{yum --installroot=\$CHROOT clean expire-cache}
-\newcommand{\install}{yum -y install}
-\newcommand{\chrootinstall}{yum -y --installroot=\$CHROOT install}
-\newcommand{\groupinstall}{yum -y groupinstall}
-\newcommand{\groupchrootinstall}{yum -y --installroot=\$CHROOT groupinstall}
-\newcommand{\remove}{yum -y remove}
-\newcommand{\upgrade}{yum -y upgrade}
-\newcommand{\chrootupgrade}{yum -y --installroot=\$CHROOT upgrade}
+\newcommand{\clean}{dnf clean expire-cache}
+\newcommand{\chrootclean}{dnf --installroot=\$CHROOT clean expire-cache}
+\newcommand{\install}{dnf -y install}
+\newcommand{\chrootinstall}{dnf -y --installroot=\$CHROOT install}
+\newcommand{\groupinstall}{dnf -y groupinstall}
+\newcommand{\groupchrootinstall}{dnf -y --installroot=\$CHROOT groupinstall}
+\newcommand{\remove}{dnf -y remove}
+\newcommand{\upgrade}{dnf -y upgrade}
+\newcommand{\chrootupgrade}{dnf -y --installroot=\$CHROOT upgrade}
 \newcommand{\tftppkg}{syslinux-tftpboot}
 \newcommand{\beegfsrepo}{https://www.beegfs.io/release/beegfs\_7.2.1/dists/beegfs-rhel8.repo}
 
@@ -71,7 +71,7 @@
 % ohpc_validation_newline
 % ohpc_validation_comment Verify OpenHPC repository has been enabled before proceeding
 % ohpc_validation_newline
-% ohpc_command yum repolist | grep -q OpenHPC
+% ohpc_command dnf repolist | grep -q OpenHPC
 % ohpc_command if [ $? -ne 0 ];then
 % ohpc_command    echo "Error: OpenHPC repository must be enabled locally"
 % ohpc_command    exit 1

--- a/docs/recipes/install/common/add_to_compute_stateful_xcat_intro.tex
+++ b/docs/recipes/install/common/add_to_compute_stateful_xcat_intro.tex
@@ -51,9 +51,9 @@ of EPEL mirror.
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true]
 # Create directory holding EPEL packages
 [sms](*\#*) mkdir -p $epel_repo_dir
-[sms](*\#*) (*\install*) yum-utils createrepo
+[sms](*\#*) (*\install*) createrepo
 # Download required EPEL packages
-[sms](*\#*) yumdownloader --destdir $epel_repo_dir fping libconfuse libunwind
+[sms](*\#*) dnf download --destdir $epel_repo_dir fping libconfuse libunwind
 # Create a repository from the downloaded packages
 [sms](*\#*) createrepo $epel_repo_dir
 

--- a/docs/recipes/install/common/add_to_compute_stateful_xcat_intro.tex
+++ b/docs/recipes/install/common/add_to_compute_stateful_xcat_intro.tex
@@ -18,7 +18,7 @@ To avoid this, we disable the online repositories:
 % ohpc_comment_header Setup nodes repositories and Install OHPC components \ref{sec:add_components}
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true]
 # Install yum-utils to have yum-config-manager available
-[sms](*\#*) psh compute yum --setopt=\*.skip_if_unavailable=1 -y install yum-utils perl
+[sms](*\#*) psh compute dnf --setopt=\*.skip_if_unavailable=1 -y install yum-utils perl
 
 # Enable CentOS-PowerTools repository
 [sms](*\#*) psh compute yum-config-manager --enable PowerTools

--- a/docs/recipes/install/common/add_to_compute_stateful_xcat_intro.tex
+++ b/docs/recipes/install/common/add_to_compute_stateful_xcat_intro.tex
@@ -17,11 +17,8 @@ To avoid this, we disable the online repositories:
 % begin_ohpc_run
 % ohpc_comment_header Setup nodes repositories and Install OHPC components \ref{sec:add_components}
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true]
-# Install yum-utils to have yum-config-manager available
-[sms](*\#*) psh compute dnf --setopt=\*.skip_if_unavailable=1 -y install yum-utils perl
-
 # Enable CentOS-PowerTools repository
-[sms](*\#*) psh compute yum-config-manager --enable PowerTools
+[sms](*\#*) psh compute dnf config-manager --enable PowerTools
 \end{lstlisting}
 % end_ohpc_run
 
@@ -31,7 +28,7 @@ setup in on the SMS in \S\ref{sec:enable_repo}
 % begin_ohpc_run
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true]
 # Add OpenHPC repo mirror hosted on SMS
-[sms](*\#*) psh compute yum-config-manager --add-repo=http://$sms_ip/$ohpc_repo_dir/OpenHPC.local.repo
+[sms](*\#*) psh compute dnf config-manager --add-repo=http://$sms_ip/$ohpc_repo_dir/OpenHPC.local.repo
 # Replace local path with SMS URL
 [sms](*\#*) psh compute "perl -pi -e 's/file:\/\/\@PATH\@/http:\/\/$sms_ip\/"${ohpc_repo_dir//\//"\/"}"/s' \
         /etc/yum.repos.d/OpenHPC.local.repo"
@@ -61,7 +58,7 @@ of EPEL mirror.
 [sms](*\#*) createrepo $epel_repo_dir
 
 # Setup access to the repo from the compute hosts
-[sms](*\#*) psh compute yum-config-manager --add-repo=http://$sms_ip/$epel_repo_dir
+[sms](*\#*) psh compute dnf config-manager --add-repo=http://$sms_ip/$epel_repo_dir
 [sms](*\#*) psh compute "echo gpgcheck=0 >> /etc/yum.repos.d/${sms_ip}_"${epel_repo_dir//\//"_"}.repo
 \end{lstlisting}
 % end_ohpc_run

--- a/docs/recipes/install/common/centos_repos.tex
+++ b/docs/recipes/install/common/centos_repos.tex
@@ -20,6 +20,6 @@ enabled by default.  In contrast, the CentOS PowerTools repository is typically
 disabled in a standard install, but can be enabled as follows:
 
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true]
-[sms](*\#*) yum install dnf-plugins-core
-[sms](*\#*) yum config-manager --set-enabled powertools
+[sms](*\#*) dnf install dnf-plugins-core
+[sms](*\#*) dnf config-manager --set-enabled powertools
 \end{lstlisting}

--- a/docs/recipes/install/common/enable_ohpc_repo.tex
+++ b/docs/recipes/install/common/enable_ohpc_repo.tex
@@ -11,7 +11,7 @@ package directly from the \OHPC{} build server.
 % CentOS
 \begin{lstlisting}[language=bash,keywords={},basicstyle=\fontencoding{T1}\fontsize{7.6}{10}\ttfamily,
 	literate={VER}{\OHPCVerTree{}}1 {OSREPO}{\OSTree{}}1 {TAG}{\OSTag{}}1 {ARCH}{\arch{}}1 {-}{-}1]
-[sms](*\#*) yum install http://repos.openhpc.community/OpenHPC/VER/OSREPO/ARCH/ohpc-release-VER-1.TAG.ARCH.rpm
+[sms](*\#*) dnf install http://repos.openhpc.community/OpenHPC/VER/OSREPO/ARCH/ohpc-release-VER-1.TAG.ARCH.rpm
 \end{lstlisting}
 \else
 % non-CentOS

--- a/docs/recipes/install/common/enable_xcat_repo.tex
+++ b/docs/recipes/install/common/enable_xcat_repo.tex
@@ -13,7 +13,6 @@ the repository be mirrored locally. In this case, we use the network.
 % ohpc_comment_header Enable xCAT repositories \ref{sec:enable_xcat}
 \begin{lstlisting}[language=bash,keywords={},basicstyle=\fontencoding{T1}\fontsize{8.0}{10}\ttfamily,
 	literate={VER}{\OHPCVerTree{}}1 {OSREPO}{\OSTree{}}1 {TAG}{\OSTag{}}1 {ARCH}{\arch{}}1 {-}{-}1]
-[sms](*\#*) (*\install*) yum-utils
 [sms](*\#*) (*\addrepo*) https://xcat.org/files/xcat/repos/yum/latest/xcat-core/xcat-core.repo
 \end{lstlisting}
 % end_ohpc_run

--- a/docs/recipes/install/common/rebuild_from_source_centos.tex
+++ b/docs/recipes/install/common/rebuild_from_source_centos.tex
@@ -21,7 +21,7 @@ co-installation and use.
 [test@sms ~]$ sudo yum-builddep fftw-gnu9-openmpi4-ohpc
 
 # Download SRPM from OpenHPC repository and install locally
-[test@sms ~]$ yumdownloader --source fftw-gnu9-openmpi4-ohpc
+[test@sms ~]$ dnf download --source fftw-gnu9-openmpi4-ohpc
 [test@sms ~]$ rpm -i ./fftw-gnu9-openmpi4-ohpc-3.3.8-5.1.ohpc.2.0.src.rpm
 
 # Modify spec file as desired

--- a/docs/recipes/install/common/rebuild_from_source_centos.tex
+++ b/docs/recipes/install/common/rebuild_from_source_centos.tex
@@ -15,10 +15,10 @@ co-installation and use.
 \begin{lstlisting}[language=bash,keywords={},basicstyle=\fontencoding{T1}\footnotesize\ttfamily,
     literate={ARCH}{\arch{}}1 {-}{-}1]
 # Install rpm-build package and dnf tools from base OS distro
-[test@sms ~]$ sudo (*\install*) rpm-build yum-utils
+[test@sms ~]$ sudo (*\install*) rpm-build
 
 # Install FFTW's build dependencies
-[test@sms ~]$ sudo yum-builddep fftw-gnu9-openmpi4-ohpc
+[test@sms ~]$ sudo dnf builddep fftw-gnu9-openmpi4-ohpc
 
 # Download SRPM from OpenHPC repository and install locally
 [test@sms ~]$ dnf download --source fftw-gnu9-openmpi4-ohpc

--- a/docs/recipes/install/common/rebuild_from_source_centos.tex
+++ b/docs/recipes/install/common/rebuild_from_source_centos.tex
@@ -7,14 +7,14 @@ flags and MPI family. A brief example using
 the FFTW library is highlighted below.  Note that the source RPMs can be downloaded from the
 community repository server at \href{http://repos.openhpc.community}
 {\color{blue}{http://repos.openhpc.community}} via a web browser or directly
-via \texttt{yum} as highlighted below. In this example we make an explicit
+via \texttt{dnf} as highlighted below. In this example we make an explicit
 change to FFTW's configuration, as well as modifying the CFLAGS environment
 variable. The package is also tagged with an additional delimiter to allow easy
 co-installation and use. 
 
 \begin{lstlisting}[language=bash,keywords={},basicstyle=\fontencoding{T1}\footnotesize\ttfamily,
     literate={ARCH}{\arch{}}1 {-}{-}1]
-# Install rpm-build package and yum tools from base OS distro
+# Install rpm-build package and dnf tools from base OS distro
 [test@sms ~]$ sudo (*\install*) rpm-build yum-utils
 
 # Install FFTW's build dependencies

--- a/docs/recipes/install/common/rebuild_from_source_centos.tex
+++ b/docs/recipes/install/common/rebuild_from_source_centos.tex
@@ -14,7 +14,7 @@ co-installation and use.
 
 \begin{lstlisting}[language=bash,keywords={},basicstyle=\fontencoding{T1}\footnotesize\ttfamily,
     literate={ARCH}{\arch{}}1 {-}{-}1]
-# Install rpm-build package and dnf tools from base OS distro
+# Install rpm-build package from base OS distro
 [test@sms ~]$ sudo (*\install*) rpm-build
 
 # Install FFTW's build dependencies

--- a/docs/recipes/install/common/rebuild_from_source_centos.tex.bak
+++ b/docs/recipes/install/common/rebuild_from_source_centos.tex.bak
@@ -7,7 +7,7 @@ flags and MPI family. A brief example using
 the FFTW library is highlighted below.  Note that the source RPMs can be downloaded from the
 community build server at \href{https://build.openhpc.community}
 {\color{blue}{https://build.openhpc.community}} via a web browser or directly
-via \texttt{yum} as highlighted below. In this example we make an explicit
+via \texttt{dnf} as highlighted below. In this example we make an explicit
 change to FFTW's configuration, as well as modifying the CFLAGS environment
 variable. The package is also tagged with an aditional delimiter to allow easy
 co-installation and use. 

--- a/docs/recipes/install/common/rebuild_from_source_centos.tex.bak
+++ b/docs/recipes/install/common/rebuild_from_source_centos.tex.bak
@@ -21,7 +21,7 @@ co-installation and use.
 [test@sms ~]$ sudo yum-builddep fftw-gnu9-openmpi4-ohpc
 
 # Download SRPM from OpenHPC repository and install locally
-[test@sms ~]$ yumdownloader --source fftw-gnu9-openmpi4-ohpc
+[test@sms ~]$ dnf download --source fftw-gnu9-openmpi4-ohpc
 [test@sms ~]$ rpm -i ./fftw-gnu9-openmpi4-ohpc-3.3.8-5.1.ohpc.2.0.src.rpm
 
 # Modify spec file as desired

--- a/docs/recipes/install/common/rebuild_from_source_centos.tex.bak
+++ b/docs/recipes/install/common/rebuild_from_source_centos.tex.bak
@@ -14,11 +14,11 @@ co-installation and use.
 
 \begin{lstlisting}[language=bash,keywords={},basicstyle=\fontencoding{T1}\footnotesize\ttfamily,
     literate={ARCH}{\arch{}}1 {-}{-}1]
-# Install rpm-build package and yum tools from base OS distro
-[test@sms ~]$ sudo (*\install*) rpm-build yum-utils
+# Install rpm-build package from base OS distro
+[test@sms ~]$ sudo (*\install*) rpm-build
 
 # Install FFTW's build dependencies
-[test@sms ~]$ sudo yum-builddep fftw-gnu9-openmpi4-ohpc
+[test@sms ~]$ sudo dnf builddep fftw-gnu9-openmpi4-ohpc
 
 # Download SRPM from OpenHPC repository and install locally
 [test@sms ~]$ dnf download --source fftw-gnu9-openmpi4-ohpc

--- a/docs/recipes/install/common/rocky_repos.tex
+++ b/docs/recipes/install/common/rocky_repos.tex
@@ -20,6 +20,6 @@ enabled by default.  In contrast, the PowerTools repository is typically
 disabled in a standard install, but can be enabled from EPEL as follows:
 
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true]
-[sms](*\#*) yum install dnf-plugins-core
-[sms](*\#*) yum config-manager --set-enabled powertools
+[sms](*\#*) dnf install dnf-plugins-core
+[sms](*\#*) dnf config-manager --set-enabled powertools
 \end{lstlisting}

--- a/docs/recipes/install/common/third_party_libs_petsc_centos.tex
+++ b/docs/recipes/install/common/third_party_libs_petsc_centos.tex
@@ -1,6 +1,6 @@
 \iftoggleverb{isx86}
 \begin{lstlisting}[language=bash,keywords={}]
-[sms](*\#*) yum search petsc-gnu9 ohpc
+[sms](*\#*) dnf search petsc-gnu9 ohpc
 Loaded plugins: fastestmirror
 Loading mirror speeds from cached hostfile
 =========================== N/S matched: petsc-gnu9, ohpc ===========================
@@ -13,7 +13,7 @@ petsc-gnu9-openmpi4-ohpc.x86_64 : Portable Extensible Toolkit for Scientific Com
 
 \iftoggleverb{isaarch}
 \begin{lstlisting}[language=bash,keywords={}]
-[sms](*\#*) yum search petsc-gnu9 ohpc
+[sms](*\#*) dnf search petsc-gnu9 ohpc
 Loaded plugins: fastestmirror
 Loading mirror speeds from cached hostfile
 =========================== N/S matched: petsc-gnu9, ohpc ===========================

--- a/docs/recipes/install/rocky8/aarch64/warewulf/openpbs/steps.tex
+++ b/docs/recipes/install/rocky8/aarch64/warewulf/openpbs/steps.tex
@@ -20,18 +20,18 @@
 \newcommand{\arch}{aarch64}
 
 % Define package manager commands
-\newcommand{\pkgmgr}{yum}
+\newcommand{\pkgmgr}{dnf}
 \newcommand{\addrepo}{wget -P /etc/yum.repos.d}
 \newcommand{\chrootaddrepo}{wget -P \$CHROOT/etc/yum.repos.d}
-\newcommand{\clean}{yum clean expire-cache}
-\newcommand{\chrootclean}{yum --installroot=\$CHROOT clean expire-cache}
-\newcommand{\install}{yum -y install}
-\newcommand{\chrootinstall}{yum -y --installroot=\$CHROOT install}
-\newcommand{\groupinstall}{yum -y groupinstall}
-\newcommand{\groupchrootinstall}{yum -y --installroot=\$CHROOT groupinstall}
-\newcommand{\remove}{yum -y remove}
-\newcommand{\upgrade}{yum -y upgrade}
-\newcommand{\chrootupgrade}{yum -y --installroot=\$CHROOT upgrade}
+\newcommand{\clean}{dnf clean expire-cache}
+\newcommand{\chrootclean}{dnf --installroot=\$CHROOT clean expire-cache}
+\newcommand{\install}{dnf -y install}
+\newcommand{\chrootinstall}{dnf -y --installroot=\$CHROOT install}
+\newcommand{\groupinstall}{dnf -y groupinstall}
+\newcommand{\groupchrootinstall}{dnf -y --installroot=\$CHROOT groupinstall}
+\newcommand{\remove}{dnf -y remove}
+\newcommand{\upgrade}{dnf -y upgrade}
+\newcommand{\chrootupgrade}{dnf -y --installroot=\$CHROOT upgrade}
 \newcommand{\tftppkg}{syslinux-tftpboot}
 
 % boolean for os-specific formatting
@@ -70,7 +70,7 @@
 % ohpc_validation_newline
 % ohpc_validation_comment Verify OpenHPC repository has been enabled before proceeding
 % ohpc_validation_newline
-% ohpc_command yum repolist | grep -q OpenHPC
+% ohpc_command dnf repolist | grep -q OpenHPC
 % ohpc_command if [ $? -ne 0 ];then
 % ohpc_command    echo "Error: OpenHPC repository must be enabled locally"
 % ohpc_command    exit 1

--- a/docs/recipes/install/rocky8/aarch64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/rocky8/aarch64/warewulf/slurm/steps.tex
@@ -20,18 +20,18 @@
 \newcommand{\arch}{aarch64}
 
 % Define package manager commands
-\newcommand{\pkgmgr}{yum}
+\newcommand{\pkgmgr}{dnf}
 \newcommand{\addrepo}{wget -P /etc/yum.repos.d}
 \newcommand{\chrootaddrepo}{wget -P \$CHROOT/etc/yum.repos.d}
-\newcommand{\clean}{yum clean expire-cache}
-\newcommand{\chrootclean}{yum --installroot=\$CHROOT clean expire-cache}
-\newcommand{\install}{yum -y install}
-\newcommand{\chrootinstall}{yum -y --installroot=\$CHROOT install}
-\newcommand{\groupinstall}{yum -y groupinstall}
-\newcommand{\groupchrootinstall}{yum -y --installroot=\$CHROOT groupinstall}
-\newcommand{\remove}{yum -y remove}
-\newcommand{\upgrade}{yum -y upgrade}
-\newcommand{\chrootupgrade}{yum -y --installroot=\$CHROOT upgrade}
+\newcommand{\clean}{dnf clean expire-cache}
+\newcommand{\chrootclean}{dnf --installroot=\$CHROOT clean expire-cache}
+\newcommand{\install}{dnf -y install}
+\newcommand{\chrootinstall}{dnf -y --installroot=\$CHROOT install}
+\newcommand{\groupinstall}{dnf -y groupinstall}
+\newcommand{\groupchrootinstall}{dnf -y --installroot=\$CHROOT groupinstall}
+\newcommand{\remove}{dnf -y remove}
+\newcommand{\upgrade}{dnf -y upgrade}
+\newcommand{\chrootupgrade}{dnf -y --installroot=\$CHROOT upgrade}
 \newcommand{\tftppkg}{syslinux-tftpboot}
 
 % boolean for os-specific formatting
@@ -70,7 +70,7 @@
 % ohpc_validation_newline
 % ohpc_validation_comment Verify OpenHPC repository has been enabled before proceeding
 % ohpc_validation_newline
-% ohpc_command yum repolist | grep -q OpenHPC
+% ohpc_command dnf repolist | grep -q OpenHPC
 % ohpc_command if [ $? -ne 0 ];then
 % ohpc_command    echo "Error: OpenHPC repository must be enabled locally"
 % ohpc_command    exit 1

--- a/docs/recipes/install/rocky8/x86_64/warewulf/openpbs/steps.tex
+++ b/docs/recipes/install/rocky8/x86_64/warewulf/openpbs/steps.tex
@@ -20,18 +20,18 @@
 \newcommand{\arch}{x86\_64}
 
 % Define package manager commands
-\newcommand{\pkgmgr}{yum}
+\newcommand{\pkgmgr}{dnf}
 \newcommand{\addrepo}{wget -P /etc/yum.repos.d}
 \newcommand{\chrootaddrepo}{wget -P \$CHROOT/etc/yum.repos.d}
-\newcommand{\clean}{yum clean expire-cache}
-\newcommand{\chrootclean}{yum --installroot=\$CHROOT clean expire-cache}
-\newcommand{\install}{yum -y install}
-\newcommand{\chrootinstall}{yum -y --installroot=\$CHROOT install}
-\newcommand{\groupinstall}{yum -y groupinstall}
-\newcommand{\groupchrootinstall}{yum -y --installroot=\$CHROOT groupinstall}
-\newcommand{\remove}{yum -y remove}
-\newcommand{\upgrade}{yum -y upgrade}
-\newcommand{\chrootupgrade}{yum -y --installroot=\$CHROOT upgrade}
+\newcommand{\clean}{dnf clean expire-cache}
+\newcommand{\chrootclean}{dnf --installroot=\$CHROOT clean expire-cache}
+\newcommand{\install}{dnf -y install}
+\newcommand{\chrootinstall}{dnf -y --installroot=\$CHROOT install}
+\newcommand{\groupinstall}{dnf -y groupinstall}
+\newcommand{\groupchrootinstall}{dnf -y --installroot=\$CHROOT groupinstall}
+\newcommand{\remove}{dnf -y remove}
+\newcommand{\upgrade}{dnf -y upgrade}
+\newcommand{\chrootupgrade}{dnf -y --installroot=\$CHROOT upgrade}
 \newcommand{\tftppkg}{syslinux-tftpboot}
 \newcommand{\beegfsrepo}{https://www.beegfs.io/release/beegfs\_7.2.1/dists/beegfs-rhel8.repo}
 
@@ -72,7 +72,7 @@
 % ohpc_validation_newline
 % ohpc_validation_comment Verify OpenHPC repository has been enabled before proceeding
 % ohpc_validation_newline
-% ohpc_command yum repolist | grep -q OpenHPC
+% ohpc_command dnf repolist | grep -q OpenHPC
 % ohpc_command if [ $? -ne 0 ];then
 % ohpc_command    echo "Error: OpenHPC repository must be enabled locally"
 % ohpc_command    exit 1

--- a/docs/recipes/install/rocky8/x86_64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/rocky8/x86_64/warewulf/slurm/steps.tex
@@ -20,18 +20,18 @@
 \newcommand{\arch}{x86\_64}
 
 % Define package manager commands
-\newcommand{\pkgmgr}{yum}
+\newcommand{\pkgmgr}{dnf}
 \newcommand{\addrepo}{wget -P /etc/yum.repos.d}
 \newcommand{\chrootaddrepo}{wget -P \$CHROOT/etc/yum.repos.d}
-\newcommand{\clean}{yum clean expire-cache}
-\newcommand{\chrootclean}{yum --installroot=\$CHROOT clean expire-cache}
-\newcommand{\install}{yum -y install}
-\newcommand{\chrootinstall}{yum -y --installroot=\$CHROOT install}
-\newcommand{\groupinstall}{yum -y groupinstall}
-\newcommand{\groupchrootinstall}{yum -y --installroot=\$CHROOT groupinstall}
-\newcommand{\remove}{yum -y remove}
-\newcommand{\upgrade}{yum -y upgrade}
-\newcommand{\chrootupgrade}{yum -y --installroot=\$CHROOT upgrade}
+\newcommand{\clean}{dnf clean expire-cache}
+\newcommand{\chrootclean}{dnf --installroot=\$CHROOT clean expire-cache}
+\newcommand{\install}{dnf -y install}
+\newcommand{\chrootinstall}{dnf -y --installroot=\$CHROOT install}
+\newcommand{\groupinstall}{dnf -y groupinstall}
+\newcommand{\groupchrootinstall}{dnf -y --installroot=\$CHROOT groupinstall}
+\newcommand{\remove}{dnf -y remove}
+\newcommand{\upgrade}{dnf -y upgrade}
+\newcommand{\chrootupgrade}{dnf -y --installroot=\$CHROOT upgrade}
 \newcommand{\tftppkg}{syslinux-tftpboot}
 \newcommand{\beegfsrepo}{https://www.beegfs.io/release/beegfs\_7.2.1/dists/beegfs-rhel8.repo}
 
@@ -71,7 +71,7 @@
 % ohpc_validation_newline
 % ohpc_validation_comment Verify OpenHPC repository has been enabled before proceeding
 % ohpc_validation_newline
-% ohpc_command yum repolist | grep -q OpenHPC
+% ohpc_command dnf repolist | grep -q OpenHPC
 % ohpc_command if [ $? -ne 0 ];then
 % ohpc_command    echo "Error: OpenHPC repository must be enabled locally"
 % ohpc_command    exit 1

--- a/docs/recipes/install/rocky8/x86_64/xcat/slurm/steps.tex
+++ b/docs/recipes/install/rocky8/x86_64/xcat/slurm/steps.tex
@@ -165,7 +165,7 @@ distributions. To enable additional repositories for local use, issue the follow
 # Include matching kernel from head node into compute image
 [sms](*\#*) genimage BOSSHORT-ARCH-netboot-compute -k `uname -r`
 # Re-enable BaseOS repo
-[sms](*\#*) yum-config-manager --installroot=$CHROOT --enable BaseOS
+[sms](*\#*) dnf config-manager --installroot=$CHROOT --enable BaseOS
 # Include modules user environment
 [sms](*\#*) (*\chrootinstall*)  --enablerepo=powertools lmod-ohpc
 \end{lstlisting}

--- a/docs/recipes/install/rocky8/x86_64/xcat/slurm/steps.tex
+++ b/docs/recipes/install/rocky8/x86_64/xcat/slurm/steps.tex
@@ -21,18 +21,18 @@
 \newcommand{\installimage}{netboot}
 
 % Define package manager commands
-\newcommand{\pkgmgr}{yum}
+\newcommand{\pkgmgr}{dnf}
 \newcommand{\addrepo}{wget -P /etc/yum.repos.d}
 \newcommand{\chrootaddrepo}{wget -P \$CHROOT/etc/yum.repos.d}
-\newcommand{\clean}{yum clean expire-cache}
-\newcommand{\chrootclean}{yum --installroot=\$CHROOT clean expire-cache}
-\newcommand{\install}{yum -y install}
-\newcommand{\chrootinstall}{yum -y --installroot=\$CHROOT install}
-\newcommand{\groupinstall}{yum -y groupinstall}
-\newcommand{\groupchrootinstall}{yum -y --installroot=\$CHROOT groupinstall}
-\newcommand{\remove}{yum -y remove}
-\newcommand{\upgrade}{yum -y upgrade}
-\newcommand{\chrootupgrade}{yum -y --installroot=\$CHROOT upgrade}
+\newcommand{\clean}{dnf clean expire-cache}
+\newcommand{\chrootclean}{dnf --installroot=\$CHROOT clean expire-cache}
+\newcommand{\install}{dnf -y install}
+\newcommand{\chrootinstall}{dnf -y --installroot=\$CHROOT install}
+\newcommand{\groupinstall}{dnf -y groupinstall}
+\newcommand{\groupchrootinstall}{dnf -y --installroot=\$CHROOT groupinstall}
+\newcommand{\remove}{dnf -y remove}
+\newcommand{\upgrade}{dnf -y upgrade}
+\newcommand{\chrootupgrade}{dnf -y --installroot=\$CHROOT upgrade}
 \newcommand{\tftppkg}{syslinux-tftpboot}
 \newcommand{\beegfsrepo}{https://www.beegfs.io/release/beegfs\_7.2.1/dists/beegfs-rhel8.repo}
 
@@ -72,7 +72,7 @@
 % ohpc_validation_newline
 % ohpc_validation_comment Verify OpenHPC repository has been enabled before proceeding
 % ohpc_validation_newline
-% ohpc_command yum repolist | grep -q OpenHPC
+% ohpc_command dnf repolist | grep -q OpenHPC
 % ohpc_command if [ $? -ne 0 ];then
 % ohpc_command    echo "Error: OpenHPC repository must be enabled locally"
 % ohpc_command    exit 1

--- a/docs/recipes/install/rocky8/x86_64/xcat_stateful/slurm/steps.tex
+++ b/docs/recipes/install/rocky8/x86_64/xcat_stateful/slurm/steps.tex
@@ -25,18 +25,18 @@
 \newcommand{\VERLONG}{2.0}
 
 % Define package manager commands
-\newcommand{\pkgmgr}{yum}
+\newcommand{\pkgmgr}{dnf}
 \newcommand{\addrepo}{wget -P /etc/yum.repos.d}
 \newcommand{\chrootaddrepo}{wget -P \$CHROOT/etc/yum.repos.d}
-\newcommand{\clean}{yum clean expire-cache}
-\newcommand{\chrootclean}{yum --installroot=\$CHROOT clean expire-cache}
-\newcommand{\install}{yum -y install}
-\newcommand{\chrootinstall}{psh compute yum -y install}
-\newcommand{\groupinstall}{yum -y groupinstall}
-\newcommand{\groupchrootinstall}{psh compute yum -y groupinstall}
-\newcommand{\remove}{yum -y remove}
-\newcommand{\upgrade}{yum -y upgrade}
-\newcommand{\chrootupgrade}{yum -y --installroot=\$CHROOT upgrade}
+\newcommand{\clean}{dnf clean expire-cache}
+\newcommand{\chrootclean}{dnf --installroot=\$CHROOT clean expire-cache}
+\newcommand{\install}{dnf -y install}
+\newcommand{\chrootinstall}{psh compute dnf -y install}
+\newcommand{\groupinstall}{dnf -y groupinstall}
+\newcommand{\groupchrootinstall}{psh compute dnf -y groupinstall}
+\newcommand{\remove}{dnf -y remove}
+\newcommand{\upgrade}{dnf -y upgrade}
+\newcommand{\chrootupgrade}{dnf -y --installroot=\$CHROOT upgrade}
 \newcommand{\tftppkg}{syslinux-tftpboot}
 \newcommand{\beegfsrepo}{https://www.beegfs.io/release/beegfs\_7.2.1/dists/beegfs-rhel8.repo}
 
@@ -143,7 +143,7 @@ distributions. To enable for local use, issue the following:
 % ohpc_validation_newline
 % ohpc_validation_comment Verify OpenHPC repository has been enabled before proceeding
 % ohpc_validation_newline
-% ohpc_command yum repolist | grep -q OpenHPC
+% ohpc_command dnf repolist | grep -q OpenHPC
 % ohpc_command if [ $? -ne 0 ];then
 % ohpc_command    echo "Error: OpenHPC repository must be enabled locally"
 % ohpc_command    exit 1


### PR DESCRIPTION
This PR is aimed to replace `yum` and it's utilities: `yumdownloader`, `yum-config-manager` and `yum-builddep` in favor of `dnf` which is the default package manager command on EL8 and upwards.