### PR TITLE
admin/meta-packages: use singularity-ce on rhel clones

### DIFF
--- a/components/admin/meta-packages/SPECS/meta-packages.spec
+++ b/components/admin/meta-packages/SPECS/meta-packages.spec
@@ -86,7 +86,6 @@ Requires:  libicu
 Requires:  libunwind
 Requires:  numactl
 Requires:  python3
-Requires:  singularity
 %if 0%{?rhel}
 Requires:  cairo-devel
 Requires:  libpciaccess
@@ -94,6 +93,7 @@ Requires:  libseccomp
 Requires:  librdmacm
 Requires:  NetworkManager
 Requires:  perl-interpreter
+Recommends: (singularity-ce or singularity or apptainer)
 %ifarch x86_64
 Requires:  libpsm2
 %endif
@@ -104,6 +104,7 @@ Requires:  libpciaccess0
 Requires:  libatomic1
 Requires:  librdmacm1
 Requires:  libicu-suse65_1
+Requires:  singularity
 %ifarch x86_64
 Requires:  libpsm2-2
 %endif
@@ -354,7 +355,12 @@ Collection of python3 related library builds for use with GNU compiler toolchain
 %package -n %{PROJ_NAME}-%{compiler_family}-runtimes
 Summary:   OpenHPC runtimes for GNU
 Requires:  charliecloud%{PROJ_DELIM}
+%if 0%{?suse_version}
 Requires:  singularity
+%endif
+%if 0%{?rhel}
+Recommends: (singularity-ce or singularity or apptainer)
+%endif
 %description -n %{PROJ_NAME}-%{compiler_family}-runtimes
 Collection of runtimes for use with GNU compiler toolchain
 

--- a/tests/ci/Makefile
+++ b/tests/ci/Makefile
@@ -1,4 +1,4 @@
-lint: codespell-lint flake8-lint whitespace-lint
+lint: codespell-lint flake8-lint whitespace-lint shellcheck-lint
 
 codespell-lint:
 	@echo "Running 'codespell' on all spec files"

--- a/tests/ci/setup_slurm_and_run_tests.sh
+++ b/tests/ci/setup_slurm_and_run_tests.sh
@@ -13,6 +13,9 @@ dnf -y install \
 	make \
 	which \
 	sudo \
+	prun-ohpc \
+	openmpi4-gnu12-ohpc \
+	mpich-gnu12-ohpc \
 	slurm-slurmd-ohpc \
 	slurm-slurmctld-ohpc \
 	slurm-example-configs-ohpc \
@@ -20,7 +23,7 @@ dnf -y install \
 
 # Install rebuilt packages (if any)
 # shellcheck disable=SC2046 # (we want the words to be split)
-dnf -y install prun-ohpc gnu12-compilers-ohpc openmpi4-gnu12-ohpc mpich-gnu12-ohpc $(find /home/"${USER}"/rpmbuild/RPMS/ -name "*rpm") || true
+dnf -y install $(find /home/"${USER}"/rpmbuild/RPMS/ -name "*rpm") || true
 
 # Setup slurm
 echo "127.0.0.1 node0 node1" >> /etc/hosts


### PR DESCRIPTION
Previously EPEL had the apptainer package which had a 'Provides: singularity'. This was removed: https://pagure.io/epel/issue/214

The changes the OpenHPC meta-package to use the package singularity-ce on RHEL clones.