### PR TITLE
ci: only run checks/builds on added and modified files

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,7 +20,7 @@ jobs:
       uses: jitterbit/get-changed-files@v1
     - name: Validate Changes
       run: |
-        tests/ci/check_spec.py ${{ steps.files.outputs.all }}
+        tests/ci/check_spec.py ${{ steps.files.outputs.added_modified }}
 
 
   build:
@@ -41,4 +41,4 @@ jobs:
     - name: Validate Build
       run: |
         . /etc/profile.d/lmod.sh
-        tests/ci/run_build.py ${{ steps.files.outputs.all }}
+        tests/ci/run_build.py ${{ steps.files.outputs.added_modified }}


### PR DESCRIPTION
The newly introduced GitHub Action to figure which files have changed does also have the target 'added_modified' which only lists added and modified files and not deleted files. It does not make much sense to run checks again deleted files in our case.

@jcsiadal This should fix the problems you had in #1327