### PR TITLE
METIS update to 5.1.1

### DIFF
--- a/components/.gitignore
+++ b/components/.gitignore
@@ -16,6 +16,7 @@ admin/nrpe/SOURCES/nrpe-*.tar.gz
 admin/pdsh/SOURCES/pdsh-*.tar.gz
 admin/powerman/SOURCES/powerman-*.tar.gz
 admin/test-suite/SOURCES/tests-ohpc.tar
+admin/ohpc-release-rcs/RC*/SOURCES/
 compiler-families/gnu-compilers/SOURCES/gcc-*.tar.xz
 compiler-families/gnu-compilers/SOURCES/gmp-*.tar.bz2
 compiler-families/gnu-compilers/SOURCES/mpc-*.tar.gz
@@ -84,7 +85,6 @@ perf-tools/scalasca/SOURCES/scalasca-*.tar.gz
 perf-tools/scalasca/SPECS/wget-log
 perf-tools/scorep/SOURCES/scorep-*.tar.gz
 perf-tools/tau/SOURCES/tau-*.tar.gz
-perf-tools/tau/SOURCES/tau-*.tar.gz
 provisioning/warewulf-cluster/SOURCES/*.tar.gz
 provisioning/warewulf-common/SOURCES/*.tar.gz
 provisioning/warewulf-ipmi/SOURCES/*.tar.gz
@@ -99,7 +99,7 @@ rms/slurm/SOURCES/slurm-*.tar.bz2
 runtimes/charliecloud/SOURCES/charliecloud-*.tar.gz
 serial-libs/R/SOURCES/R-*.tar.gz
 serial-libs/gsl/SOURCES/gsl-*.tar.gz
-serial-libs/metis/SOURCES/metis-*.tar.gz
+serial-libs/metis/SOURCES/*.tar.gz
 serial-libs/openblas/SOURCES/openblas-*.tar.gz
 serial-libs/plasma/SOURCES/lapack-*.tar.gz
 serial-libs/plasma/SOURCES/plasma-installer*.tar.gz

--- a/components/serial-libs/metis/SPECS/metis.spec
+++ b/components/serial-libs/metis/SPECS/metis.spec
@@ -9,20 +9,20 @@
 #----------------------------------------------------------------------------eh-
 
 # Serial metis build dependent on compiler toolchain
-%define ohpc_compiler_dependent 1
+%global ohpc_compiler_dependent 1
 %include %{_sourcedir}/OHPC_macros
-
-# Base package name
-%define pname metis
+%global pname metis
+%global dist_ver 0.5
 
 Name:    %{pname}-%{compiler_family}%{PROJ_DELIM}
 Summary: Serial Graph Partitioning and Fill-reducing Matrix Ordering
-Version: 5.1.0
+Version: 5.1.1
 Release: 1%{?dist}
-License: Apache License 2.0
+License: ASL 2.0
 Group:   %{PROJ_NAME}/serial-libs
 URL:     http://glaros.dtc.umn.edu/gkhome/metis/metis/overview
-Source0: http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/metis-%{version}.tar.gz
+Source0: https://github.com/KarypisLab/METIS/archive/refs/tags/v%{version}-DistDGL-v%{dist_ver}.tar.gz
+Source1: https://github.com/KarypisLab/GKlib/archive/refs/tags/METIS-v%{version}-DistDGL-%{dist_ver}.tar.gz
 BuildRequires: make
 BuildRequires: pkgconfig
 BuildRequires: cmake
@@ -31,45 +31,28 @@ Provides:      libmetis = %{version}
 Provides:      libmetis0 = %{version}
 
 # Default library install path
-%define install_path %{OHPC_LIBS}/%{compiler_family}/%{pname}%{OHPC_CUSTOM_PKG_DELIM}/%version
+%global install_path %{OHPC_LIBS}/%{compiler_family}/%{pname}%{OHPC_CUSTOM_PKG_DELIM}/%version
+%global module_path %{OHPC_MODULEDEPS}/%{compiler_family}/%{pname}
 
 %description
-METIS is a family of programs for partitioning unstructured graphs and hypergraph
-and computing fill-reducing orderings of sparse matrices. The underlying algorithms
-used by METIS are based on the state-of-the-art multilevel paradigm that has been
-shown to produce high quality results and scale to very large problems.
+METIS is a set of serial programs for partitioning graphs, partitioning
+finite element meshes, and producing fill reducing orderings for sparse
+matrices. The algorithms implemented in METIS are based on the multilevel
+recursive-bisection, multilevel k-way, and multi-constraint partitioning
+schemes developed in our lab.
 
-%package -n libmetis0
-Summary:        Serial Graph Partitioning and Fill-reducing Matrix Ordering
-Group:          System/Libraries
-
-%package devel
-License:         Free for non-commercial use
-Requires:        %name = %version
-Requires:	 pkgconfig
-Summary:         Metis development files
-Group:           Development/Libraries/C and C++
-
-%description -n libmetis0
-METIS is a family of programs for partitioning unstructured graphs and hypergraph
-and computing fill-reducing orderings of sparse matrices. The underlying algorithms
-used by METIS are based on the state-of-the-art multilevel paradigm that has been
-shown to produce high quality results and scale to very large problems.
-
-%description devel
-METIS is a family of programs for partitioning unstructured graphs and hypergraph
-and computing fill-reducing orderings of sparse matrices. The underlying algorithms
-used by METIS are based on the state-of-the-art multilevel paradigm that has been
-shown to produce high quality results and scale to very large problems.
 
 %prep
-%setup -q -n %{pname}-%{version}
-%build
-# OpenHPC compiler/mpi designation
-%ohpc_setup_compiler
+%setup -q -b0 -a1 -n METIS-%{version}-DistDGL-v%{dist_ver}
+rmdir GKlib
+ln -s GKlib-METIS-v%{version}-DistDGL-%{dist_ver} GKlib
 
+
+%build
+%ohpc_setup_compiler
 make config shared=1 prefix=%{install_path}
 make
+
 
 %install
 # OpenHPC compiler/mpi designation
@@ -78,47 +61,40 @@ make
 make install DESTDIR=${RPM_BUILD_ROOT}
 
 # OpenHPC module file
-%{__mkdir} -p %{buildroot}%{OHPC_MODULEDEPS}/%{compiler_family}/%{pname}
-%{__cat} << EOF > %{buildroot}/%{OHPC_MODULEDEPS}/%{compiler_family}/%{pname}/%{version}%{OHPC_CUSTOM_PKG_DELIM}
-#%Module1.0#####################################################################
+mkdir -p %{buildroot}%{module_path}
+cat << EOF > %{buildroot}%{module_path}/%{version}%{OHPC_CUSTOM_PKG_DELIM}.lua
+help([[
+This module loads the %{PNAME} library built with the %{compiler_family} compiler toolchain.
+Version %{version}
+]])
 
-proc ModulesHelp { } {
+whatis("Name: %{PNAME} built with %{compiler_family} toolchain")
+whatis("Version: %{version}")
+whatis("Category: runtime library")
+whatis("Description: %{summary}")
+whatis("%{url}")
 
-puts stderr " "
-puts stderr "This module loads the %{PNAME} library built with the %{compiler_family} compiler toolchain."
-puts stderr "\nVersion %{version}\n"
+local version = "%{version}"
 
-}
-module-whatis "Name: %{PNAME} built with %{compiler_family} toolchain"
-module-whatis "Version: %{version}"
-module-whatis "Category: runtime library"
-module-whatis "Description: %{summary}"
-module-whatis "%{url}"
+prepend_path("PATH",            "%{install_path}/bin")
+prepend_path("INCLUDE",         "%{install_path}/include")
+prepend_path("LD_LIBRARY_PATH",	"%{install_path}/lib")
 
-set     version			    %{version}
+setenv("%{PNAME}_DIR", "%{install_path}")
+setenv("%{PNAME}_BIN", "%{install_path}/bin")
+setenv("%{PNAME}_LIB", "%{install_path}/lib")
+setenv("%{PNAME}_INC", "%{install_path}/include")
 
-prepend-path    PATH                %{install_path}/bin
-prepend-path    INCLUDE             %{install_path}/include
-prepend-path	LD_LIBRARY_PATH	    %{install_path}/lib
-
-setenv          %{PNAME}_DIR        %{install_path}
-setenv          %{PNAME}_BIN        %{install_path}/bin
-setenv          %{PNAME}_LIB        %{install_path}/lib
-setenv          %{PNAME}_INC        %{install_path}/include
-
-family "metis"
+family("metis")
 EOF
 
-%{__cat} << EOF > %{buildroot}/%{OHPC_MODULEDEPS}/%{compiler_family}/%{pname}/.version.%{version}%{OHPC_CUSTOM_PKG_DELIM}
-#%Module1.0#####################################################################
-##
-## version file for %{pname}-%{version}
-##
-set     ModulesVersion      "%{version}%{OHPC_CUSTOM_PKG_DELIM}"
-EOF
+ln -s %{version}%{OHPC_CUSTOM_PKG_DELIM}.lua %{buildroot}%{module_path}/default
 
-%{__mkdir} -p %{buildroot}/%{_docdir}
+mkdir -p %{buildroot}%{_docdir}
+
 
 %files
-%{OHPC_PUB}
-%doc BUILD.txt Changelog Install.txt LICENSE.txt
+%{install_path}
+%{module_path}
+%doc Changelog 
+%license LICENSE


### PR DESCRIPTION
Signed-off-by: jcsiadal <jeremy.c.siadal@intel.com>

The old METIS source repo isn't responding. The author has a new source repo on GitHub. I've updated the specfile to the new source, updating the spec format, and migrated the module to Lua.