### PR TITLE
Test for existence of sys/types.ph before trying to include it

### DIFF
--- a/components/provisioning/warewulf-vnfs/SOURCES/warewulf-vnfs.wwvnfs.requires.patch
+++ b/components/provisioning/warewulf-vnfs/SOURCES/warewulf-vnfs.wwvnfs.requires.patch
@@ -1,0 +1,15 @@
+diff --git i/bin/wwvnfs w/bin/wwvnfs
+index 48c4ecb..5ef0415 100755
+--- i/bin/wwvnfs
++++ w/bin/wwvnfs
+@@ -26,7 +26,9 @@ use POSIX;
+     if (eval { require "sys/sysmacros.ph"; }) {
+       require "sys/sysmacros.ph"
+     }
+-    require "sys/types.ph";
++    if (eval { require "sys/types.ph"; }) {
++      require "sys/types.ph"
++    }
+     require "syscall.ph";
+ }
+ 

--- a/components/provisioning/warewulf-vnfs/SPECS/warewulf-vnfs.spec
+++ b/components/provisioning/warewulf-vnfs/SPECS/warewulf-vnfs.spec
@@ -43,6 +43,7 @@ Patch11: warewulf-vnfs.leap.patch
 Patch12: warewulf-vnfs.bootstrap_drivers.patch
 Patch13: warewulf-vnfs.hybridize.patch
 Patch14: warewulf-vnfs.boot_fw_symlink.patch
+Patch15: warewulf-vnfs.wwvnfs.requires.patch
 Group:   %{PROJ_NAME}/provisioning
 ExclusiveOS: linux
 Requires: warewulf-common%{PROJ_DELIM}
@@ -91,6 +92,7 @@ cd %{_builddir}
 %patch12 -p1
 %patch13 -p1
 %patch14 -p1
+%patch15 -p1
 
 %build
 ./autogen.sh


### PR DESCRIPTION
This is what is already done for sys/sysmacros.ph in 3.10.0 https://github.com/warewulf/warewulf3/blob/c6de604fc76eabfaef2cb99f4c6ae5ed44eff1e0/vnfs/bin/wwvnfs#L27