### PR TITLE
Add test dependency to zlib-devel for HDF5

### DIFF
--- a/tests/ci/spec_to_test_mapping.py
+++ b/tests/ci/spec_to_test_mapping.py
@@ -26,6 +26,18 @@ test_map = {
         'easybuild',
         'gcc-c++',
     ],
+    'components/io-libs/hdf5/SPECS/hdf5.spec': [
+        'hdf5',
+        'zlib-devel'
+    ],
+    'components/parallel-libs/ptscotch/SPECS/ptscotch.spec': [
+        'ptscotch',
+        'zlib-devel'
+    ],
+    'components/serial-libs/scotch/SPECS/scotch.spec': [
+        'scotch',
+        'zlib-devel'
+    ],
 }
 
 


### PR DESCRIPTION
Currently the test fails on openEuler 22.03 and RockyLinux aarch64. 

File `./tests/libs/hdf5/test-h5-wrappers/config.log` contains:

```
...
configure:3417: h5cc    conftest.c  >&5
/usr/bin/ld: cannot find -lz
collect2: error: ld returned 1 exit status
configure:3421: $? = 1
configure:3461: result: no
...
```

Signed-off-by: Martin Tzvetanov Grigorov <mgrigorov@apache.org>