### PR TITLE
warewulf-provision build fix for SUSE 15.4+

### DIFF
--- a/components/provisioning/warewulf-provision/SPECS/warewulf-provision.spec
+++ b/components/provisioning/warewulf-provision/SPECS/warewulf-provision.spec
@@ -42,6 +42,7 @@ Conflicts: warewulf < 3
 BuildRequires: autoconf
 BuildRequires: automake, make
 BuildRequires: which
+BuildRequires: gcc
 BuildRequires: warewulf-common%{PROJ_DELIM}
 BuildRequires: libselinux-devel, libacl-devel, libattr-devel
 BuildRequires: libuuid-devel, device-mapper-devel, xz-devel

--- a/components/provisioning/warewulf-provision/SPECS/warewulf-provision.spec
+++ b/components/provisioning/warewulf-provision/SPECS/warewulf-provision.spec
@@ -40,7 +40,7 @@ Requires: perl-CGI
 Requires: %{name}-initramfs-%{_arch} = %{version}-%{release}
 Conflicts: warewulf < 3
 BuildRequires: autoconf
-BuildRequires: automake
+BuildRequires: automake, make
 BuildRequires: which
 BuildRequires: warewulf-common%{PROJ_DELIM}
 BuildRequires: libselinux-devel, libacl-devel, libattr-devel


### PR DESCRIPTION
Signed-off-by: jcsiadal <jeremy.c.siadal@intel.com>

Busybox source in WW3 will not build against newer glibc. This works around the issue by using the Busybox included with OpenSUSE.

Changes the specfile to use the SUSE release virtual package, allowing this package to also build on SLED and SLES.
