### PR TITLE
admin/hpc-workspace: Fix Source0 and add make requirement

### DIFF
--- a/components/admin/hpc-workspace/SPECS/hpcworkspace.spec
+++ b/components/admin/hpc-workspace/SPECS/hpcworkspace.spec
@@ -17,12 +17,12 @@ Version: 1.4.0
 Release: 1%{?dist}
 Summary: Temporary workspace management
 License: GPL
-Source:  https://github.com/holgerBerger/hpc-workspace/archive/refs/tags/%{version}.tar.gz
+Source0: https://github.com/holgerBerger/hpc-workspace/archive/refs/tags/%{version}.tar.gz
 Source1: ws.conf.template
 Group:   %{PROJ_NAME}/admin
 URL:     https://github.com/holgerBerger/hpc-workspace
 
-BuildRequires: gcc-c++
+BuildRequires: gcc-c++ make
 BuildRequires: python3-devel
 BuildRequires: boost-devel
 %if 0%{?suse_version}


### PR DESCRIPTION
- Fix Source0 to fix `error: No source number 0` on rehl and openEuler
- Add make build requirement to fix `CMAKE_MAKE_PROGRAM is not set`

Signed-off-by: Yikun Jiang <yikunkero@gmail.com>