### PR TITLE
misc: do not hardcode 'rhel' to '7'

### DIFF
--- a/misc/shell-functions
+++ b/misc/shell-functions
@@ -25,7 +25,7 @@ build_srpm() {
 	local DIR=`dirname ${1}`
 	local MPI_FAMILY=${2}
 
-	SRPM=`rpmbuild -bs --nodeps --define "_sourcedir ${DIR}/../SOURCES" --define 'rhel 7' --define "mpi_family ${MPI_FAMILY}" --undefine 'fedora' ${SPEC}`
+	SRPM=`rpmbuild -bs --nodeps --define "_sourcedir ${DIR}/../SOURCES" --define "mpi_family ${MPI_FAMILY}" ${SPEC}`
 	RESULT=$?
 
 	echo ${SRPM} | tail -1 | awk -F\  '{ print $2 }'


### PR DESCRIPTION
During SRPM creation the define 'rhel' was hard-coded to '7' which does not really make sense. Just use the values of the underlying operating system.