### PR TITLE
perf-tools/scalasca: fix build with latest intel compiler

### DIFF
--- a/components/perf-tools/scalasca/SPECS/scalasca.spec
+++ b/components/perf-tools/scalasca/SPECS/scalasca.spec
@@ -27,7 +27,7 @@ Source0:   http://apps.fz-juelich.de/scalasca/releases/scalasca/%{version}/dist/
 Requires:  lmod%{PROJ_DELIM} >= 7.6.1
 BuildRequires: scorep-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  scorep-%{compiler_family}-%{mpi_family}%{PROJ_DELIM} >= 4.0
-BuildRequires: zlib-devel gcc-c++
+BuildRequires: zlib-devel gcc-c++ which make
 
 # Default library install path
 %define install_path %{OHPC_LIBS}/%{compiler_family}/%{mpi_family}/%{pname}/%version
@@ -61,6 +61,7 @@ module load scorep
 
 %if "%{compiler_family}" == "intel"
 CONFIGURE_OPTIONS="--with-nocross-compiler-suite=intel "
+export __INTEL_PRE_CFLAGS="-diag-disable=10441"
 %endif
 
 %if "%{mpi_family}" == "impi"
@@ -84,6 +85,8 @@ CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --with-mpi=openmpi "
 %endif
 
 ./configure --prefix=%{install_path} $CONFIGURE_OPTIONS
+
+make %{?_smp_mflags}
 
 %install
 

--- a/tests/ci/spec_to_test_mapping.py
+++ b/tests/ci/spec_to_test_mapping.py
@@ -146,7 +146,7 @@ test_map = {
     'components/perf-tools/scalasca/SPECS/scalasca.spec': [
         'scalasca',
         '',
-        ''
+        'lmod-defaults-gnu12-openmpi4-ohpc'
     ],
     'components/perf-tools/tau/SPECS/tau.spec': [
         'tau',


### PR DESCRIPTION
The latest intel compiler prints out a deprecation warning that breaks one of the tests during configure. If this deprecation message is disabled configure passes.