### PR TITLE
rms/pmix: add "BuildRequires: make"

### DIFF
--- a/components/rms/pmix/SPECS/pmix.spec
+++ b/components/rms/pmix/SPECS/pmix.spec
@@ -20,6 +20,7 @@ URL: https://pmix.github.io/pmix/
 Group: %{PROJ_NAME}/rms
 Source0: https://github.com/pmix/pmix/releases/download/v%{version}/pmix-%{version}.tar.bz2
 
+BuildRequires: make
 BuildRequires: libevent-devel
 BuildRequires: gcc-c++
 BuildRequires: python3


### PR DESCRIPTION
OBS build results:
https://obs.openhpc.community/package/show/home:mgrigorov/pmix-gnu12-openmpi4

There are no tests for PMIx, so nothing to update in the mapping file.