### PR TITLE
paraver: Adapt pkg for openEuler

### DIFF
--- a/components/perf-tools/paraver/SPECS/paraver.spec
+++ b/components/perf-tools/paraver/SPECS/paraver.spec
@@ -27,7 +27,7 @@ Source0:       https://ftp.tools.bsc.es/wxparaver/wxparaver-%{version}-src.tar.b
 BuildRequires: gcc-c++
 BuildRequires: bison
 BuildRequires: boost-devel
-%if 0%{?rhel}
+%if 0%{?rhel} || 0%{?openEuler}
 BuildRequires: libfabric-devel
 BuildRequires: flex-devel
 BuildRequires: wxGTK3-devel
@@ -67,7 +67,7 @@ achieving these targets.
 
 %build
 
-%if 0%{?rhel}
+%if 0%{?rhel} || 0%{?openEuler}
 CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --with-wx-config=/usr/bin/wx-config-3.0 "
 %endif
 %if 0%{?suse_version}

--- a/tests/ci/run_build.py
+++ b/tests/ci/run_build.py
@@ -172,8 +172,9 @@ def build_srpm_and_rpm(command, family=None):
     if family is not None:
         rebuild_command[-1] += " --define 'mpi_family %s'" % family
 
-    # Disable parallel builds for boost on aarch64 to avoid OOM
-    if "boost-" in src_rpm and os.uname().machine == "aarch64":
+    # Disable parallel builds for below packages on aarch64 to avoid OOM
+    pkgs = ["boost-", "paraver-"]
+    if any([x in src_rpm for x in pkgs]) and os.uname().machine == "aarch64":
         rebuild_command[-1] += " --define '_smp_mflags -j1'"
 
     success, _ = run_command(rebuild_command)


### PR DESCRIPTION
Adapt paraver pkg for openEuler and disable parallel builds on aarch64 to avoid OOM.

Signed-off-by: Yikun Jiang <yikunkero@gmail.com>