### PR TITLE
dev-tools/spack: upgrade to 0.19.2

### DIFF
--- a/components/dev-tools/spack/SPECS/spack.spec
+++ b/components/dev-tools/spack/SPECS/spack.spec
@@ -13,7 +13,7 @@
 %define pname spack
 
 Name:		%{pname}%{PROJ_DELIM}
-Version:	0.19.0
+Version:	0.19.2
 Release:	%{?dist}.1
 Summary:	HPC software package management
 
@@ -29,7 +29,6 @@ Requires: coreutils
 Requires: subversion
 Requires: hg
 Requires: patch
-Requires: python3-mock
 Requires: gcc
 Requires: gcc-c++
 Requires: make


### PR DESCRIPTION
Drop requires on 'python3-mock'. That package does not exist as the functionality is part of the Python standard library since 3.3.