### PR TITLE
ww3-provision: Use mod_perl for openEuler

### DIFF
--- a/components/provisioning/warewulf-provision/SPECS/warewulf-provision.spec
+++ b/components/provisioning/warewulf-provision/SPECS/warewulf-provision.spec
@@ -71,6 +71,12 @@ BuildRequires: systemd-rpm-macros
 %global dhcpsrv dhcp-server
 %endif
 
+%if 0%{?openEuler}
+%global perl_apache mod_perl
+%else
+%global perl_apache perl(Apache)
+%endif
+
 # If multiple architectures are needed, set
 # --define="cross_compile 1" as an rpmbuild option
 %if 0%{?cross_compile}
@@ -203,7 +209,7 @@ image and to provide boot capability for %{_arch} architecture.
 Summary: Warewulf - System provisioning server
 Requires: %{name} = %{version}-%{release}
 Requires: %{name}-server-ipxe-%{_arch} = %{version}-%{release}
-Requires: %{httpsvc}, perl(Apache), %{tftpsvc}, %{dhcpsrv}
+Requires: %{httpsvc}, %{perl_apache}, %{tftpsvc}, %{dhcpsrv}, tcpdump
 
 %if 0%{?rhel} >= 8 || 0%{?openEuler}
 Requires(post): policycoreutils-python-utils

--- a/components/provisioning/warewulf-provision/SPECS/warewulf-provision.spec
+++ b/components/provisioning/warewulf-provision/SPECS/warewulf-provision.spec
@@ -71,12 +71,6 @@ BuildRequires: systemd-rpm-macros
 %global dhcpsrv dhcp-server
 %endif
 
-%if 0%{?openEuler}
-%global perl_apache mod_perl
-%else
-%global perl_apache perl(Apache)
-%endif
-
 # If multiple architectures are needed, set
 # --define="cross_compile 1" as an rpmbuild option
 %if 0%{?cross_compile}
@@ -209,7 +203,7 @@ image and to provide boot capability for %{_arch} architecture.
 Summary: Warewulf - System provisioning server
 Requires: %{name} = %{version}-%{release}
 Requires: %{name}-server-ipxe-%{_arch} = %{version}-%{release}
-Requires: %{httpsvc}, %{perl_apache}, %{tftpsvc}, %{dhcpsrv}, tcpdump
+Requires: %{httpsvc}, perl(Apache), %{tftpsvc}, %{dhcpsrv}, tcpdump
 
 %if 0%{?rhel} >= 8 || 0%{?openEuler}
 Requires(post): policycoreutils-python-utils


### PR DESCRIPTION
Fixes #1726 

Also add a dependency to tcpdump as in upstream:
https://github.com/warewulf/warewulf3/blob/c6de604fc76eabfaef2cb99f4c6ae5ed44eff1e0/provision/warewulf-provision.spec.in#L163

c6de604fc76eabfaef2cb99f4c6ae5ed44eff1e0 is the commit for ww3 3.10.0