### PR TITLE
Change upload-artifact action retention-days to 1

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -69,6 +69,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: rhel-rpms
+        retention-days: 1
         path: |
           /home/ohpc/rpmbuild/RPMS/noarch/*rpm
           /home/ohpc/rpmbuild/RPMS/x86_64/*rpm


### PR DESCRIPTION
Change upload-artifact action retention-days to `1` to avoid over the spending limit.



Signed-off-by: Yikun Jiang <yikunkero@gmail.com>