### PR TITLE
Add devel repo to CI builds

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,6 +32,7 @@ jobs:
       run: |
         dnf install -y epel-release dnf-plugins-core git python3 http://repos.openhpc.community/OpenHPC/2/CentOS_8/x86_64/ohpc-release-2-1.el8.x86_64.rpm findutils rpm-build wget gawk
         dnf config-manager --set-enabled powertools
+        dnf config-manager --set-enabled devel
         dnf install -y lmod-ohpc
         adduser ohpc
     - uses: actions/checkout@v2


### PR DESCRIPTION
Signed-off-by: jcsiadal <jeremy.c.siadal@intel.com>

I have one package that needs access to a static library during build.

Devel repo is where Rocky/RHEL keeps its static libraries. OpenSUSE normally installs them with the -devel package. This puts BuildRequires on parity for the two distros.