### PR TITLE
Add support for testing on openEuler 22.03 at CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,6 +6,7 @@ env:
 
 task:
   name: RHEL/Rocky on aarch64
+  timeout_in: 120m
   arm_container:
     image: docker.io/library/rockylinux:8
     cpu: 4
@@ -21,7 +22,6 @@ task:
   build_script: |
     . /etc/profile.d/lmod.sh
     tests/ci/run_build.py ohpc $(tests/ci/cirrus_get_changed_files.sh)
-
 
 openeuler_task:
   name: openEuler on aarch64

--- a/tests/m4/distro_family.m4
+++ b/tests/m4/distro_family.m4
@@ -34,6 +34,9 @@ if test -r "/etc/os-release"; then
    elif grep -q "openSUSE Leap" /etc/os-release; then
       AC_MSG_RESULT([openSUSE Leap])
       DISTRO_FAMILY=SLES
+   elif grep -q "openEuler" /etc/os-release; then
+      AC_MSG_RESULT([openEuler])
+      DISTRO_FAMILY=openEuler
    else  
       AC_MSG_RESULT([unknown])
       echo


### PR DESCRIPTION
Updates the configs for CirrusCI and Github Actions to test on openEuler 22.03.
Updates the Python tests/ci scripts to support openEuler 22.03.

Signed-off-by: Martin Tzvetanov Grigorov <mgrigorov@apache.org>