### PR TITLE
Change --localstatedir to --sharedstatedir for all ww3 3.10.0 modules

### DIFF
--- a/components/provisioning/warewulf-cluster/SPECS/warewulf-cluster.spec
+++ b/components/provisioning/warewulf-cluster/SPECS/warewulf-cluster.spec
@@ -56,7 +56,7 @@ cd %{_builddir}
 
 %build
 ./autogen.sh
-%configure --localstatedir=%{wwsrvdir}
+%configure --sharedstatedir=%{wwsrvdir}
 %{__make} %{?mflags}
 
 

--- a/components/provisioning/warewulf-common/SPECS/warewulf-common.spec
+++ b/components/provisioning/warewulf-common/SPECS/warewulf-common.spec
@@ -76,7 +76,7 @@ cd %{_builddir}
 %build
 ./autogen.sh
 WAREWULF_STATEDIR=%{wwsrvdir}
-%configure --localstatedir=%{wwsrvdir}
+%configure --sharedstatedir=%{wwsrvdir}
 %{__make} %{?mflags}
 
 

--- a/components/provisioning/warewulf-vnfs/SPECS/warewulf-vnfs.spec
+++ b/components/provisioning/warewulf-vnfs/SPECS/warewulf-vnfs.spec
@@ -92,7 +92,7 @@ cd %{_builddir}
 
 %build
 ./autogen.sh
-%configure --localstatedir=%{wwsrvdir}
+%configure --sharedstatedir=%{wwsrvdir}
 %{__make} %{?mflags}
 
 


### PR DESCRIPTION
I believe this is the reason for the problem in https://github.com/openhpc/ohpc/pull/1711
warewulf-common should use `--sharedstatedir=...`, so that later https://github.com/warewulf/warewulf3/blob/f13a37796c333069a7c9e08aa0b00c0643cf3ee0/ipmi/configure.ac#L44 would properly resolve it.

3.10.0 uses `--sharedstatedir=...`:
https://github.com/warewulf/warewulf3/blob/c6de604fc76eabfaef2cb99f4c6ae5ed44eff1e0/ipmi/warewulf-ipmi.spec.in#L43

Latest `master` does not set local/shared statedir at all: https://github.com/warewulf/warewulf3/blob/master/ipmi/warewulf-ipmi.spec.in#L33