### PR TITLE
Fix for OpenSUSE validation failures

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -48,7 +48,7 @@ jobs:
   build_on_leap:
     runs-on: ubuntu-latest
     container:
-      image: registry.opensuse.org/opensuse/leap:latest
+      image: registry.opensuse.org/opensuse/leap:15.3
     steps:
     - name: Setup
       run: |

--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -160,24 +160,18 @@ Requires:      %{python_prefix}
 
 # Single-line macro for running compiler/MPI setup scripts
 # Script bodies are evaluated and stored in this macro definition
-%global ohpc_setup_compiler %{expand:\
-    %if 0%{?OHPC_CFLAGS:1} \
-         export OHPC_CFLAGS=%{OHPC_CFLAGS} \
-    %endif \
-    %if 0%{?OHPC_CXXFLAGS:1} \
-         export OHPC_CXXFLAGS=%{OHPC_CXXFLAGS} \
-    %endif \
-    %if 0%{?OHPC_FCFLAGS:1} \
-         export OHPC_FCFLAGS=%{OHPC_FCFLAGS} \
-    %endif \
-    %if 0%{?OHPC_F77FLAGS:1} \
-         export OHPC_F77FLAGS=%{OHPC_F77FLAGS} \
-    %endif \
-    . %{OHPC_ADMIN}/ohpc/OHPC_setup_compiler %{compiler_family} \
-    %if 0%{?ohpc_mpi_dependent} == 1 \
-        . %{OHPC_ADMIN}/ohpc/OHPC_setup_mpi %{mpi_family} \
-    %endif \
-}
+%global ohpc_setup_compiler %{expand:
+%{?OHPC_CFLAGS:export OHPC_CFLAGS=%{OHPC_CFLAGS}}
+%{?OHPC_CXXFLAGS:export OHPC_CXXFLAGS=%{OHPC_CXXFLAGS}}
+%{?OHPC_FCFLAGS:"export OHPC_FCFLAGS=%{OHPC_FCFLAGS}}
+%{?OHPC_F77FLAGS:"export OHPC_F77FLAGS=%{OHPC_F77FLAGS}}
+. %{OHPC_ADMIN}/ohpc/OHPC_setup_compiler %{compiler_family}}
+
+%if 0%{?ohpc_mpi_dependent} == 01
+%global ohpc_setup_compiler %{expand:
+%{ohpc_setup_compiler}
+. %{OHPC_ADMIN}/ohpc/OHPC_setup_mpi %{mpi_family}}
+%endif
 
 # Lua version
 %if 0%{!?luaver:1}

--- a/components/parallel-libs/fftw/SPECS/fftw.spec
+++ b/components/parallel-libs/fftw/SPECS/fftw.spec
@@ -52,6 +52,7 @@ data, and of arbitrary input size.
 %setup -q -n %{pname}-%{version}
 %patch0 -p1 
 
+
 %build
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler

--- a/tests/ci/run_build.py
+++ b/tests/ci/run_build.py
@@ -100,6 +100,7 @@ def build_srpm_and_rpm(command, family=None):
     rebuild_command = [
         'su',
         build_user,
+        '-l'
         '-c',
         'rpmbuild --rebuild %s' % src_rpm,
     ]

--- a/tests/ci/run_build.py
+++ b/tests/ci/run_build.py
@@ -100,7 +100,7 @@ def build_srpm_and_rpm(command, family=None):
     rebuild_command = [
         'su',
         build_user,
-        '-l'
+        '-l',
         '-c',
         'rpmbuild --rebuild %s' % src_rpm,
     ]


### PR DESCRIPTION
Signed-off-by: jcsiadal <jeremy.c.siadal@intel.com>

The validation errors were a combination of running the su command with no login shell and running Lmod. This doesn't work under LEAP,.

This update does a few things:

- Updates validation to add login for the su command.
- Changes OpenSUSE to use 15.3, which is formally supported, instead of the latest version.
- Rewrote the compiler_setup macro. The rpm developers say that %if within a macro isn't supported (although it usually works). They also noted that line continuation doesn't do anything in specfile macros (they only work in macrofile macros), so I removed them.
- Added a newline in the FFTW spec, so I could validate this on GitHub.
