### PR TITLE
Remove python2-xml dependency from OpenPBS

### DIFF
--- a/components/rms/openpbs/SPECS/openpbs.spec
+++ b/components/rms/openpbs/SPECS/openpbs.spec
@@ -94,7 +94,6 @@ BuildRequires: libXext-devel
 BuildRequires: libXft-devel
 BuildRequires: fontconfig
 BuildRequires: timezone
-#BuildRequires: python-xml
 %else
 BuildRequires: expat-devel
 BuildRequires: openssl-devel

--- a/components/rms/openpbs/SPECS/openpbs.spec
+++ b/components/rms/openpbs/SPECS/openpbs.spec
@@ -94,7 +94,7 @@ BuildRequires: libXext-devel
 BuildRequires: libXft-devel
 BuildRequires: fontconfig
 BuildRequires: timezone
-BuildRequires: python-xml
+#BuildRequires: python-xml
 %else
 BuildRequires: expat-devel
 BuildRequires: openssl-devel


### PR DESCRIPTION
Signed-off-by: jcsiadal <jeremy.c.siadal@intel.com>

OpenSUSE 15.4 removes Python 2 support. I can't see any reason for including this build dependency, as it still builds without it (artifact from old version?).