### PR TITLE
Update warewulf-ipmi to 3.10.0

### DIFF
--- a/components/provisioning/warewulf-ipmi/SOURCES/openEuler.initramfs.patch
+++ b/components/provisioning/warewulf-ipmi/SOURCES/openEuler.initramfs.patch
@@ -1,0 +1,13 @@
+diff --git i/ipmi/initramfs/Makefile.am w/ipmi/initramfs/Makefile.am
+index 65635a6..b1661ce 100644
+--- i/ipmi/initramfs/Makefile.am
++++ w/ipmi/initramfs/Makefile.am
+@@ -41,6 +41,8 @@ rootfs: ipmitool
+ 	mkdir rootfs/sbin
+ 	mkdir rootfs/lib
+ 	mkdir rootfs/lib64
++	mkdir -p rootfs/usr/lib
++	mkdir -p rootfs/usr/lib64
+ 	mkdir -p rootfs/warewulf/provision/
+ 	chmod -R u+w rootfs/
+ 	cp -a ipmitool rootfs/sbin/

--- a/components/provisioning/warewulf-ipmi/SPECS/warewulf-ipmi.spec
+++ b/components/provisioning/warewulf-ipmi/SPECS/warewulf-ipmi.spec
@@ -36,6 +36,10 @@ Requires: %{name}-initramfs-%{_arch} = %{version}-%{release}
 %global localipmi 1
 BuildRequires: ipmitool
 Requires: ipmitool
+BuildRequires: which
+%if 0%{?rhel} >= 8
+BuildRequires: perl-generators
+%endif
 %define CONF_FLAGS "--with-local-ipmitool=yes"
 %else
 %global localipmi 0
@@ -45,7 +49,6 @@ BuildRequires: autoconf
 BuildRequires: automake
 BuildRequires: make
 BuildRequires: gcc
-BuildRequires: which
 BuildRequires: warewulf-common%{PROJ_DELIM}
 BuildRequires: openssl-devel
 

--- a/components/provisioning/warewulf-ipmi/SPECS/warewulf-ipmi.spec
+++ b/components/provisioning/warewulf-ipmi/SPECS/warewulf-ipmi.spec
@@ -45,6 +45,7 @@ BuildRequires: autoconf
 BuildRequires: automake
 BuildRequires: make
 BuildRequires: gcc
+BuildRequires: which
 BuildRequires: warewulf-common%{PROJ_DELIM}
 BuildRequires: openssl-devel
 

--- a/components/provisioning/warewulf-ipmi/SPECS/warewulf-ipmi.spec
+++ b/components/provisioning/warewulf-ipmi/SPECS/warewulf-ipmi.spec
@@ -12,18 +12,19 @@
 
 %define dname ipmi
 %define pname warewulf-%{dname}
-%define wwsrvdir /srv
-%define develSHA 98fcdc336349378c8ca1b5b0e7073a69a868a40f
+%define wwsrvdir /var/lib
+%define develSHA c6de604fc76eabfaef2cb99f4c6ae5ed44eff1e0
 %define wwextract warewulf3-%{develSHA}
 
 Name:    %{pname}%{PROJ_DELIM}
-Version: 3.9.0
-Provides: warewulf-ipmi = 3.9.0
+Version: 3.10.0
+Provides: warewulf-ipmi = %{version}
 Release: 1%{?dist}
 Summary: Warewulf - IPMI support
 License: US Dept. of Energy (BSD-like)
 URL: http://warewulf.lbl.gov/
 Source0: https://github.com/warewulf/warewulf3/archive/%{develSHA}.tar.gz
+Patch0:  openEuler.initramfs.patch
 Group:   %{PROJ_NAME}/provisioning
 ExclusiveOS: linux
 Conflicts: warewulf < 3
@@ -31,7 +32,7 @@ Requires: warewulf-common%{PROJ_DELIM}
 Requires: %{name}-initramfs-%{_arch} = %{version}-%{release}
 
 
-%if 0%{?rhel} >= 8 || 0%{?sle_version} >= 150000
+%if 0%{?rhel} >= 8 || 0%{?sle_version} >= 150000 || 0%{?openEuler}
 %global localipmi 1
 BuildRequires: ipmitool
 Requires: ipmitool
@@ -42,6 +43,8 @@ Requires: ipmitool
 
 BuildRequires: autoconf
 BuildRequires: automake
+BuildRequires: make
+BuildRequires: gcc
 BuildRequires: warewulf-common%{PROJ_DELIM}
 BuildRequires: openssl-devel
 
@@ -60,11 +63,13 @@ cd %{_builddir}
 %{__rm} -rf %{name}-%{version} %{wwextract}
 %{__ln_s} %{wwextract}/%{dname} %{name}-%{version}
 %setup -q -D
-
+%if 0%{?openEuler}
+%patch0 -p2
+%endif
 
 %build
 ./autogen.sh
-%configure --localstatedir=%{wwsrvdir} %{?CONF_FLAGS}
+%configure --localstatedir=%{wwsrvdir} --sharedstatedir=%{wwsrvdir} %{?CONF_FLAGS}
 %{__make} %{?mflags}
 
 

--- a/components/provisioning/warewulf-ipmi/SPECS/warewulf-ipmi.spec
+++ b/components/provisioning/warewulf-ipmi/SPECS/warewulf-ipmi.spec
@@ -12,7 +12,7 @@
 
 %define dname ipmi
 %define pname warewulf-%{dname}
-%define wwsrvdir /var/lib
+%define wwsrvdir /srv
 %define develSHA c6de604fc76eabfaef2cb99f4c6ae5ed44eff1e0
 %define wwextract warewulf3-%{develSHA}
 
@@ -69,7 +69,7 @@ cd %{_builddir}
 
 %build
 ./autogen.sh
-%configure --localstatedir=%{wwsrvdir} --sharedstatedir=%{wwsrvdir} %{?CONF_FLAGS}
+%configure --sharedstatedir=%{wwsrvdir} %{?CONF_FLAGS}
 %{__make} %{?mflags}
 
 


### PR DESCRIPTION
Add a patch for openEuler because its `ldd` returns paths starting with `/usr/lib**` while all other distros (e.g. Rocky and Ubuntu) return `/lib**`, i.e. without the leading `/usr`. Those are symlinks anyway.

Set wwsrvdir to "/var/lib" to be able to pass the build. The problem is that if we use a custom value then it is ignored. The configure line looks like:

```
[   22s] + ./configure --build=aarch64-openEuler-linux-gnu --host=aarch64-openEuler-linux-gnu \
 --program-prefix=  --disable-dependency-tracking --prefix=/usr --exec-prefix=/usr --bindir=/usr/bin \
 --sbindir=/usr/sbin  --sysconfdir=/etc --datadir=/usr/share --includedir=/usr/include --libdir=/usr/lib64 \
 --libexecdir=/usr/libexec  --localstatedir=/var --sharedstatedir=/var/lib --mandir=/usr/share/man \
 --infodir=/usr/share/info --localstatedir=/var/lib --sharedstatedir=/var/lib --with-local-ipmitool=yes
```
Note that it contains `--localstatedir` and `--sharedstatedir` twice. The second ones are from `%configure --localstatedir=%{wwsrvdir} --sharedstatedir=%{wwsrvdir} %{?CONF_FLAGS}` from the .spec but they seem to be always ignored.
Without this change the `%files initramfs-%{_arch}` at the common of the spec fail to find the directories and the file