### PR TITLE
Add support for building Likwid on Linux ARM64

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,6 @@ env:
     components/compiler-families/intel-compilers-devel/SPECS/intel-compilers-devel.spec
     components/mpi-families/impi-devel/SPECS/intel-mpi.spec
     components/parallel-libs/trilinos/SPECS/trilinos.spec
-    components/perf-tools/likwid/SPECS/likwid.spec
 
 task:
   name: RHEL/Rocky on aarch64
@@ -41,6 +40,7 @@ openeuler_task:
   env:
     JOB_SKIP_CI_SPECS: |
       components/runtimes/charliecloud/SPECS/charliecloud.spec
+      components/perf-tools/likwid/SPECS/likwid.spec
   test_script: |
     export SKIP_CI_SPECS="${SKIP_CI_SPECS}${JOB_SKIP_CI_SPECS}"
     chown ohpc -R tests

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,7 +12,6 @@ env:
   SKIP_CI_SPECS: |
     components/fs/lustre-client/SPECS/lustre.spec
     components/parallel-libs/trilinos/SPECS/trilinos.spec
-    components/perf-tools/likwid/SPECS/likwid.spec
 
 jobs:
   check_spec:
@@ -93,6 +92,9 @@ jobs:
   test_on_rhel:
     runs-on: ubuntu-latest
     name: Test on RHEL
+    env:
+      JOB_SKIP_CI_SPECS: |
+        components/perf-tools/likwid/SPECS/likwid.spec
     container:
       image: docker.io/library/rockylinux:8
       options: --privileged
@@ -111,6 +113,7 @@ jobs:
         path: /home/ohpc/rpmbuild/RPMS
     - name: Run CI Tests
       run: |
+        export SKIP_CI_SPECS="${{ env.SKIP_CI_SPECS }}${{ env.JOB_SKIP_CI_SPECS }}"
         . /etc/profile.d/lmod.sh
         chown ohpc -R tests
         tests/ci/setup_slurm_and_run_tests.sh ohpc ${{ steps.files.outputs.added_modified }}
@@ -148,6 +151,7 @@ jobs:
     env:
       JOB_SKIP_CI_SPECS: |
         components/runtimes/charliecloud/SPECS/charliecloud.spec
+        components/perf-tools/likwid/SPECS/likwid.spec
     runs-on: ubuntu-latest
     name: Test on openEuler
     container:

--- a/components/perf-tools/likwid/SPECS/likwid.spec
+++ b/components/perf-tools/likwid/SPECS/likwid.spec
@@ -83,7 +83,14 @@ It consists of:
           FC="ifort" \
           FCFLAGS="-module ./" \
 %else
+    %ifarch aarch64
+          COMPILER="GCCARMv8" \
+          BUILDDAEMON="true" \
+          BUILDFREQ="true" \
+          ACCESSMODE="perf_event" \
+    %else
           COMPILER="GCC" \
+    %endif
           FC="gfortran" \
           FCFLAGS="-J ./ -fsyntax-only" \
 %endif
@@ -105,7 +112,14 @@ It consists of:
           FC="ifort" \
           FCFLAGS="-module ./" \
 %else
+    %ifarch aarch64
+          COMPILER="GCCARMv8" \
+          BUILDDAEMON="true" \
+          BUILDFREQ="true" \
+          ACCESSMODE="perf_event" \
+    %else
           COMPILER="GCC" \
+    %endif
           FC="gfortran" \
           FCFLAGS="-J ./ -fsyntax-only" \
 %endif


### PR DESCRIPTION
Fixes https://github.com/openhpc/ohpc/pull/1326

OBS builds on x86_64 and aarch64: https://obs.openhpc.community/package/show/home:mgrigorov/likwid-gnu12-openmpi4