### PR TITLE
boost: Adapt distro pkgs for openEuler

### DIFF
--- a/components/parallel-libs/boost/SPECS/boost.spec
+++ b/components/parallel-libs/boost/SPECS/boost.spec
@@ -43,6 +43,7 @@ BuildRequires:  libquadmath-devel
 %endif
 %endif
 
+BuildRequires:  make
 BuildRequires:  fdupes
 BuildRequires:  dos2unix
 BuildRequires:  gmp-devel
@@ -106,7 +107,7 @@ export RPM_OPT_FLAGS="$RPM_OPT_FLAGS -fno-strict-aliasing -Wno-unused-local-type
 export RPM_LD_FLAGS
 
 cat << "EOF" >> rpm-config.jam
-%if 0%{?rhel} >= 9
+%if 0%{?rhel} >= 9 || 0%{?openEuler}
 using python : %{python3_version} : %{__python3} : /usr/include/python%{python3_version} ;
 %else
 using python : %{python3_version} : %{__python3} : /usr/include/python%{python3_version}m ;

--- a/tests/ci/run_build.py
+++ b/tests/ci/run_build.py
@@ -172,6 +172,10 @@ def build_srpm_and_rpm(command, family=None):
     if family is not None:
         rebuild_command[-1] += " --define 'mpi_family %s'" % family
 
+    # Disable parallel builds for boost on aarch64 to avoid OOM
+    if "boost-" in src_rpm and os.uname().machine == "aarch64":
+        rebuild_command[-1] += " --define '_smp_mflags -j1'"
+
     success, _ = run_command(rebuild_command)
     if not success:
         logging.error("Running 'rpmbuild --rebuild' failed")

--- a/tests/ci/spec_to_test_mapping.py
+++ b/tests/ci/spec_to_test_mapping.py
@@ -178,6 +178,11 @@ test_map = {
         '',
         'cmake-ohpc'
     ],
+    'components/parallel-libs/boost/SPECS/boost.spec': [
+        'boost',
+        '',
+        ''
+    ],
 }
 
 


### PR DESCRIPTION
- Add make build requires
- Adapt distro pkgs for openEuler
- Add test mapping for boost

Signed-off-by: Yikun Jiang <yikunkero@gmail.com>