### PR TITLE
ci: use jitterbit/get-changed-files@v1

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,9 +16,11 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+    - id: files
+      uses: jitterbit/get-changed-files@v1
     - name: Validate Changes
       run: |
-        tests/ci/check_spec.py ${{ github.event.before }}..${{ github.event.after }}
+        tests/ci/check_spec.py ${{ steps.files.outputs.all }}
 
 
   build:
@@ -34,7 +36,9 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+    - id: files
+      uses: jitterbit/get-changed-files@v1
     - name: Validate Build
       run: |
         . /etc/profile.d/lmod.sh
-        tests/ci/run_build.py ${{ github.event.before }}..${{ github.event.after }}
+        tests/ci/run_build.py ${{ steps.files.outputs.all }}

--- a/components/dev-tools/spack/SPECS/spack.spec
+++ b/components/dev-tools/spack/SPECS/spack.spec
@@ -25,7 +25,6 @@ Source0:	https://github.com/LLNL/%{pname}/archive/v%{version}.tar.gz
 BuildRequires: rsync
 BuildRequires: python3
 Requires: bash
-Requires: curl
 Requires: coreutils
 Requires: subversion
 Requires: hg

--- a/tests/ci/check_spec.py
+++ b/tests/ci/check_spec.py
@@ -31,15 +31,9 @@ regex_required = [
     '(^URL:.*$|Url:.*$)',
     ]
 
-if len(sys.argv) != 2:
-    print("SKIP. Needs a git range as parameter")
+if len(sys.argv) <= 1:
+    print("SKIP. Needs a list of files to check")
     sys.exit(0)
-
-command = ['git', 'diff', '--diff-filter=ACMRTUXB', '--name-only', sys.argv[1]]
-
-print("About to run command %s" % ' '.join(command))
-
-result = subprocess.run(command, stdout=subprocess.PIPE)
 
 regex_wrong_string = '(' + '|'.join(regex_wrong) + ')'
 
@@ -47,13 +41,10 @@ print("Checking that %s does not exist" % regex_wrong_string)
 
 pattern = re.compile(regex_wrong_string)
 
-if result.returncode != 0:
-    sys.exit(1)
-
 error = False
 spec_found = False
 
-for spec in result.stdout.decode('utf-8').split('\n'):
+for spec in sys.argv[1:]:
     if not spec.endswith('.spec'):
         continue
     spec_found = True

--- a/tests/ci/run_build.py
+++ b/tests/ci/run_build.py
@@ -7,25 +7,9 @@ import os
 
 logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
 
-if len(sys.argv) != 2:
-    logging.info("SKIP. Needs a git range as parameter")
+if len(sys.argv) <= 1:
+    print("SKIP. Needs a list of files to check")
     sys.exit(0)
-
-command = [
-    'git',
-    'diff',
-    '--diff-filter=ACMRTUXB',
-    '--name-only',
-    sys.argv[1],
-]
-
-logging.info("About to run command %s" % ' '.join(command))
-
-result = subprocess.run(command, stdout=subprocess.PIPE)
-
-if result.returncode != 0:
-    logging.info("Running git failed with %s" % result)
-    sys.exit(1)
 
 error = False
 spec_found = False
@@ -107,7 +91,7 @@ def build_srpm_and_rpm(command, family=None):
     return True
 
 
-for spec in result.stdout.decode('utf-8').split('\n'):
+for spec in sys.argv[1:]:
     if not spec.endswith('.spec'):
         continue
     spec_found = True


### PR DESCRIPTION
jitterbit/get-changed-files@v1 provides an easier way to figure out the changed files in a pull request. Let's switch to this for better CI results.
