### PR TITLE
admin/losf: only requires yum-plugin-downloadonly in rhel series

### DIFF
--- a/components/admin/losf/SPECS/losf.spec
+++ b/components/admin/losf/SPECS/losf.spec
@@ -41,7 +41,7 @@ provides: perl(LosF_history_utils)
 Requires: perl-Config-IniFiles >= 2.43
 Requires: perl-Log-Log4perl
 %else #rhel
-%if 0%{?rhel_version} < 800
+%if 0%{?rhel} && 0%{?rhel} < 8
 requires: yum-plugin-downloadonly
 %endif
 %endif


### PR DESCRIPTION
Avoid missing `yum-plugin-downloadonly` in openEuler

Signed-off-by: Yikun Jiang <yikunkero@gmail.com>