### PR TITLE
Fix WW4 builds on OBS

### DIFF
--- a/components/provisioning/warewulf/SPECS/warewulf.spec
+++ b/components/provisioning/warewulf/SPECS/warewulf.spec
@@ -10,13 +10,18 @@
 
 %include %{_sourcedir}/OHPC_macros
 
-%define debug_package %{nil}
+%global debug_package %{nil}
 
 # Base package name
-%define pname warewulf
+%global pname warewulf
 
 # Group for warewulfd and other WW operations
 %global wwgroup warewulf
+
+# Service directories (normally defaults to /var/lib/*)
+%global tftpdir /srv/tftpboot
+%global srvdir /srv
+%global statedir /srv
 
 Name:    %{pname}%{PROJ_DELIM}
 Summary: A provisioning system for large clusters of bare metal and/or virtual systems
@@ -38,10 +43,8 @@ Conflicts: warewulf-vnfs
 Conflicts: warewulf-provision
 Conflicts: warewulf-ipmi
 
-BuildRequires: make
-BuildRequires: /etc/os-release
-
 %if 0%{?suse_version} || 0%{?sle_version}
+BuildRequires: distribution-release
 BuildRequires: systemd-rpm-macros
 BuildRequires: go
 BuildRequires: firewall-macros
@@ -52,16 +55,15 @@ Requires: nfs-kernel-server
 Requires: firewalld
 %else
 # Assume Fedora-based OS if not SUSE-based
+BuildRequires: system-release
 BuildRequires: systemd
 BuildRequires: golang
 BuildRequires: firewalld-filesystem
 Requires: tftp-server
 Requires: nfs-utils
 %endif
+BuildRequires: make
 Requires: dhcp-server
-%global tftpdir /srv/tftpboot
-%global srvdir /srv
-%global statedir /srv
 
 %description
 Warewulf is a stateless and diskless container operating system provisioning


### PR DESCRIPTION
Signed-off-by: jcsiadal <jeremy.c.siadal@intel.com>

Replaces the filename requires with distro-specific virtual package names. It still builds without error on local Rocky8, OpenSUSE15.3, and SLE15.4.

Reorganized a few lines in the spec and replaced "define" with "global" for global constants.