### PR TITLE
devtoosl/libtool: Add gcc-c++/make buildrequires

### DIFF
--- a/components/dev-tools/libtool/SPECS/libtool.spec
+++ b/components/dev-tools/libtool/SPECS/libtool.spec
@@ -30,6 +30,7 @@ Requires:      autoconf%{PROJ_DELIM} >= 2.69
 Requires:      automake%{PROJ_DELIM} >= 1.14.1
 BuildRequires: autoconf%{PROJ_DELIM} >= 2.69
 BuildRequires: automake%{PROJ_DELIM} >= 1.14.1
+BuildRequires: gcc-c++ make
 
 %description
 GNU Libtool is a set of shell scripts which automatically configure UNIX and


### PR DESCRIPTION
Add gcc-c++/make buildrequires to avoid error like:
```
configure: error: in `/home/abuild/rpmbuild/BUILD/libtool-2.4.6':
configure: error: no acceptable C compiler found in $PATH
```

```
/var/tmp/rpm-tmp.lwYcMM: line 37: make: command not found
```

Signed-off-by: Yikun Jiang <yikunkero@gmail.com>