### PR TITLE
misc/obs: add easybuild to 2.7.0 builds

### DIFF
--- a/misc/obs/config.2.x
+++ b/misc/obs/config.2.x
@@ -36,7 +36,7 @@ mpi-families=["impi-devel","mpich","mvapich2","openmpi","libfabric","ucx"]
 compiler_families=["gnu12","intel","arm1"]
 mpi_families=["openmpi4","mpich","mvapich2","impi"]
 
-standalone = ["ohpc-filesystem","slurm","hwloc","lmod","genders","magpie"]
+standalone = ["ohpc-filesystem","slurm","hwloc","lmod","genders","magpie","easybuild"]
 
 [2.6.0]
 

--- a/misc/obs/obs_config.py
+++ b/misc/obs/obs_config.py
@@ -75,8 +75,7 @@ class ohpc_obs_tool(object):
                 activeComponents.append(item)
         return activeComponents
 
-
-    def parseConfig(self,configFile=None):
+    def parseConfig(self, configFile=None, service_file=None):
         assert(configFile is not None)
         logging.info("\nReading config information from file = %s" % configFile)
         if os.path.isfile(configFile):
@@ -103,10 +102,13 @@ class ohpc_obs_tool(object):
                 self.MPIFamilies       = ast.literal_eval(self.buildConfig.get(self.vip,'mpi_families'))
 
             except:
-                ERROR("Unable to parse global settings for %s" % vip)
+                ERROR("Unable to parse global settings for %s" % self.vip)
 
             assert(len(self.compilerFamilies) > 0)
             assert(len(self.MPIFamilies) > 0)
+
+            if service_file:
+                self.serviceFile = service_file
 
             self.Lock = True      # flag to indicate whether to lock new packages after creation (git trigger will unlock)
 
@@ -611,6 +613,14 @@ def main():
     parser.add_argument("--version"   ,help="version in progress",type=str)
     parser.add_argument("--no-lock",dest='lock',help="do not lock new build additions",action="store_false")
     parser.add_argument("--package",help="check OBS config for provided package only",type=str)
+    parser.add_argument(
+            "--service-file",
+            help=(
+                "OBS service file template "
+                "(default taken from configuration file)"
+            ),
+            type=str,
+    )
 
     parser.set_defaults(dryrun=True)
     parser.set_defaults(lock=True)
@@ -624,8 +634,8 @@ def main():
     # main worker bee class
     obs = ohpc_obs_tool(args.version)
 
-    # read config file and parse component packages desiredfor current version
-    obs.parseConfig(configFile=args.configFile)
+    # read config file and parse component packages desired for current version
+    obs.parseConfig(configFile=args.configFile, service_file=args.service_file)
     components = obs.query_components()
 
     # override dryrun option if requested


### PR DESCRIPTION
Also add support to run obs_config.py from everywhere and not just the directory it is located in.