### PR TITLE
dev-tools/hwloc: update to 2.7.2 or 2.9.0

### DIFF
--- a/components/dev-tools/hwloc/SPECS/hwloc.spec
+++ b/components/dev-tools/hwloc/SPECS/hwloc.spec
@@ -10,16 +10,25 @@
 
 %include %{_sourcedir}/OHPC_macros
 
+%if 0%{?rhel} >= 9 || 0%{?openEuler} || 0%{?sle_version} >= 150400
+%define major_version 2.9
+%define minor_version 0
+%else
+%define major_version 2.7
+%define minor_version 2
+%endif
+%define version %{major_version}.%{minor_version}
+
 %define pname hwloc
 
 Name:           %{pname}%{PROJ_DELIM}
-Version:        2.7.1
+Version:        %{version}
 Release:        %{?dist}.1
 Summary:        Portable Hardware Locality
 License:        BSD-3-Clause
 Group:          %{PROJ_NAME}/dev-tools
 Url:            http://www.open-mpi.org/projects/hwloc/
-Source0:        https://download.open-mpi.org/release/hwloc/v2.7/%{pname}-%{version}.tar.bz2
+Source0:        https://download.open-mpi.org/release/hwloc/v%{major_version}/%{pname}-%{version}.tar.bz2
 
 BuildRequires:  make
 BuildRequires:  doxygen
@@ -31,7 +40,7 @@ BuildRequires:  libxml2-devel
 BuildRequires:  ncurses-devel
 BuildRequires:  ncurses-devel
 BuildRequires:  transfig
-%if 0%{?sles_version} || 0%{?suse_version}
+%if 0%{?sle_version}
 BuildRequires:  libnuma-devel
 %else
 BuildRequires:  numactl-devel

--- a/misc/get_source.sh
+++ b/misc/get_source.sh
@@ -5,6 +5,13 @@ if [ $# -ne 1 ]; then
 	exit 1
 fi
 
+# If running on Fedora special defines are needed
+DISTRO=$(rpm --eval '0%{?fedora}')
+
+if [ "${DISTRO}" != "0" ]; then
+	FLAGS=(--undefine fedora --define "rhel 8")
+fi
+
 PATTERN=${1}
 
 IFS=$'\n'
@@ -22,7 +29,7 @@ do
 	pushd "${DIR}" > /dev/null || exit 1
 	BASE=$(basename "${file}")
 
-	SOURCES=$(rpmspec --parse --define '_sourcedir ../../..' --define 'rhel 8' "${BASE}" | grep Source)
+	SOURCES=$(rpmspec --parse --define '_sourcedir ../../..' "${FLAGS[@]}" "${BASE}" | grep Source)
 	for u in ${SOURCES}; do
 		echo "${u}"
 		if [[ "${u}" != *"http"* ]]; then


### PR DESCRIPTION
Based on the build distribution hwloc is upgraded to 2.7.2 (for the OpenHPC 2.x branch) or 2.9.0 (for the OpenHPC 3.x branch).