### PR TITLE
dev-tools: Adapt all pkgs for openEuler

### DIFF
--- a/components/dev-tools/automake/SPECS/automake.spec
+++ b/components/dev-tools/automake/SPECS/automake.spec
@@ -15,7 +15,7 @@
 Summary:   A GNU tool for automatically creating Makefiles
 Name:      %{pname}%{PROJ_DELIM}
 Version:   1.16.1
-Release:   1%{?dist}
+Release:   %{?dist}.1
 License:   GNU GPL
 Group:     %{PROJ_NAME}/dev-tools
 URL:       http://www.gnu.org/software/automake/

--- a/components/dev-tools/cmake/SPECS/cmake.spec
+++ b/components/dev-tools/cmake/SPECS/cmake.spec
@@ -24,14 +24,14 @@ License:        BSD-3-Clause
 Group:          %{PROJ_NAME}/dev-tools
 URL:            https://cmake.org/
 Source0:        https://cmake.org/files/v%{major_version}/cmake-%{version}.tar.gz
-BuildRequires:  gcc-c++
+BuildRequires:  gcc-c++ make
 BuildRequires:  curl-devel
 BuildRequires:  ncurses-devel
 BuildRequires:  xz-devel
 BuildRequires:  zlib-devel
 BuildRequires:  pkgconfig
 
-%if 0%{?rhel}
+%if 0%{?rhel} || 0%{?openEuler}
 BuildRequires:  expat-devel
 BuildRequires:  bzip2-devel
 %endif

--- a/components/dev-tools/libtool/SPECS/libtool.spec
+++ b/components/dev-tools/libtool/SPECS/libtool.spec
@@ -15,7 +15,7 @@
 Summary:   The GNU Portable Library Tool
 Name:      %{pname}%{PROJ_DELIM}
 Version:   2.4.6
-Release:   1%{?dist}
+Release:   %{?dist}.1
 License:   GPLv2
 Group:     %{PROJ_NAME}/dev-tools
 URL:       http://www.gnu.org/software/libtool/

--- a/components/dev-tools/spack/SPECS/spack.spec
+++ b/components/dev-tools/spack/SPECS/spack.spec
@@ -42,7 +42,7 @@ Requires: zstd
 Requires: file
 Requires: git
 Requires: curl
-%if 0%{?rhel}
+%if 0%{?rhel} || 0%{?openEuler}
 Requires: gnupg2
 %endif
 %if 0%{?suse_version}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,7 +4,7 @@ AM_MAKEFLAGS     = --no-print-directory
 SUBDIRS          = 
 TESTS            =
 
-# Tests are broken up into those which require elevetated credentials
+# Tests are broken up into those which require elevated credentials
 # versus those that run in normal userspace
 
 if ROOT_ENABLED

--- a/tests/ci/setup_slurm_and_run_tests.sh
+++ b/tests/ci/setup_slurm_and_run_tests.sh
@@ -121,7 +121,7 @@ fi
 
 set -e
 
-# If we are here, the tests failed. Print the logs.
+# If we are here, the tests failed. Print the logs and exit with an error code.
 echo -e "\nThe tests execution failed. Printing the logs.\n"
 find ./ -name "*.log" -print0 | while IFS= read -r -d '' log_file
 do

--- a/tests/ci/spec_to_test_mapping.py
+++ b/tests/ci/spec_to_test_mapping.py
@@ -168,6 +168,16 @@ test_map = {
         'oob',
         ''
     ],
+    'components/dev-tools/autoconf/SPECS/autoconf.spec': [
+        'autotools',
+        '',
+        'autoconf-ohpc automake-ohpc libtool-ohpc'
+    ],
+    'components/dev-tools/cmake/SPECS/cmake.spec': [
+        'cmake',
+        '',
+        'cmake-ohpc'
+    ],
 }
 
 

--- a/tests/configure.ac
+++ b/tests/configure.ac
@@ -586,7 +586,7 @@ if test "x$ROOT_ENABLED" = "x1" ; then
     else 
        echo '    'Out of band tools......... : disabled
     fi
-    
+   
     if test "x$enable_spack" = "xyes"; then
        echo '    'Spack..................... : enabled
     else


### PR DESCRIPTION
Duplicate of https://github.com/openhpc/ohpc/pull/1657 + tests


- Add make as autoconf/cmake BuildRequires
- Adapt openEuler 22.03
- Add perl(File::Compare) buildrequires to fix autoconf error

Signed-off-by: Yikun Jiang <yikunkero@gmail.com>

Add mappings for testing autoconf, cmake and spack

Signed-off-by: Martin Tzvetanov Grigorov <mgrigorov@apache.org>