### PR TITLE
Additional changes for GNU12 update

### DIFF
--- a/components/dev-tools/scipy/SPECS/python-scipy.spec
+++ b/components/dev-tools/scipy/SPECS/python-scipy.spec
@@ -14,8 +14,6 @@
 %define ohpc_python_dependent 1
 %include %{_sourcedir}/OHPC_macros
 
-%global gnu_family gnu9
-
 %if "%{compiler_family}" != "intel" && "%{compiler_family}" != "arm"
 BuildRequires: openblas-%{compiler_family}%{PROJ_DELIM}
 Requires: openblas-%{compiler_family}%{PROJ_DELIM}

--- a/components/mpi-families/mpich/SPECS/mpich.spec
+++ b/components/mpi-families/mpich/SPECS/mpich.spec
@@ -109,16 +109,11 @@ module load ucx
 module load libfabric
 %endif
 
-%if "%{compiler_family}" == "gnu12"
-# configure fails with:
-#   The Fortran compiler gfortran does not accept programs that
-#   call the same routine with arguments of different types without
-#   the option -fallow-argument-mismatch.
-#   Rerun configure with FFLAGS=-fallow-argument-mismatch
-# This seems to fix the build.
-export FFLAGS=-fallow-argument-mismatch
-%endif
-./configure --prefix=%{install_path} \
+./configure \
+%if %{compiler_family} == "gnu12"
+        FFLAGS="$FFLAGS -fallow-argument-mismatch" \
+%endif 
+            --prefix=%{install_path} \
             --libdir=%{install_path}/lib \
 %if 0%{with_slurm}
             --with-pm=no --with-pmi=slurm \

--- a/components/mpi-families/mvapich2/SPECS/mvapich2.spec
+++ b/components/mpi-families/mvapich2/SPECS/mvapich2.spec
@@ -88,17 +88,13 @@ across multiple networks.
 
 %build
 %ohpc_setup_compiler
-%if "%{compiler_family}" == "gnu12"
-# configure fails with:
-#   The Fortran compiler gfortran does not accept programs that
-#   call the same routine with arguments of different types without
-#   the option -fallow-argument-mismatch.
-#   Rerun configure with FFLAGS=-fallow-argument-mismatch
-# This seems to fix the build.
-export FFLAGS=-fallow-argument-mismatch
-%endif
-./configure --prefix=%{install_path} \
-            --libdir=%{install_path}/lib \
+
+./configure \
+%if %{compiler_family} == "gnu12"
+        FFLAGS="$FFLAGS -fallow-argument-mismatch" \
+%endif 
+--prefix=%{install_path} \
+        --libdir=%{install_path}/lib \
 	    --enable-cxx \
 	    --enable-g=dbg \
             --with-device=ch3:mrail \

--- a/components/parallel-libs/mumps/SPECS/mumps.spec
+++ b/components/parallel-libs/mumps/SPECS/mumps.spec
@@ -13,8 +13,6 @@
 %define ohpc_mpi_dependent 1
 %include %{_sourcedir}/OHPC_macros
 
-%global gnu_family gnu9
-
 # Base package name
 %define pname mumps
 

--- a/tests/admin/spack/spack
+++ b/tests/admin/spack/spack
@@ -21,7 +21,7 @@ setup() {
 }
 
 @test "[spack] add compiler" {
-    module load  gnu9
+    module load  gnu12
     spack compiler find
     assert_success
 }

--- a/tests/ci/run_build.py
+++ b/tests/ci/run_build.py
@@ -106,7 +106,6 @@ def build_srpm_and_rpm(command, family=None):
         build_user,
         '-l',
         '-c',
-        'rpmbuild --rebuild %s' % src_rpm,
     ]
 
     if family is not None:


### PR DESCRIPTION
Follow-up to #1439

Updates MVAPICH, MPICH, and other components to compile with GCC 12.1. 
Signed-off-by: jcsiadal <jeremy.c.siadal@intel.com>