### PR TITLE
Preserve the SIMPLE_CI environment variable when executing the tests as user 'ohpc'

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -105,6 +105,14 @@ jobs:
         . /etc/profile.d/lmod.sh
         chown ohpc -R tests
         tests/ci/setup_slurm_and_run_tests.sh ohpc ${{ steps.files.outputs.added_modified }}
+    - name: Print logs on error
+      if: failure()
+      run: |
+        for f in `find ./ -name "*.log"`; do 
+          echo $f; 
+          cat $f;
+          echo "================================================" 
+        done
 
   build_on_leap:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -105,7 +105,7 @@ jobs:
         . /etc/profile.d/lmod.sh
         chown ohpc -R tests
         tests/ci/setup_slurm_and_run_tests.sh ohpc ${{ steps.files.outputs.added_modified }}
-    - name: Print logs on error
+    - name: Print logs on failure
       if: failure()
       run: |
         for f in `find ./ -name "*.log"`; do 

--- a/tests/ci/setup_slurm_and_run_tests.sh
+++ b/tests/ci/setup_slurm_and_run_tests.sh
@@ -12,6 +12,7 @@ dnf -y install \
 	automake \
 	make \
 	which \
+	sudo \
 	slurm-slurmd-ohpc \
 	slurm-slurmctld-ohpc \
 	slurm-example-configs-ohpc \
@@ -88,4 +89,4 @@ export SIMPLE_CI=1
 
 # Always running at least with '--enable-modules'. No need to check for
 # an empty TESTS array.
-su "${USER}" --whitelist-environment SIMPLE_CI -l -c "cd ${PWD}/tests; ./bootstrap; ./configure --disable-all --enable-modules --with-mpi-families='openmpi4 mpich' ${TESTS[*]}; make check"
+sudo --user="${USER}" --preserve-env=SIMPLE_CI --login bash -c "cd ${PWD}/tests; ./bootstrap; ./configure --disable-all --enable-modules --with-mpi-families='openmpi4 mpich' ${TESTS[*]}; make check"

--- a/tests/ci/setup_slurm_and_run_tests.sh
+++ b/tests/ci/setup_slurm_and_run_tests.sh
@@ -88,4 +88,4 @@ export SIMPLE_CI=1
 
 # Always running at least with '--enable-modules'. No need to check for
 # an empty TESTS array.
-su "${USER}" -l -c "cd ${PWD}/tests; ./bootstrap; ./configure --disable-all --enable-modules --with-mpi-families='openmpi4 mpich' ${TESTS[*]}; make check"
+su "${USER}" --whitelist-environment SIMPLE_CI -l -c "cd ${PWD}/tests; ./bootstrap; ./configure --disable-all --enable-modules --with-mpi-families='openmpi4 mpich' ${TESTS[*]}; make check"

--- a/tests/ci/setup_slurm_and_run_tests.sh
+++ b/tests/ci/setup_slurm_and_run_tests.sh
@@ -20,7 +20,7 @@ dnf -y install \
 
 # Install rebuilt packages (if any)
 # shellcheck disable=SC2046 # (we want the words to be split)
-dnf -y install $(find /home/"${USER}"/rpmbuild/RPMS/ -name "*rpm") || true
+dnf -y install prun-ohpc $(find /home/"${USER}"/rpmbuild/RPMS/ -name "*rpm") || true
 
 # Setup slurm
 echo "127.0.0.1 node0 node1" >> /etc/hosts

--- a/tests/ci/setup_slurm_and_run_tests.sh
+++ b/tests/ci/setup_slurm_and_run_tests.sh
@@ -20,7 +20,7 @@ dnf -y install \
 
 # Install rebuilt packages (if any)
 # shellcheck disable=SC2046 # (we want the words to be split)
-dnf -y install prun-ohpc gnu12-compilers-ohpc $(find /home/"${USER}"/rpmbuild/RPMS/ -name "*rpm") || true
+dnf -y install prun-ohpc gnu12-compilers-ohpc openmpi4-gnu12-ohpc mpich-gnu12-ohpc $(find /home/"${USER}"/rpmbuild/RPMS/ -name "*rpm") || true
 
 # Setup slurm
 echo "127.0.0.1 node0 node1" >> /etc/hosts

--- a/tests/ci/setup_slurm_and_run_tests.sh
+++ b/tests/ci/setup_slurm_and_run_tests.sh
@@ -20,7 +20,7 @@ dnf -y install \
 
 # Install rebuilt packages (if any)
 # shellcheck disable=SC2046 # (we want the words to be split)
-dnf -y install prun-ohpc $(find /home/"${USER}"/rpmbuild/RPMS/ -name "*rpm") || true
+dnf -y install prun-ohpc gnu12-compilers-ohpc $(find /home/"${USER}"/rpmbuild/RPMS/ -name "*rpm") || true
 
 # Setup slurm
 echo "127.0.0.1 node0 node1" >> /etc/hosts

--- a/tests/ci/setup_slurm_and_run_tests.sh
+++ b/tests/ci/setup_slurm_and_run_tests.sh
@@ -89,4 +89,4 @@ export SIMPLE_CI=1
 
 # Always running at least with '--enable-modules'. No need to check for
 # an empty TESTS array.
-sudo --user="${USER}" --preserve-env=SIMPLE_CI --login bash -c "cd ${PWD}/tests; ./bootstrap; ./configure --disable-all --enable-modules --with-mpi-families='openmpi4 mpich' ${TESTS[*]}; make check"
+sudo --user="${USER}" --preserve-env=SIMPLE_CI --login bash -c "cd ${PWD}/tests; ./bootstrap; ./configure --disable-all --enable-modules --enable-rms-harness --with-mpi-families='openmpi4 mpich' ${TESTS[*]}; make check"

--- a/tests/ci/spec_to_test_mapping.py
+++ b/tests/ci/spec_to_test_mapping.py
@@ -42,6 +42,10 @@ test_map = {
         'scotch',
         'zlib-devel'
     ],
+    '../components/parallel-libs/fftw/SPECS/fftw.spec': [
+        'fftw',
+        'openmpi4-gnu12-ohpc mpich-gnu12-ohpc'
+    ],
 }
 
 

--- a/tests/ci/spec_to_test_mapping.py
+++ b/tests/ci/spec_to_test_mapping.py
@@ -118,6 +118,14 @@ test_map = {
         'tau',
         'openmpi4-gnu12-ohpc mpich-gnu12-ohpc'
     ],
+    'components/mpi-families/openmpi/SPECS/openmpi.spec': [
+        'openmpi4',
+        'openmpi4-gnu12-ohpc'
+    ],
+    'components/mpi-families/mpich/SPECS/mpich.spec': [
+        'mpich',
+        'mpich-gnu12-ohpc'
+    ],
 }
 
 

--- a/tests/ci/spec_to_test_mapping.py
+++ b/tests/ci/spec_to_test_mapping.py
@@ -42,8 +42,80 @@ test_map = {
         'scotch',
         'zlib-devel'
     ],
-    '../components/parallel-libs/fftw/SPECS/fftw.spec': [
+    'components/parallel-libs/fftw/SPECS/fftw.spec': [
         'fftw',
+        'openmpi4-gnu12-ohpc mpich-gnu12-ohpc'
+    ],
+    'components/parallel-libs/hypre/SPECS/hypre.spec': [
+        'hypre',
+        'openmpi4-gnu12-ohpc mpich-gnu12-ohpc'
+    ],
+    'components/parallel-libs/mfem/SPECS/mfem.spec': [
+        'mfem',
+        'openmpi4-gnu12-ohpc mpich-gnu12-ohpc'
+    ],
+    'components/parallel-libs/mumps/SPECS/mumps.spec': [
+        'mumps',
+        'openmpi4-gnu12-ohpc mpich-gnu12-ohpc'
+    ],
+    'components/parallel-libs/opencoarrays/SPECS/opencoarrays.spec': [
+        'opencoarrays',
+        'openmpi4-gnu12-ohpc mpich-gnu12-ohpc'
+    ],
+    'components/parallel-libs/petsc/SPECS/petsc.spec': [
+        'petsc',
+        'openmpi4-gnu12-ohpc mpich-gnu12-ohpc'
+    ],
+    'components/io-libs/phdf5/SPECS/hdf5.spec': [
+        'phdf5',
+        'openmpi4-gnu12-ohpc mpich-gnu12-ohpc'
+    ],
+    'components/io-libs/pnetcdf/SPECS/pnetcdf.spec': [
+        'pnetcdf',
+        'openmpi4-gnu12-ohpc mpich-gnu12-ohpc'
+    ],
+    'components/parallel-libs/scalapack/SPECS/scalapack.spec': [
+        'scalapack',
+        'openmpi4-gnu12-ohpc mpich-gnu12-ohpc'
+    ],
+    'components/parallel-libs/slepc/SPECS/slepc.spec': [
+        'slepc',
+        'openmpi4-gnu12-ohpc mpich-gnu12-ohpc'
+    ],
+    'components/serial-libs/superlu/SPECS/superlu.spec': [
+        'superlu',
+        'openmpi4-gnu12-ohpc mpich-gnu12-ohpc'
+    ],
+    'components/parallel-libs/superlu_dist/SPECS/superlu_dist.spec': [
+        'superlu_dist',
+        'openmpi4-gnu12-ohpc mpich-gnu12-ohpc'
+    ],
+    'components/parallel-libs/trilinos/SPECS/trilinos.spec': [
+        'trilinos',
+        'openmpi4-gnu12-ohpc mpich-gnu12-ohpc'
+    ],
+    'components/perf-tools/extrae/SPECS/extrae.spec': [
+        'extrae',
+        'openmpi4-gnu12-ohpc mpich-gnu12-ohpc'
+    ],
+    'components/perf-tools/geopm/SPECS/geopm.spec': [
+        'geopm',
+        'openmpi4-gnu12-ohpc mpich-gnu12-ohpc'
+    ],
+    'components/perf-tools/likwid/SPECS/likwid.spec': [
+        'likwid',
+        'openmpi4-gnu12-ohpc mpich-gnu12-ohpc'
+    ],
+    'components/perf-tools/papi/SPECS/papi.spec': [
+        'papi',
+        'openmpi4-gnu12-ohpc mpich-gnu12-ohpc'
+    ],
+    'components/perf-tools/scalasca/SPECS/scalasca.spec': [
+        'scalasca',
+        'openmpi4-gnu12-ohpc mpich-gnu12-ohpc'
+    ],
+    'components/perf-tools/tau/SPECS/tau.spec': [
+        'tau',
         'openmpi4-gnu12-ohpc mpich-gnu12-ohpc'
     ],
 }

--- a/tests/common/test_helper_functions.bash
+++ b/tests/common/test_helper_functions.bash
@@ -144,3 +144,13 @@ batslib_prefix() {
   done
 }
 
+# Returns the number of tasks to run in parallel.
+# If SIMPLE_CI is set, returns 2, otherwise returns the value of $1.
+# Defaults to '8' if no $1.
+tasks_count() {
+  local TASKS=${1:-8}
+  if [ ! -z "$SIMPLE_CI" ]; then
+      TASKS=2
+  fi
+  echo $TASKS
+}

--- a/tests/dev-tools/mpi4py/tests/hipy
+++ b/tests/dev-tools/mpi4py/tests/hipy
@@ -12,7 +12,7 @@ check_rms
 rm=$RESOURCE_MANAGER
 
 NODES=2
-TASKS=8
+TASKS=`tasks_count 8`
 ARGS=8
 
 module load $python_module_prefix-mpi4py

--- a/tests/libs/adios/tests/rm_execution
+++ b/tests/libs/adios/tests/rm_execution
@@ -13,11 +13,7 @@ rm=$RESOURCE_MANAGER
 testname="libs/ADIOS"
 
 NODES=2
-if [ -z "$SIMPLE_CI" ]; then
-    TASKS=8
-else
-    TASKS=2
-fi
+TASKS=`tasks_count 8`
 
 @test "[$testname] MPI C binary runs under resource manager ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
     binary=arrays_write

--- a/tests/libs/adios/tests/rm_execution
+++ b/tests/libs/adios/tests/rm_execution
@@ -14,9 +14,9 @@ testname="libs/ADIOS"
 
 NODES=2
 if [ -z "$SIMPLE_CI" ]; then
-    TASKS=2
-else
     TASKS=8
+else
+    TASKS=2
 fi
 
 @test "[$testname] MPI C binary runs under resource manager ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {

--- a/tests/libs/fftw/tests/rm_execution
+++ b/tests/libs/fftw/tests/rm_execution
@@ -12,8 +12,13 @@ check_rms
 rm=$RESOURCE_MANAGER
 
 NODES=2
-TASKS=8
 ARGS=8
+if [ -z "$SIMPLE_CI" ]; then
+    TASKS=8
+else
+    TASKS=2
+fi
+
 
 TIMEOUT="00:05:00"
 

--- a/tests/libs/fftw/tests/rm_execution
+++ b/tests/libs/fftw/tests/rm_execution
@@ -12,13 +12,8 @@ check_rms
 rm=$RESOURCE_MANAGER
 
 NODES=2
+TASKS=`tasks_count 8`
 ARGS=8
-if [ -z "$SIMPLE_CI" ]; then
-    TASKS=8
-else
-    TASKS=2
-fi
-
 
 TIMEOUT="00:05:00"
 

--- a/tests/libs/hypre/tests/rm_execution
+++ b/tests/libs/hypre/tests/rm_execution
@@ -12,7 +12,7 @@ check_rms
 rm=$RESOURCE_MANAGER
 
 NODES=2
-TASKS=4
+TASKS=`tasks_count 4`
 ARGS=8
 
 @test "[libs/HYPRE] 2 PE structured test binary runs under resource manager ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {

--- a/tests/libs/mfem/tests/parallel/rm_execution
+++ b/tests/libs/mfem/tests/parallel/rm_execution
@@ -13,7 +13,7 @@ rm=$RESOURCE_MANAGER
 testname="libs/MFEM"
 
 NODES=2
-TASKS=8
+TASKS=`tasks_count 8`
 
 @test "[$testname] p_laplace MPI binary runs under resource manager ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
     binary=p_laplace

--- a/tests/libs/mumps/tests/rm_execution
+++ b/tests/libs/mumps/tests/rm_execution
@@ -14,7 +14,7 @@ rm=$RESOURCE_MANAGER
 testname="libs/Mumps"
 
 NODES=2
-TASKS=4
+TASKS=`tasks_count 4`
 ARGS=null
 
 @test "[$testname] C (double precision) runs under resource manager ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {

--- a/tests/libs/opencoarrays/tests/rm_execution
+++ b/tests/libs/opencoarrays/tests/rm_execution
@@ -12,7 +12,7 @@ check_rms
 rm=$RESOURCE_MANAGER
 
 NODES=2
-TASKS=2
+TASKS=`tasks_count 2`
 ARGS=8
 
 @test "[libs/OpenCoarrays] hello_multiverse binary runs under resource manager ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {

--- a/tests/libs/petsc/tests/rm_execution
+++ b/tests/libs/petsc/tests/rm_execution
@@ -14,7 +14,7 @@ rm=$RESOURCE_MANAGER
 testname="libs/PETSc"
 
 NODES=2
-TASKS=8
+TASKS=`tasks_count 8`
 ARGS=8
 
 @test "[$testname] MPI C binary runs under resource manager ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {

--- a/tests/libs/phdf5/tests/rm_execution
+++ b/tests/libs/phdf5/tests/rm_execution
@@ -13,7 +13,7 @@ rm=$RESOURCE_MANAGER
 
 CMD_TIMEOUT="1:20"
 NODES=2
-TASKS=8
+TASKS=`tasks_count 8`
 ARGS="$LUSTRE_TEST_PATH/phdf_test.out"
 
 @test "[libs/PHDF5] MPI C binary runs under resource manager ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {

--- a/tests/libs/pnetcdf/tests/rm_execution
+++ b/tests/libs/pnetcdf/tests/rm_execution
@@ -12,7 +12,7 @@ check_rms
 rm=$RESOURCE_MANAGER
 
 NODES=1
-TASKS=2
+TASKS=`tasks_count 2`
 
 @test "[libs/PNETCDF] Parallel Fortran binary runs under resource manager ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
     if [ ! -s f90tst_parallel ];then

--- a/tests/libs/ptscotch/tests/rm_execution
+++ b/tests/libs/ptscotch/tests/rm_execution
@@ -9,7 +9,7 @@ if [ -s ./common/TEST_ENV ];then
 fi
 
 NODES=2
-TASKS=4
+TASKS=`tasks_count 4`
 
 check_rms
 rm=$RESOURCE_MANAGER

--- a/tests/libs/scalapack/tests/rm_execution
+++ b/tests/libs/scalapack/tests/rm_execution
@@ -14,7 +14,7 @@ rm=$RESOURCE_MANAGER
 testname="libs/ScaLAPACK"
 
 NODES=2
-TASKS=8
+TASKS=`tasks_count 8`
 ARGS=0
 
 @test "[$testname/PCSCAEX] CPCGESV under resource manager ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {

--- a/tests/libs/slepc/tests/rm_execution
+++ b/tests/libs/slepc/tests/rm_execution
@@ -12,7 +12,7 @@ check_rms
 rm=$RESOURCE_MANAGER
 
 NODES=2
-TASKS=4
+TASKS=`tasks_count 4`
 ARGS=8
 
 @test "[libs/SLEPc] F90 SVD test binary runs under resource manager ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {

--- a/tests/libs/superlu/tests/rm_execution
+++ b/tests/libs/superlu/tests/rm_execution
@@ -14,7 +14,7 @@ rm=$RESOURCE_MANAGER
 testname="libs/SuperLU"
 
 NODES=1
-TASKS=4
+TASKS=`tasks_count 4`
 ARGS=null
 
 @test "[$testname] C test runs under resource manager ($rm/$LMOD_FAMILY_COMPILER)" {

--- a/tests/libs/superlu_dist/tests/rm_execution
+++ b/tests/libs/superlu_dist/tests/rm_execution
@@ -14,7 +14,7 @@ rm=$RESOURCE_MANAGER
 testname="libs/superLU_dist"
 
 NODES=2
-TASKS=4
+TASKS=`tasks_count 4`
 
 export MV2_ENABLE_AFFINITY=0
 

--- a/tests/libs/trilinos/tests/rm_execution
+++ b/tests/libs/trilinos/tests/rm_execution
@@ -14,7 +14,7 @@ rm=$RESOURCE_MANAGER
 testname="libs/Trilinos"
 
 NODES=2
-TASKS=4
+TASKS=`tasks_count 4`
 ARGS=null
 
 @test "[$testname] Kokkos-MemorySpace runs under resource manager ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {

--- a/tests/mpi/tests/rm_execution_multi_host
+++ b/tests/mpi/tests/rm_execution_multi_host
@@ -12,7 +12,7 @@ check_rms
 RMS=$RESOURCE_MANAGER
 
 NODES=2
-TASKS=8
+TASKS=`tasks_count 8`
 ARGS=8
 
 @test "[MPI] C   binary runs on two nodes under resource manager ($RMS/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {

--- a/tests/mpi/tests/rm_execution_single_host
+++ b/tests/mpi/tests/rm_execution_single_host
@@ -12,7 +12,7 @@ check_rms
 RMS=$RESOURCE_MANAGER
 
 NODES=1
-TASKS=2
+TASKS=`tasks_count 2`
 ARGS=2
 
 @test "[MPI] C binary runs on single node under resource manager ($RMS/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {

--- a/tests/perf-tools/extrae/tests/rm_execution
+++ b/tests/perf-tools/extrae/tests/rm_execution
@@ -12,7 +12,7 @@ check_rms
 rm=$RESOURCE_MANAGER
 
 NODES=2
-TASKS=8
+TASKS=`tasks_count 8`
 ARGS=8
 
 unset OMP_NUM_THREADS

--- a/tests/perf-tools/geopm/tests/rm_execution
+++ b/tests/perf-tools/geopm/tests/rm_execution
@@ -14,7 +14,7 @@ rm=$RESOURCE_MANAGER
 testname="perf-tools/geopm"
 
 NODES=2
-TASKS=4
+TASKS=`tasks_count 4`
 
 @test "[$testname] Test LD_PRELOAD ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
     if [ ! -s tutorial_0 ]; then

--- a/tests/perf-tools/likwid/tests/rm_execution
+++ b/tests/perf-tools/likwid/tests/rm_execution
@@ -14,7 +14,7 @@ rm=$RESOURCE_MANAGER
 testname="perf-tools/likwid"
 
 NODES=2
-TASKS=5
+TASKS=`tasks_count 5`
 ARGS=5
 
 @test "[$testname] C marker API under resource manager ($rm/$LMOD_FAMILY_COMPILER)" {

--- a/tests/perf-tools/papi/tests/rm_execution
+++ b/tests/perf-tools/papi/tests/rm_execution
@@ -14,7 +14,7 @@ rm=$RESOURCE_MANAGER
 testname="perf-tools/papi"
 
 NODES=2
-TASKS=5
+TASKS=`tasks_count 5`
 ARGS=5
 
 @test "[$testname] C dynamic memory info under resource manager ($rm/$LMOD_FAMILY_COMPILER)" {

--- a/tests/perf-tools/scalasca/tests/rm_execution
+++ b/tests/perf-tools/scalasca/tests/rm_execution
@@ -13,7 +13,7 @@ rm=$RESOURCE_MANAGER
 export SCAN_MPI_LAUNCHER=prun
 
 NODES=2
-TASKS=8
+TASKS=`tasks_count 8`
 ARGS=8
 
 @test "[perf-tools/Scalasca] MPI C binary runs under resource manager ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {

--- a/tests/perf-tools/tau/tests/rm_execution
+++ b/tests/perf-tools/tau/tests/rm_execution
@@ -12,7 +12,7 @@ check_rms
 rm=$RESOURCE_MANAGER
 
 NODES=2
-TASKS=8
+TASKS=`tasks_count 8`
 ARGS=8
 LAST_TASK_INDEX=`echo "$TASKS -1" | bc`
 

--- a/tests/rms-harness/tests/test_harness
+++ b/tests/rms-harness/tests/test_harness
@@ -12,7 +12,7 @@ check_rms
 rm=$RESOURCE_MANAGER
 
 NODES=2
-TASKS=2
+TASKS=`tasks_count 2`
 ARGS=2
 
 @test "[RMS/harness] Verify zero exit code from MPI job runs OK ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {


### PR DESCRIPTION
Add mapping for FFTW test.
Fix the value of TASKS depending on whether or not SIMPLE_CI is exported.

Signed-off-by: Martin Tzvetanov Grigorov <mgrigorov@apache.org>