### PR TITLE
Switch openEuler repo to mirror repo

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -31,6 +31,7 @@ openeuler_task:
     cpu: 4
     memory: 12G
   script: uname -a
+  repo_script: sed -i "s@repo.openeuler.org@repo.huaweicloud.com/openeuler@g" /etc/yum.repos.d/openEuler.repo
   setup_script: tests/ci/prepare-ci-environment.sh
   build_script: |
     . /etc/profile.d/lmod.sh

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -117,6 +117,8 @@ jobs:
     container:
       image: docker.io/openeuler/openeuler:22.03-lts
     steps:
+    - name: Switch repo
+      run: sed -i "s@repo.openeuler.org@repo.huaweicloud.com/openeuler@g" /etc/yum.repos.d/openEuler.repo
     - name: Install git
       run: dnf -y install git
     - uses: actions/checkout@v3
@@ -145,6 +147,8 @@ jobs:
       image: docker.io/openeuler/openeuler:22.03-lts
     needs: build_on_openEuler
     steps:
+    - name: Switch repo
+      run: sed -i "s@repo.openeuler.org@repo.huaweicloud.com/openeuler@g" /etc/yum.repos.d/openEuler.repo
     - name: Install git
       run: dnf -y install git
     - uses: actions/checkout@v3


### PR DESCRIPTION
openEuler infra team will add CDN for openEuler repo in 2023 H1, Before this, we'd better switch to mirror repo to speed up CI.

[1] https://www.openeuler.org/en/mirror/list/
[2] https://github.com/Yikun/test-repo/pull/1

Signed-off-by: Yikun Jiang <yikunkero@gmail.com>