### PR TITLE
mpi-families/ucx: Update UCX to 1.14.0

### DIFF
--- a/components/mpi-families/ucx/SPECS/ucx.spec
+++ b/components/mpi-families/ucx/SPECS/ucx.spec
@@ -28,7 +28,7 @@
 %define pname ucx
 
 Name:    ucx%{PROJ_DELIM}
-Version: 1.11.2
+Version: 1.14.0
 Release: 1%{?dist}
 Summary: UCX is a communication library implementing high-performance messaging
 Group:   %{PROJ_NAME}/mpi-families


### PR DESCRIPTION
Successful builds on Leap and openEuler aarch64: https://obs.openhpc.community/package/show/home:mgrigorov/ucx-gnu12-openmpi4