### PR TITLE
parallel-libs/hypre: add make as a BuildRequires

### DIFF
--- a/components/parallel-libs/hypre/SPECS/hypre.spec
+++ b/components/parallel-libs/hypre/SPECS/hypre.spec
@@ -29,6 +29,7 @@ License:        Apache-2.0 or MIT
 Group:          %{PROJ_NAME}/parallel-libs
 Url:            http://www.llnl.gov/casc/hypre/
 Source0:        https://github.com/hypre-space/hypre/archive/v%{version}.tar.gz#/hypre-%{version}.tar.gz
+BuildRequires:  make
 BuildRequires:  superlu-%{compiler_family}%{PROJ_DELIM}
 Requires:       superlu-%{compiler_family}%{PROJ_DELIM}
 Requires:       lmod%{PROJ_DELIM} >= 7.6.1

--- a/tests/common/functions
+++ b/tests/common/functions
@@ -255,10 +255,14 @@ run_mpi_binary () {
     # Parse optional arguments
     input_file=""
     output_file=""
-    if [ "$RESOURCE_MANAGER" = "slurm" ];then
-	timeout=5		# default job timeout (in minutes)
+    if [ "$RESOURCE_MANAGER" = "slurm" ]; then
+		if [ ! -z "$SIMPLE_CI" ]; then
+			timeout=5		# default job timeout (in minutes)
+		else
+			timeout=2		# default job timeout (in minutes)
+		fi
     else
-	timeout="00:02:00"
+		timeout="00:02:00"
     fi
 
     local OPTIND=1

--- a/tests/common/functions
+++ b/tests/common/functions
@@ -256,7 +256,7 @@ run_mpi_binary () {
     input_file=""
     output_file=""
     if [ "$RESOURCE_MANAGER" = "slurm" ];then
-	timeout=2		# default job timeout (in minutes)
+	timeout=5		# default job timeout (in minutes)
     else
 	timeout="00:02:00"
     fi


### PR DESCRIPTION
The builds at OBS are successful:
* https://obs.openhpc.community/package/show/home:mgrigorov/hypre-gnu12-openmpi4
* https://obs.openhpc.community/package/show/home:mgrigorov/hypre-gnu12-mpich

There is a test mapping already:
https://github.com/openhpc/ohpc/blob/222d7931e7df61b1aeacc4e975e2b859dca3af82/tests/ci/spec_to_test_mapping.py#L66-L70