### PR TITLE
mpi-families: Adapt mpi related pkgs for openEuler

### DIFF
--- a/components/mpi-families/libfabric/SPECS/libfabric.spec
+++ b/components/mpi-families/libfabric/SPECS/libfabric.spec
@@ -28,7 +28,7 @@ BuildRequires: gcc make
 Buildrequires: ofed
 BuildRequires: rdma-core-devel infiniband-diags-devel
 %endif
-%if 0%{?rhel}
+%if 0%{?rhel} || 0%{?openEuler}
 Buildrequires: rdma-core-devel libibmad-devel
 %endif
 %ifarch x86_64

--- a/components/mpi-families/mpich/SPECS/mpich.spec
+++ b/components/mpi-families/mpich/SPECS/mpich.spec
@@ -63,6 +63,7 @@ Patch0:    config.pmix.patch
 %global _default_patch_fuzz 2
 
 Requires: prun%{PROJ_DELIM} >= 1.2
+BuildRequires: perl
 Requires: perl
 BuildRequires: zlib-devel make
 %if 0%{?suse_version}

--- a/components/mpi-families/mvapich2/SPECS/mvapich2.spec
+++ b/components/mpi-families/mvapich2/SPECS/mvapich2.spec
@@ -61,7 +61,7 @@ Conflicts: %{pname}-%{compiler_family}%{PROJ_DELIM}
 Buildrequires: ofed
 BuildRequires: rdma-core-devel infiniband-diags-devel
 %endif
-%if 0%{?rhel}
+%if 0%{?rhel} || 0%{?openEuler}
 Buildrequires: rdma-core-devel libibmad-devel
 %endif
 

--- a/components/mpi-families/openmpi/SPECS/openmpi.spec
+++ b/components/mpi-families/openmpi/SPECS/openmpi.spec
@@ -68,7 +68,7 @@ BuildRequires:  libevent-devel
 %endif
 %if 0%{with_ofi}
 BuildRequires:  libfabric%{PROJ_DELIM}
-%if 0%{?rhel}
+%if 0%{?rhel} || 0%{?openEuler}
 BuildRequires:  libibverbs-devel
 %endif
 %ifarch x86_64
@@ -81,7 +81,7 @@ Requires: ucx%{PROJ_DELIM}
 Requires: ucx-ib%{PROJ_DELIM}
 %endif
 BuildRequires:  hwloc%{PROJ_DELIM}
-%if 0%{?rhel}
+%if 0%{?rhel} || 0%{?openEuler}
 BuildRequires: libtool-ltdl
 %endif
 %if 0%{with_slurm}


### PR DESCRIPTION
- Adapt mvapich2/openmpi for openEuler
- Add perl build requires for mpich (mpich-ucx-gnu12) to solve `*** No rule to make target 'include/mplconfig.h', needed by 'all-am'.  Stop.`

Signed-off-by: Yikun Jiang <yikunkero@gmail.com>