### PR TITLE
Ignore library-without-ldconfig-post[iu]n for ADIOS2

### DIFF
--- a/components/io-libs/adios2/SOURCES/rpmlintrc
+++ b/components/io-libs/adios2/SOURCES/rpmlintrc
@@ -1,2 +1,4 @@
 addFilter("devel-file-in-non-devel-package")
 addFilter("suse-filelist-forbidden-opt")
+addFilter("library-without-ldconfig-postin")
+addFilter("library-without-ldconfig-postun")


### PR DESCRIPTION
Fixes errors like:

adios2-gnu12-mpich-ohpc.aarch64: E: library-without-ldconfig-postin (Badness: 300) /opt/ohpc/pub/libs/gnu12/mpich/adios2/2.8.3/lib64/libadios2_atl.so.2.2.1

adios2-gnu12-mpich-ohpc.aarch64: E: library-without-ldconfig-postun (Badness: 300) /opt/ohpc/pub/libs/gnu12/mpich/adios2/2.8.3/lib64/libadios2_atl.so.2.2.1