### PR TITLE
admin/ohpc-filesystem: use %{?dist} differently

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,6 +12,9 @@ env:
 
 jobs:
   check_spec:
+    env:
+      JOB_SKIP_CI_SPECS: |
+        components/admin/ohpc-filesystem/SPECS/ohpc-filesystem.spec
 
     runs-on: ubuntu-latest
     container:

--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -27,8 +27,8 @@
 %global OHPC_MPI_STACKS %{OHPC_PUB}/mpi
 %global OHPC_UTILS      %{OHPC_PUB}/utils
 %global debug_package   %{nil}
-%global dist            .ohpc.2.0.0
 
+%{!?dist: %global dist 27.ohpc}
 %{!?PROJ_DELIM: %global PROJ_DELIM -ohpc}
 
 # Update package docs location to include version info (to allow

--- a/components/admin/ohpc-filesystem/SPECS/ohpc-filesystem.spec
+++ b/components/admin/ohpc-filesystem/SPECS/ohpc-filesystem.spec
@@ -9,8 +9,8 @@
 #----------------------------------------------------------------------------eh-
 
 Name: ohpc-filesystem
-Version: 2.6
-Release: 1%{?dist}
+Version: 2.7
+Release: %{?dist}.1
 Summary: Common top-level OpenHPC directories
 
 Group:   ohpc/admin

--- a/tests/ci/check_spec.py
+++ b/tests/ci/check_spec.py
@@ -48,6 +48,9 @@ skip_ci_specs = []
 skip_ci_specs_env = os.getenv('SKIP_CI_SPECS')
 if skip_ci_specs_env:
     skip_ci_specs = skip_ci_specs_env.rstrip().split(' ')
+skip_ci_specs_env = os.getenv('JOB_SKIP_CI_SPECS')
+if skip_ci_specs_env:
+    skip_ci_specs.extend(skip_ci_specs_env.rstrip().split(' '))
 
 for spec in sys.argv[1:]:
     if not spec.endswith('.spec'):

--- a/tests/ci/run_build.py
+++ b/tests/ci/run_build.py
@@ -16,6 +16,7 @@ if len(sys.argv) <= 2:
 spec_found = False
 build_user = sys.argv[1]
 dnf_based = False
+dist = "9999.ci.ohpc"
 
 # Check which base OS we are using
 reader = csv.DictReader(open('/etc/os-release'), delimiter="=")
@@ -116,7 +117,7 @@ def build_srpm_and_rpm(command, family=None):
         build_user,
         '-l',
         '-c',
-        'rpmbuild --rebuild %s' % src_rpm,
+        'rpmbuild --define "dist %s" --rebuild %s' % (dist, src_rpm),
     ]
 
     if family is not None:


### PR DESCRIPTION
This tries to use the %{?dist} differently. Instead of a suffix it is now used as a prefix and OBS will fill out %dist similar to how it used to set 'Release:'.