### PR TITLE
ci: enable aarch64 CI runs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,24 @@
+---
+kind: pipeline
+type: docker
+name: aarch64 RHEL
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: build
+  image: docker.io/library/rockylinux:8
+  commands:
+  - dnf install -y epel-release dnf-plugins-core git python3 http://repos.openhpc.community/OpenHPC/2/CentOS_8/aarch64/ohpc-release-2-1.el8.aarch64.rpm findutils rpm-build wget gawk jq
+  - dnf config-manager --set-enabled powertools
+  - dnf config-manager --set-enabled devel
+  - dnf install -y lmod-ohpc
+  - adduser ohpc
+  - . /etc/profile.d/lmod.sh
+  - tests/ci/run_build.py ohpc $(tests/ci/drone_get_changed_files.sh)
+
+trigger:
+  event:
+  - pull_request

--- a/tests/ci/drone_get_changed_files.sh
+++ b/tests/ci/drone_get_changed_files.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -x
+
+if [ "$DRONE_BUILD_EVENT" != "pull_request" ]; then
+	echo "This script only support pull requests"
+	exit 0
+fi
+
+if [ -z  "$DRONE_REPO_OWNER" ]; then
+	echo "\$DRONE_REPO_OWNER not set. Exiting."
+	exit 0
+fi
+if [ -z  "$DRONE_REPO_NAME" ]; then
+	echo "\$DRONE_REPO_NAME not set. Exiting."
+	exit 0
+fi
+if [ -z  "$DRONE_PULL_REQUEST" ]; then
+	echo "\$DRONE_PULL_REQUEST not set. Exiting."
+	exit 0
+fi
+
+RESULT=""
+COMMITS=$( curl -s https://api.github.com/repos/"$DRONE_REPO_OWNER"/"$DRONE_REPO_NAME"/pulls/"$DRONE_PULL_REQUEST"/commits | jq -r .[].sha )
+
+for c in $COMMITS; do
+	FILES=$( git diff-tree --no-commit-id --name-only -r "$c" )
+	for f in $FILES; do
+		if [ ! -e "$f" ]; then
+			# If this file was deleted we ignore it
+			continue
+		fi
+		RESULT="$RESULT $f"
+	done
+done
+
+echo "$RESULT"


### PR DESCRIPTION
This extends our CI to run builds also on AARCH64. The AARCH64 machine are available from Drone CI.

@utdsimmons For this to work we need to enable drone.io CI on the OpenHPC github repository.

See https://cloud.drone.io/adrianreber/ohpc/15/1/2 for a result building the plasma RPM on AARCH64 from a PR on my fork of OHPC.