### PR TITLE
Install texlive-gsftopk for openEuler

### DIFF
--- a/components/admin/docs/SPECS/docs.spec
+++ b/components/admin/docs/SPECS/docs.spec
@@ -62,6 +62,7 @@ BuildRequires:  tex
 %if 0%{?openEuler}
 BuildRequires:  texlive-pdftex
 BuildRequires:  texlive-epstopdf
+BuildRequires:  texlive-gsftopk
 %endif
 
 %description


### PR DESCRIPTION
Should fix the following error:
```
kpathsea: Running mktexpk --mfmode / --bdpi 600 --mag 0+540/600 --dpi 540 phvr8r
[  376s] /usr/bin/mktexpk: line 160: gsftopk: command not found
[  376s] mktexpk: don't know how to create bitmap font for phvr8r.
[  376s] mktexpk: perhaps phvr8r is missing from the map file.
[  376s] kpathsea: Appending font creation commands to missfont.log.
```

https://obs.openhpc.community/package/live_build_log/OpenHPC:3.0:Factory/docs/openEuler_22.03/aarch64