### PR TITLE
Issue #1627: Re-generate the ADIOS numpy wrappers on the fly

### DIFF
--- a/components/io-libs/adios/SPECS/adios.spec
+++ b/components/io-libs/adios/SPECS/adios.spec
@@ -60,7 +60,8 @@ BuildRequires: lustre-lite
 Requires: lustre-client%{PROJ_DELIM}
 %endif
 BuildRequires: %{python_prefix}-numpy-%{compiler_family}%{PROJ_DELIM}
-
+BuildRequires: %{python_prefix}-mpi4py-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+BuildRequires: %{python_prefix}-Cython%{PROJ_DELIM}
 
 %if 0%{?sles_version} || 0%{?suse_version}
 # define fdupes, clean up rpmlint errors
@@ -192,13 +193,15 @@ export PATH=$(pwd):$PATH
 module load openblas
 %endif
 module load %{python_module_prefix}numpy
+module load %{python_module_prefix}mpi4py
 export CFLAGS="-I$NUMPY_DIR$PPATH/numpy/core/include -I$(pwd)/src/public -L$(pwd)/src"
 export CFLAGS="$CFLAGS -I$MPI_DIR/include"
 pushd wrappers/numpy
 mkdir .bin
 ln -s /usr/bin/python3 .bin/python
 export PATH="$PWD/.bin:$PATH"
-make MPI=y python
+rm -f adios.cpp adios_mpi.cpp
+make CYTHON=y MPI=y python
 
 #%{python_prefix} setup.py install --prefix="%buildroot%{install_path}/python"
 python3 setup.py install --prefix="%buildroot%{install_path}/python"

--- a/tests/ci/setup_slurm_and_run_tests.sh
+++ b/tests/ci/setup_slurm_and_run_tests.sh
@@ -88,4 +88,4 @@ export SIMPLE_CI=1
 
 # Always running at least with '--enable-modules'. No need to check for
 # an empty TESTS array.
-su "${USER}" -l -c "cd ${PWD}/tests; ./bootstrap; ./configure --disable-all --enable-modules ${TESTS[*]}; make check"
+su "${USER}" -l -c "cd ${PWD}/tests; ./bootstrap; ./configure --disable-all --enable-modules --with-mpi-families='openmpi4 mpich' ${TESTS[*]}; make check"

--- a/tests/ci/spec_to_test_mapping.py
+++ b/tests/ci/spec_to_test_mapping.py
@@ -28,7 +28,7 @@ test_map = {
     ],
     'components/io-libs/adios/SPECS/adios.spec': [
         'adios',
-        ''
+        'openmpi4-gnu12-ohpc mpich-gnu12-ohpc'
     ],
     'components/io-libs/hdf5/SPECS/hdf5.spec': [
         'hdf5',

--- a/tests/ci/spec_to_test_mapping.py
+++ b/tests/ci/spec_to_test_mapping.py
@@ -26,6 +26,10 @@ test_map = {
         'easybuild',
         'gcc-c++',
     ],
+    'components/io-libs/adios/SPECS/adios.spec': [
+        'adios',
+        ''
+    ],
     'components/io-libs/hdf5/SPECS/hdf5.spec': [
         'hdf5',
         'zlib-devel'

--- a/tests/libs/adios/tests/rm_execution
+++ b/tests/libs/adios/tests/rm_execution
@@ -13,7 +13,11 @@ rm=$RESOURCE_MANAGER
 testname="libs/ADIOS"
 
 NODES=2
-TASKS=8
+if [ -z "$SIMPLE_CI" ]; then
+    TASKS=2
+else
+    TASKS=8
+fi
 
 @test "[$testname] MPI C binary runs under resource manager ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
     binary=arrays_write


### PR DESCRIPTION
 This way adios.cpp and adios_mpi.cpp should be buildable with the  current versions of Python and Cython on the build system.
    
Suggested-by @adrianreber at https://github.com/openhpc/ohpc/pull/1635#issuecomment-1347402589
