### PR TITLE
perf-tools/papi57: add compatibility papi57 package

### DIFF
--- a/components/perf-tools/papi57/LICENSE
+++ b/components/perf-tools/papi57/LICENSE
@@ -1,0 +1,33 @@
+                           Copyright (c) 2005 - 2010
+                        Innovative Computing Laboratory
+               Dept of Electrical Engineering & Computer Science
+                            University of Tennessee, 
+                                 Knoxville, TN. 
+                              All Rights Reserved. 
+
+
+Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, 
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice, 
+      this list of conditions and the following disclaimer in the documentation 
+      and/or other materials provided with the distribution.
+    * Neither the name of the University of Tennessee nor the names of its 
+      contributors may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR 
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON 
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+This open source software license conforms to the BSD License template.

--- a/components/perf-tools/papi57/SOURCES/papi.ldconfig.patch
+++ b/components/perf-tools/papi57/SOURCES/papi.ldconfig.patch
@@ -1,0 +1,11 @@
+--- papi-5.4.0/src/libpfm4/config.mk	2014-11-14 12:09:41.000000000 -0800
++++ papi-5.4.0.patch/src/libpfm4/config.mk	2014-11-19 11:38:34.879719300 -0800
+@@ -194,7 +194,7 @@
+ CC?=gcc
+ LIBS=
+ INSTALL=install
+-LDCONFIG=ldconfig
++LDCONFIG=/sbin/ldconfig
+ LN?=ln -sf
+ PFMINCDIR=$(TOPDIR)/include
+ PFMLIBDIR=$(TOPDIR)/lib

--- a/components/perf-tools/papi57/SOURCES/rpmlintrc
+++ b/components/perf-tools/papi57/SOURCES/rpmlintrc
@@ -1,0 +1,3 @@
+addFilter("devel-file-in-non-devel-package")
+addFilter("library-without-ldconfig-postun")
+addFilter("library-without-ldconfig-postin")

--- a/components/perf-tools/papi57/SPECS/papi57.spec
+++ b/components/perf-tools/papi57/SPECS/papi57.spec
@@ -1,0 +1,106 @@
+#----------------------------------------------------------------------------bh-
+# This RPM .spec file is part of the OpenHPC project.
+#
+# It may have been modified from the default version supplied by the underlying
+# release package (if available) in order to apply patches, perform customized
+# build/install configurations, and supply additional files to support
+# desired integration conventions.
+#
+#----------------------------------------------------------------------------eh-
+
+%include %{_sourcedir}/OHPC_macros
+
+# Base package name
+%define pname papi
+
+Summary:   Performance Application Programming Interface
+Name:      %{pname}57%{PROJ_DELIM}
+Version:   5.7.0
+Release:   1%{?dist}
+License:   BSD
+Group:     %{PROJ_NAME}/perf-tools
+URL:       http://icl.cs.utk.edu/papi/
+Source0:   http://icl.cs.utk.edu/projects/papi/downloads/papi-%{version}.tar.gz
+Patch1:    papi.ldconfig.patch
+
+BuildRequires: ncurses-devel make
+%if 0%{?sle_version}
+BuildRequires: gcc-fortran
+%else
+BuildRequires: gcc-gfortran
+BuildRequires: chrpath
+%endif
+
+# Default library install path
+%define install_path %{OHPC_LIBS}/%{pname}/%version
+
+%description
+PAPI provides a programmer interface to monitor the performance of
+running programs.
+
+%prep
+%setup -q -n %{pname}-%{version}
+%patch1 -p1
+
+%build
+
+cd src
+CFLAGS="-fPIC -DPIC" CXXFLAGS="-fPIC -DPIC" FCFLAGS="-fPIC" ./configure --with-static-lib=yes --with-shared-lib=yes --with-shlib --prefix=%{install_path}
+#DBG workaround to make sure libpfm just uses the normal CFLAGS
+DBG="" CFLAGS="-fPIC -DPIC" CXXFLAGS="-fPIC -DPIC" FCFLAGS="-fPIC" make
+
+%install
+cd src
+
+make DESTDIR=$RPM_BUILD_ROOT install
+
+# OpenHPC module file
+%{__mkdir} -p %{buildroot}%{OHPC_MODULES}/%{pname}
+%{__cat} << EOF > %{buildroot}/%{OHPC_MODULES}/%{pname}/%{version}
+#%Module1.0#####################################################################
+
+proc ModulesHelp { } {
+
+    puts stderr " "
+    puts stderr "This module loads the %{pname} library toolchain."
+    puts stderr "\nVersion %{version}\n"
+
+}
+module-whatis "Name: %{pname}"
+module-whatis "Version: %{version}"
+module-whatis "Category: runtime library"
+module-whatis "Description: %{summary}"
+module-whatis "URL %{url}"
+
+set     version                     %{version}
+
+prepend-path    PATH                %{install_path}/bin
+prepend-path    MANPATH             %{install_path}/share/man
+prepend-path    INCLUDE             %{install_path}/include
+prepend-path    LD_LIBRARY_PATH     %{install_path}/lib
+
+setenv          %{PNAME}_DIR        %{install_path}
+setenv          %{PNAME}_BIN        %{install_path}/bin
+setenv          %{PNAME}_LIB        %{install_path}/lib
+setenv          %{PNAME}_INC        %{install_path}/include
+
+EOF
+
+%{__cat} << EOF > %{buildroot}/%{OHPC_MODULES}/%{pname}/.version.%{version}
+#%Module1.0#####################################################################
+##
+## version file for %{pname}-%{version}
+##
+set     ModulesVersion      "%{version}"
+EOF
+
+%ifarch x86_64
+rm -rf $RPM_BUILD_ROOT/%{install_path}/lib/*.a
+%endif
+rm -rf $RPM_BUILD_ROOT%{_libdir}/*.la
+
+%{__mkdir_p} $RPM_BUILD_ROOT/%{_docdir}
+
+%files
+%{OHPC_PUB}
+%doc ChangeLog*.txt INSTALL.txt LICENSE.txt README.md RELEASENOTES.txt


### PR DESCRIPTION
To handle broken dependencies introduced with the 2.6.0 release this is a compatibility package to provide missing libraries.

Fixes: #1705

CC: @mghpcsim : this is my proposal to fix the broken dependencies reported in #1705 for 2.7.0