### PR TITLE
ci: setup slurm on CI system for further tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,6 +15,7 @@ task:
     dnf install -y epel-release dnf-plugins-core git python3 http://repos.openhpc.community/OpenHPC/2/CentOS_8/aarch64/ohpc-release-2-1.el8.aarch64.rpm findutils rpm-build wget gawk jq which
     dnf config-manager --set-enabled powertools
     dnf config-manager --set-enabled devel
+    wget http://obs.openhpc.community:82/OpenHPC:/2.7:/Factory/EL_8/OpenHPC:2.7:Factory.repo -O /etc/yum.repos.d/obs.repo
     dnf install -y lmod-ohpc
     adduser ohpc
   build_script: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -52,40 +52,69 @@ jobs:
 
   build_on_rhel:
     runs-on: ubuntu-latest
+    name: Build on RHEL
     container:
       image: docker.io/library/rockylinux:8
     steps:
-    - name: Setup
-      run: |
-        dnf install -y epel-release dnf-plugins-core git python3 http://repos.openhpc.community/OpenHPC/2/CentOS_8/x86_64/ohpc-release-2-1.el8.x86_64.rpm findutils rpm-build wget gawk
-        dnf config-manager --set-enabled powertools
-        dnf config-manager --set-enabled devel
-        dnf install -y lmod-ohpc
-        adduser ohpc
+    - name: Install git
+      run: dnf -y install git
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+    - name: Setup
+      run: tests/ci/prepare-ci-environment.sh
     - id: files
       uses: jitterbit/get-changed-files@v1
     - name: Validate Build
       run: |
         . /etc/profile.d/lmod.sh
         tests/ci/run_build.py ohpc ${{ steps.files.outputs.added_modified }}
+    - uses: actions/upload-artifact@v3
+      with:
+        name: rhel-rpms
+        path: |
+          /home/ohpc/rpmbuild/RPMS/noarch/*rpm
+          /home/ohpc/rpmbuild/RPMS/x86_64/*rpm
 
-  build_on_leap:
+  test_on_rhel:
     runs-on: ubuntu-latest
+    name: Test on RHEL
     container:
-      image: registry.opensuse.org/opensuse/leap:15.3
+      image: docker.io/library/rockylinux:8
+    needs: build_on_rhel
     steps:
-    - name: Setup
-      run: |
-        zypper -n install awk rpmbuild wget python3
-        zypper -n --no-gpg-checks install http://repos.openhpc.community/OpenHPC/2/Leap_15/x86_64/ohpc-release-2-1.leap15.x86_64.rpm
-        zypper -n --no-gpg-checks install lmod-ohpc
-        useradd -m ohpc
+    - name: Install git
+      run: dnf -y install git
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+    - name: Setup
+      run: tests/ci/prepare-ci-environment.sh
+    - id: files
+      uses: jitterbit/get-changed-files@v1
+    - uses: actions/download-artifact@v3
+      with:
+        name: rhel-rpms
+        path: /home/ohpc/rpmbuild/RPMS
+    - name: Run CI Tests
+      run: |
+        . /etc/profile.d/lmod.sh
+        chown ohpc -R tests
+        tests/ci/setup_slurm_and_run_tests.sh ohpc ${{ steps.files.outputs.added_modified }}
+
+  build_on_leap:
+    runs-on: ubuntu-latest
+    name: Build on LEAP
+    container:
+      image: registry.opensuse.org/opensuse/leap:15.3
+    steps:
+    - name: Install git
+      run: zypper -n install git
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Setup
+      run: tests/ci/prepare-ci-environment.sh
     - id: files
       uses: jitterbit/get-changed-files@v1
     - name: Validate Build

--- a/components/dev-tools/hwloc/SPECS/hwloc.spec
+++ b/components/dev-tools/hwloc/SPECS/hwloc.spec
@@ -13,20 +13,17 @@
 %define pname hwloc
 
 Name:           %{pname}%{PROJ_DELIM}
-Version:        2.7.0
-Release:        1%{?dist}
+Version:        2.7.1
+Release:        %{?dist}.1
 Summary:        Portable Hardware Locality
 License:        BSD-3-Clause
 Group:          %{PROJ_NAME}/dev-tools
 Url:            http://www.open-mpi.org/projects/hwloc/
 Source0:        https://download.open-mpi.org/release/hwloc/v2.7/%{pname}-%{version}.tar.bz2
 
-BuildRequires:  autoconf
-BuildRequires:  automake
+BuildRequires:  make
 BuildRequires:  doxygen
-%if 0%{?suse_version}
 BuildRequires:  fdupes
-%endif
 BuildRequires:  gcc-c++
 BuildRequires:  libtool
 BuildRequires:  cairo-devel
@@ -34,15 +31,10 @@ BuildRequires:  libxml2-devel
 BuildRequires:  ncurses-devel
 BuildRequires:  ncurses-devel
 BuildRequires:  transfig
-# % ifnarch s390 s390x
-# BuildRequires:  libibverbs-devel
-# % endif
-%ifnarch s390 s390x i586 %{arm}
-%if 0%{?suse_version}
+%if 0%{?sles_version} || 0%{?suse_version}
 BuildRequires:  libnuma-devel
 %else
 BuildRequires:  numactl-devel
-%endif
 %endif
 #!BuildIgnore: post-build-checks rpmlint-Factory
 #!BuildIgnore: #!BuildIgnore: brp-check-suse
@@ -72,13 +64,7 @@ about the hardware, bind processes, and much more.
 %setup -q -n %{pname}-%{version}
 
 %build
-%if 0%{?sles_version} || 0%{?suse_version}
-sed -i 's/1.11 dist-bzip2 subdir-objects foreign tar-ustar parallel-tests -Wall -Werror/1.10 dist-bzip2 subdir-objects foreign tar-ustar -Wall -Werror/g' configure.ac
-%endif
-autoreconf --force --install
 ./configure --prefix=%{install_path}
-##sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool
-##sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
 %{__make} %{?_smp_mflags} V=1
 
 %install
@@ -137,10 +123,6 @@ set     ModulesVersion      "%{version}"
 EOF
 
 %{__mkdir_p} ${RPM_BUILD_ROOT}/%{_docdir}
-
-%post -p /sbin/ldconfig
-
-%postun -p /sbin/ldconfig
 
 %files
 %doc AUTHORS COPYING NEWS README VERSION

--- a/components/rms/slurm/SPECS/slurm.spec
+++ b/components/rms/slurm/SPECS/slurm.spec
@@ -21,9 +21,9 @@
 # $Id$
 #
 Name:		%{pname}%{PROJ_DELIM}
-Version:	22.05.2
+Version:	22.05.6
 %global rel	1
-Release:	%{rel}%{?dist}
+Release:	%{?dist}.1
 Summary:	Slurm Workload Manager
 
 Group:		%{PROJ_NAME}/rms

--- a/tests/ci/.gitignore
+++ b/tests/ci/.gitignore
@@ -1,1 +1,0 @@
-!Makefile

--- a/tests/ci/Makefile
+++ b/tests/ci/Makefile
@@ -6,7 +6,11 @@ codespell-lint:
 
 flake8-lint:
 	@echo "Running 'flake8' on selected Python files"
-	flake8 ../../tests/ci/check_spec.py ../../tests/ci/run_build.py ../../misc/build_order.py
+	flake8 \
+		../../tests/ci/check_spec.py \
+		../../tests/ci/run_build.py \
+		../../misc/build_order.py \
+		../../tests/ci/spec_to_test_mapping.py
 
 whitespace-lint:
 	@echo "Checking spec files for trailing whitespaces"
@@ -14,4 +18,11 @@ whitespace-lint:
 
 shellcheck-lint:
 	@echo "Running 'shellcheck' on selected shell scripts"
-	shellcheck ../../misc/build_srpm.sh ../../misc/build_order.sh ../../misc/get_source.sh ../../misc/shell-functions
+	shellcheck \
+		-o require-variable-braces,quote-safe-variables,deprecate-which,avoid-nullary-conditions \
+		../../misc/build_srpm.sh \
+		../../misc/build_order.sh \
+		../../misc/get_source.sh \
+		../../misc/shell-functions \
+		../../tests/ci/prepare-ci-environment.sh \
+		../../tests/ci/setup_slurm_and_run_tests.sh

--- a/tests/ci/prepare-ci-environment.sh
+++ b/tests/ci/prepare-ci-environment.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# shellcheck disable=SC2086
+
+set -x
+set -e
+
+FACTORY_VERSION=2.7
+
+if [ ! -e /etc/os-release ]; then
+	echo "Cannot detect OS without /etc/os-release"
+	exit 1
+fi
+
+# shellcheck disable=SC1091
+. /etc/os-release
+
+PKG_MANAGER=zypper
+
+retry_counter=0
+max_retries=5
+
+loop_command() {
+	local retry_counter=0
+	local max_retries=5
+
+	while true; do
+		(( retry_counter+=1 ))
+		if [ "${retry_counter}" -gt "${max_retries}" ]; then
+			exit 1
+		fi
+		# shellcheck disable=SC2068
+		$@ && break
+
+		# In case it is a network error let's wait a bit.
+		echo "Retrying attempt ${retry_counter}"
+		sleep "${retry_counter}"
+	done
+}
+
+
+for like in ${ID_LIKE}; do
+	if [ "${like}" = "fedora" ]; then
+		PKG_MANAGER=dnf
+		break
+	fi
+done
+
+if [ "${PKG_MANAGER}" = "dnf" ]; then
+	OHPC_RELEASE="http://repos.openhpc.community/OpenHPC/2/CentOS_8/x86_64/ohpc-release-2-1.el8.x86_64.rpm"
+else
+	OHPC_RELEASE="http://repos.openhpc.community/OpenHPC/2/Leap_15/x86_64/ohpc-release-2-1.leap15.x86_64.rpm"
+fi
+
+if [ "${FACTORY_VERSION}" != "" ]; then
+	FACTORY_REPOSITORY=http://obs.openhpc.community:82/OpenHPC:/2.7:/Factory/
+	if [ "${PKG_MANAGER}" = "dnf" ]; then
+		FACTORY_REPOSITORY="${FACTORY_REPOSITORY}EL_8"
+		FACTORY_REPOSITORY_DESTINATION="/etc/yum.repos.d/obs.repo"
+	else
+		FACTORY_REPOSITORY="${FACTORY_REPOSITORY}Leap_15"
+		FACTORY_REPOSITORY_DESTINATION="/etc/zypp/repos.d/obs.repo"
+	fi
+	FACTORY_REPOSITORY="${FACTORY_REPOSITORY}/OpenHPC:2.7:Factory.repo"
+fi
+
+COMMON_PKGS="wget python3"
+
+if [ "${PKG_MANAGER}" = "dnf" ]; then
+	loop_command "${PKG_MANAGER}" -y install ${COMMON_PKGS} epel-release dnf-plugins-core git rpm-build gawk "${OHPC_RELEASE}"
+	loop_command "${PKG_MANAGER}" config-manager --set-enabled powertools
+	loop_command "${PKG_MANAGER}" config-manager --set-enabled devel
+	if [ "${FACTORY_VERSION}" != "" ]; then
+		loop_command wget "${FACTORY_REPOSITORY}" -O "${FACTORY_REPOSITORY_DESTINATION}"
+	fi
+	loop_command "${PKG_MANAGER}" -y install lmod-ohpc
+	adduser ohpc
+else
+	loop_command "${PKG_MANAGER}" -n install ${COMMON_PKGS} awk rpmbuild
+	loop_command "${PKG_MANAGER}" -n --no-gpg-checks install "${OHPC_RELEASE}"
+	if [ "${FACTORY_VERSION}" != "" ]; then
+		loop_command wget "${FACTORY_REPOSITORY}" -O "${FACTORY_REPOSITORY_DESTINATION}"
+	fi
+	loop_command "${PKG_MANAGER}" -n --no-gpg-checks install lmod-ohpc
+	useradd -m ohpc
+fi

--- a/tests/ci/setup_slurm_and_run_tests.sh
+++ b/tests/ci/setup_slurm_and_run_tests.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+set -x
+set -e
+
+USER=$1
+shift
+
+# First install slurm and needed packages
+dnf -y install \
+	autoconf \
+	automake \
+	make \
+	which \
+	slurm-slurmd-ohpc \
+	slurm-slurmctld-ohpc \
+	slurm-example-configs-ohpc \
+	slurm-ohpc
+
+# Install rebuilt packages (if any)
+# shellcheck disable=SC2046 # (we want the words to be split)
+dnf -y install $(find /home/"${USER}"/rpmbuild/RPMS/ -name "*rpm") || true
+
+# Setup slurm
+echo "127.0.0.1 node0 node1" >> /etc/hosts
+
+cp /etc/slurm/slurm.conf.example /etc/slurm/slurm.conf
+
+sed -i -e "
+	s,SlurmdLogFile=.*$,SlurmdLogFile=/var/log/slurmd.%n.log,g; \
+	s,SlurmdSpoolDir=.*$,SlurmdSpoolDir=/var/spool/slurmd.%n,g; \
+	s,SlurmdPidFile=.*$,SlurmdPidFile=/var/run/slurmd.%n.pid,g; \
+	s,JobCompType=jobcomp/none,,g; \
+	s,ProctrackType=.*,ProctrackType=proctrack/linuxproc,g; \
+	s,TaskPlugin=.*,TaskPlugin=task/none,g; \
+	s,NodeName=.*$,,g; \
+	s,PartitionName.*$,,g; \
+	s,ReturnToService.*$,ReturnToService=2,g; \
+	s,SlurmctldHost=.*$,SlurmctldHost=${HOSTNAME},g;" /etc/slurm/slurm.conf
+
+{
+	echo "NodeName=c0 NodeHostname=node0 Port=17004 CPUs=2"
+	echo "NodeName=c1 NodeHostname=node1 Port=17005 CPUs=2"
+	echo "PartitionName=normal Nodes=c0,c1 Default=YES MaxTime=24:00:00 State=UP"
+} >> /etc/slurm/slurm.conf
+
+chown root.root /var/log/munge
+
+/usr/sbin/munged -f
+/usr/sbin/slurmctld
+slurmd -N c0
+slurmd -N c1
+
+sinfo
+
+retry_counter=0
+max_retries=5
+
+while true; do
+	(( retry_counter+=1 ))
+	if [ "${retry_counter}" -gt "${max_retries}" ]; then
+		exit 1
+	fi
+	scontrol update nodename=c[0-1] state=idle && break
+	sinfo
+
+	# In case it is a network error let's wait a bit.
+	echo "Retrying scontrol attempt ${retry_counter}"
+	sleep "${retry_counter}"
+done
+
+srun -N2 hostname
+
+# Figure out which tests we need to run.
+# This script returns two array variables: PKGS and TESTS
+# shellcheck disable=SC2068 # (we want individual elements)
+eval "$(tests/ci/spec_to_test_mapping.py $@)"
+
+if [ "${#PKGS[@]}" -gt 0 ]; then
+	dnf -y install "${PKGS[@]}"
+fi
+
+export SIMPLE_CI=1
+
+# Always running at least with '--enable-modules'. No need to check for
+# an empty TESTS array.
+su "${USER}" -l -c "cd ${PWD}/tests; ./bootstrap; ./configure --disable-all --enable-modules ${TESTS[*]}; make check"

--- a/tests/ci/spec_to_test_mapping.py
+++ b/tests/ci/spec_to_test_mapping.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+#
+# This script tries to create a mapping between spec files
+# and which tests to enable in the test suite.
+# This script will return two shell arrays (TESTS and PKGS).
+
+import sys
+
+# This dictionary defines the mapping
+# 'path/to/file.spec': ['test-option', 'required packages for test']
+test_map = {
+    # 'path/to/file.spec': ['test-option', 'required packages test']
+    'components/rms/slurm/SPECS/slurm.spec': [
+        'munge',
+        'magpie-ohpc pdsh-mod-slurm-ohpc openmpi4-gnu12-ohpc pdsh-ohpc'
+    ],
+    'components/dev-tools/hwloc/SPECS/hwloc.spec': [
+        'hwloc',
+        'gnu12-compilers-ohpc',
+    ],
+}
+
+
+if len(sys.argv) <= 1:
+    print('TESTS=() PKGS=()')
+    sys.exit(0)
+
+tests = ''
+pkgs = ''
+
+for i in sys.argv[1:]:
+    if i in test_map.keys():
+        if len(tests) > 0:
+            tests += ' '
+        if len(pkgs) > 0:
+            pkgs += ' '
+
+        tests += f'--enable-{test_map[i][0]}'
+        pkgs += test_map[i][1]
+
+print(
+    'TESTS=(%s) PKGS=(%s)' % (
+        tests,
+        pkgs,
+    )
+)

--- a/tests/user-env/mem_limits
+++ b/tests/user-env/mem_limits
@@ -8,6 +8,10 @@ if [ -s ../TEST_ENV ];then
     source ../TEST_ENV
 fi
 
+if [ -z "$SIMPLE_CI" ]; then
+	skip "Not supported in simple CI setup"
+fi
+
 check_rms
 
 @test "[memlock] check increased soft limit" {


### PR DESCRIPTION
This adds an additional step to our existing CI scripts to run some of the tests from the test suite in GitHub's CI setup.

For now I am only running 5 tests to see if it works. So far it looks good.

I have to rebuild slurm to allow multiple slurmd processes on one host. This step could be skipped if we include the multihost support in our regular slurm build.