### PR TITLE
Fixes #1691: Add rpmlintrc for hpc-workspace

### DIFF
--- a/components/admin/hpc-workspace/SOURCES/rpmlintrc
+++ b/components/admin/hpc-workspace/SOURCES/rpmlintrc
@@ -1,0 +1,1 @@
+setBadness('permissions-file-setuid-bit', 0)


### PR DESCRIPTION
Set badness to `0` for `permissions-file-setuid-bit`. I.e. suppress it.