### PR TITLE
perf-tools/likwid: add a "BuildRequires: make"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,6 +4,7 @@ env:
     components/compiler-families/intel-compilers-devel/SPECS/intel-compilers-devel.spec
     components/mpi-families/impi-devel/SPECS/intel-mpi.spec
     components/parallel-libs/trilinos/SPECS/trilinos.spec
+    components/perf-tools/likwid/SPECS/likwid.spec
 
 task:
   name: RHEL/Rocky on aarch64

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,6 +12,7 @@ env:
   SKIP_CI_SPECS: |
     components/fs/lustre-client/SPECS/lustre.spec
     components/parallel-libs/trilinos/SPECS/trilinos.spec
+    components/perf-tools/likwid/SPECS/likwid.spec
 
 jobs:
   check_spec:

--- a/components/perf-tools/likwid/SPECS/likwid.spec
+++ b/components/perf-tools/likwid/SPECS/likwid.spec
@@ -32,6 +32,7 @@ BuildRequires: gcc-gfortran
 BuildRequires: gcc-fortran
 %endif
 
+BuildRequires: make
 BuildRequires: perl
 Requires: perl
 BuildRequires: lua


### PR DESCRIPTION
There is a test mapping:
https://github.com/openhpc/ohpc/blob/20443346a8a719622569a3b01741348898ff6710/tests/ci/spec_to_test_mapping.py#L136-L140

The build passes on OBS x86_64: https://obs.openhpc.community/package/live_build_log/home:mgrigorov/likwid-gnu12-openmpi4/OpenHPC_3.0_Factory_openEuler_22.03/x86_64

But fails on aarch64:
https://obs.openhpc.community/package/live_build_log/home:mgrigorov/likwid-gnu12-openmpi4/OpenHPC_3.0_Factory_openEuler_22.03/aarch64 with
```
[   21s] gcc -c  -O2 -std=c99 -Wno-format -fPIC -fPIC -fvisibility=hidden   -DPAGE_ALIGNMENT=4096 -DLIKWID_MONITOR_LOCK -DDEBUGLEV=0 -DVERSION=5 -DRELEASE=2 -DMINORVERSION=2 -DCFGFILE=/etc/likwid.cfg -DTOPOFILE=/etc/likwid_topo.cfg -DINSTALL_PREFIX=/opt/ohpc/pub/libs/gnu12/likwid/5.2.2 -DMAX_NUM_THREADS=300 -DMAX_NUM_NODES=64 -DMAX_NUM_CLIARGS=16384 -DACCESSDAEMON=/opt/ohpc/pub/libs/gnu12/likwid/5.2.2/sbin/likwid-accessD -DFREQDAEMON=/opt/ohpc/pub/libs/gnu12/likwid/5.2.2/sbin/likwid-setFreq -DGROUPPATH=/opt/ohpc/pub/libs/gnu12/likwid/5.2.2/share/likwid/perfgroups -DLIKWIDLOCK=/var/run/likwid.lock -DLIKWIDSOCKETBASE=/tmp/likwid   -DGITCOMMIT=233ab943543480cd46058b34616c174198ba0459 -D_GNU_SOURCE -DCOLOR=BLUE -DHAS_MEMPOLICY -DHAS_SCHEDAFFINITY -DLIKWID_USE_HWLOC -DACCESSMODE=1 -I./src/includes -I/home/abuild/rpmbuild/BUILD/likwid-5.2.2/ext/lua/includes -I/home/abuild/rpmbuild/BUILD/likwid-5.2.2/ext/hwloc/include -I./GCC ./src/access_x86_rdpmc.c -o GCC/access_x86_rdpmc.o
[   21s] In function '__rdpmc',
[   21s]     inlined from 'test_rdpmc.constprop' at ./src/access_x86_rdpmc.c:118:13:
[   21s] ./src/access_x86_rdpmc.c:77:5: error: impossible constraint in 'asm'
[   21s]    77 |     __asm__ volatile("rdpmc" : "=a" (low), "=d" (high) : "c" (counter));
[   21s]       |     ^~~~~~~
[   21s] ./src/access_x86_rdpmc.c:77:5: error: impossible constraint in 'asm'
[   21s] make: *** [Makefile:302: GCC/access_x86_rdpmc.o] Error 1
[   21s] error: Bad exit status from /var/tmp/rpm-tmp.EszyWr (%build)
[   21s] 
[   21s] 
[   21s] RPM build errors:
[   21s]     Bad exit status from /var/tmp/rpm-tmp.EszyWr (%build)
```
