### PR TITLE
mpi-families/libfabric: Bump libfabric to 1.18.0

### DIFF
--- a/components/mpi-families/libfabric/SPECS/libfabric.spec
+++ b/components/mpi-families/libfabric/SPECS/libfabric.spec
@@ -15,7 +15,7 @@
 %define pname libfabric
 
 Name: libfabric%{PROJ_DELIM}
-Version: 1.13.0
+Version: 1.18.0
 Release: 1%{?dist}
 Summary: User-space RDMA Fabric Interfaces
 Group:   %{PROJ_NAME}/mpi-families


### PR DESCRIPTION
Successful OBS build for Leap and openEuler: https://obs.openhpc.community/package/show/home:mgrigorov/libfabric-gnu12-openmpi4