### PR TITLE
Change `Source` to `Source0` in mrsh and warewulf

### DIFF
--- a/components/admin/mrsh/SPECS/mrsh.spec
+++ b/components/admin/mrsh/SPECS/mrsh.spec
@@ -16,21 +16,22 @@
 Name:    %{pname}%{PROJ_DELIM}
 Version: 2.12
 Release: 1%{?dist}
-Epoch: 3
+Epoch:   3
 Summary: Remote shell program that uses munge authentication
 License: none
-Group: %{PROJ_NAME}/admin
-URL: https://github.com/chaos/mrsh
-Source:    https://github.com/chaos/mrsh/archive/%{version}.tar.gz#/mrsh-%{version}.tar.gz
-Patch1: mrsh-pam-suse.patch
-Patch2: mrlogin-Don-t-use-union-wait.patch
-Patch3: Add-force-to-libtoolize.patch
+Group:   %{PROJ_NAME}/admin
+URL:     https://github.com/chaos/mrsh
+Source0: https://github.com/chaos/mrsh/archive/%{version}.tar.gz#/mrsh-%{version}.tar.gz
+Patch1:  mrsh-pam-suse.patch
+Patch2:  mrlogin-Don-t-use-union-wait.patch
+Patch3:  Add-force-to-libtoolize.patch
 BuildRequires: ncurses-devel pam-devel munge-devel
 Requires: munge
 Provides: mrsh
 BuildRequires:  systemd-devel
 
 # support re-run of autogen
+BuildRequires: make
 BuildRequires: autoconf
 BuildRequires: automake
 BuildRequires: libtool

--- a/components/provisioning/warewulf/SPECS/warewulf.spec
+++ b/components/provisioning/warewulf/SPECS/warewulf.spec
@@ -30,7 +30,7 @@ Release: 1%{?dist}
 License: BSD-3-Clause
 Group:   %{PROJ_NAME}/provisioning
 URL:     https://github.com/hpcng/warewulf
-Source:  https://github.com/hpcng/warewulf/releases/download/v%{version}/warewulf-%{version}.tar.gz
+Source0: https://github.com/hpcng/warewulf/releases/download/v%{version}/warewulf-%{version}.tar.gz
 Source2: go_vendor-4.3.tgz
 Patch0:  warewulf-4.3.0-network_type.patch
 Patch1:  warewulf-4.3.0-ssh_completion.patch


### PR DESCRIPTION
Change `Source` to `Source0` in mrsh.spec otherwise the `No source number 0` error raise

According to https://rpm-packaging-guide.github.io:

> Path or URL to the compressed archive of the upstream source code (unpatched, patches are handled elsewhere). This should point to an accessible and reliable storage of the archive, for example, the upstream page and not the packager’s local storage. If needed, more SourceX directives can be added, incrementing the number each time, for example: Source1, Source2, Source3, and so on.