### PR TITLE
Use local busybox also for openEuler

### DIFF
--- a/components/provisioning/warewulf-provision/SPECS/warewulf-provision.spec
+++ b/components/provisioning/warewulf-provision/SPECS/warewulf-provision.spec
@@ -94,7 +94,7 @@ BuildRequires: libarchive.so.13()(64bit)
 Requires: libarchive.so.13()(64bit)
 %global CONF_FLAGS --with-local-e2fsprogs --with-local-libarchive --with-local-parted --with-local-partprobe
 # The included Busybox will not build on OpenSUSE 15.4
-%if 0%{?sle_version} >= 150400
+%if 0%{?sle_version} >= 150400 || 0%{?openEuler}
 BuildRequires: busybox
 Requires: busybox
 %global CONF_FLAGS %{CONF_FLAGS} --with-local-busybox


### PR DESCRIPTION
OBS build: https://obs.openhpc.community/package/live_build_log/home:mgrigorov/warewulf-provision-gnu12-openmpi4/OpenHPC_3.0_Factory_openEuler_22.03/aarch64

Related to:
https://obs.openhpc.community/package/live_build_log/OpenHPC:3.0:Factory/warewulf-provision/openEuler_22.03/aarch64

```
[  165s] Trying libraries: -L/usr/lib crypt m resolv rt selinux sepol tirpc
[  166s] sed: -e expression #1, char 11: unknown option to `s'
[  166s]  Library -L/usr/lib is needed, can't exclude it (yet)
[  167s]  Library crypt is not needed, excluding it
[  167s]  Library m is needed, can't exclude it (yet)
[  167s]  Library resolv is needed, can't exclude it (yet)
[  167s]  Library rt is not needed, excluding it
[  167s]  Library selinux is needed, can't exclude it (yet)
[  168s]  Library sepol is not needed, excluding it
[  168s]  Library tirpc is not needed, excluding it
[  168s] sed: -e expression #1, char 11: unknown option to `s'
[  169s]  Library -L/usr/lib is needed, can't exclude it (yet)
[  169s]  Library m is needed, can't exclude it (yet)
[  169s]  Library resolv is needed, can't exclude it (yet)
[  170s]  Library selinux is needed, can't exclude it (yet)
[  170s] Final link with: -L/usr/lib m resolv selinux
[  170s] make[2]: Leaving directory '/home/abuild/rpmbuild/BUILD/warewulf3-c6de604fc76eabfaef2cb99f4c6ae5ed44eff1e0/provision/initramfs/_work/busybox-1.33.1'
[  170s] Installing initramfs core
[  170s] make[2]: Entering directory '/home/abuild/rpmbuild/BUILD/warewulf3-c6de604fc76eabfaef2cb99f4c6ae5ed44eff1e0/provision/initramfs/_work/busybox-1.33.1'
[  172s] make[2]: /usr/bin/make: Operation not permitted
[  172s] make[2]: *** [Makefile:357: scripts_basic] Error 127
[  172s] make[2]: Leaving directory '/home/abuild/rpmbuild/BUILD/warewulf3-c6de604fc76eabfaef2cb99f4c6ae5ed44eff1e0/provision/initramfs/_work/busybox-1.33.1'
[  172s] make[1]: *** [Makefile:664: busybox] Error 2
[  172s] make[1]: Leaving directory '/home/abuild/rpmbuild/BUILD/warewulf3-c6de604fc76eabfaef2cb99f4c6ae5ed44eff1e0/provision/initramfs'
[  172s] make: *** [Makefile:377: all-recursive] Error 1
[  172s] error: Bad exit status from /var/tmp/rpm-tmp.7TPi9j (%build)
```