### PR TITLE
Update autoconf.spec to support openEuler

### DIFF
--- a/components/dev-tools/autoconf/SPECS/autoconf.spec
+++ b/components/dev-tools/autoconf/SPECS/autoconf.spec
@@ -21,11 +21,13 @@ Group:     %{PROJ_NAME}/dev-tools
 URL:       http://www.gnu.org/software/autoconf/
 Source0:   https://ftp.gnu.org/gnu/autoconf/autoconf-%{version}.tar.gz
 
-BuildRequires: m4
+BuildRequires: m4 make
 Requires: m4
 
-%if 0%{?rhel_version} || 0%{?centos_version} || 0%{?rhel}
+%if 0%{?rhel_version} || 0%{?centos_version} || 0%{?rhel} || 0%{?openEuler}
 BuildRequires: perl-macros
+BuildRequires: perl(File::Compare)
+BuildRequires: perl(File::Copy)
 BuildRequires: perl(Data::Dumper)
 # from f19, Text::ParseWords is not the part of 'perl' package
 BuildRequires: perl(Text::ParseWords)


### PR DESCRIPTION
Extracts just the `autoconf` related changes from https://github.com/openhpc/ohpc/pull/1663.
This is needed because `automake-ohpc` cannot be built without `autoconf-ohpc` being installed. 

Signed-off-by: Martin Tzvetanov Grigorov <mgrigorov@apache.org>