### PR TITLE
Relocate software licenses under /opt/ohpc

### DIFF
--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -35,6 +35,7 @@
 # possibility of coinstall of multiple package versions)
 DocDir:    %{OHPC_PUB}/doc/contrib
 %global _docdir_fmt     %{name}-%{version}
+%global _licensedir     %{OHPC_PUB}/doc/licenses
 
 # Define PNAME which can be used in modulefile generation for env vars (derived
 # from pname defined in each component .spec file)


### PR DESCRIPTION
The use of %license is now required by the major distros for RPMs. We need to move license files from %doc to %license.

As the first step, this will place licenses in the /opt/ohpc/pub/doc/licenses folder. Current packages that use the %license tag place files in /usr/share.

We should also consider failing spec validation if a %license macro isn't found.

Signed-off-by: jcsiadal <jeremy.c.siadal@intel.com>