### PR TITLE
Fix lmod build on openEuler 22.03

### DIFF
--- a/components/admin/lmod/SPECS/lmod.spec
+++ b/components/admin/lmod/SPECS/lmod.spec
@@ -28,7 +28,7 @@ BuildRequires: rsync
 BuildRequires: tcl-devel
 BuildRequires: gcc make bc
 
-%if 0%{?rhel}
+%if 0%{?rhel} || 0%{?openEuler}
 BuildRequires: lua-libs
 BuildRequires: lua-filesystem
 BuildRequires: lua-posix

--- a/tests/ci/prepare-ci-environment.sh
+++ b/tests/ci/prepare-ci-environment.sh
@@ -116,7 +116,7 @@ dnf_rhel() {
 }
 
 dnf_openeuler() {
-	loop_command "${PKG_MANAGER}" -y install ${COMMON_PKGS} git rpm-build gawk
+	loop_command "${PKG_MANAGER}" -y install ${COMMON_PKGS} git dnf-plugins-core rpm-build gawk
 	loop_command "${PKG_MANAGER}" -y install ohpc-filesystem
 }
 


### PR DESCRIPTION
Currently it fails with:
```
[   14s]
[   14s] Error: The follow lua module(s) are missing:  posix
[   14s]
[   14s] You can not run Lmod without:  posix
[   15s] error: Bad exit status from /var/tmp/rpm-tmp.2bQCpR (%build)
[   15s]
```
https://obs.openhpc.community/package/live_build_log/OpenHPC:3.0:Factory/lmod/openEuler_22.03/aarch64

Signed-off-by: Martin Tzvetanov Grigorov <mgrigorov@apache.org>