### PR TITLE
Check for license file

### DIFF
--- a/tests/ci/check_spec.py
+++ b/tests/ci/check_spec.py
@@ -29,6 +29,9 @@ regex_required = [
     'provisioning|rms|runtimes|serial-libs)$',
     # Need a URL
     '(^URL:.*$|Url:.*$)',
+    # RPMs should include their license files; don't use %doc for licenses
+    # Add a comment if no license file is needed
+    '(^%License.*$|^# No license.*$)',
     ]
 
 if len(sys.argv) <= 1:


### PR DESCRIPTION
Done correctly this time -- no typo. The purpose of the check is to make sure there's a %license included under %files, or make a "No license" comment to meet the check.

This is a very simple check so the submitter remembers not to add license files as %doc or wildcard them in with other files.