### PR TITLE
dev-tools/auto*: update auto*tools

### DIFF
--- a/components/dev-tools/autoconf/SPECS/autoconf.spec
+++ b/components/dev-tools/autoconf/SPECS/autoconf.spec
@@ -14,7 +14,7 @@
 
 Summary:   A GNU tool for automatically configuring source code
 Name:      %{pname}%{PROJ_DELIM}
-Version:   2.69
+Version:   2.71
 Release:   %{?dist}.1
 License:   GNU GPL
 Group:     %{PROJ_NAME}/dev-tools
@@ -23,6 +23,8 @@ Source0:   https://ftp.gnu.org/gnu/autoconf/autoconf-%{version}.tar.gz
 
 BuildRequires: m4 make
 Requires: m4
+Requires: perl(Thread::Queue)
+Requires: perl(threads)
 
 BuildRequires: perl-macros
 BuildRequires: perl(File::Compare)

--- a/components/dev-tools/automake/SPECS/automake.spec
+++ b/components/dev-tools/automake/SPECS/automake.spec
@@ -14,7 +14,7 @@
 
 Summary:   A GNU tool for automatically creating Makefiles
 Name:      %{pname}%{PROJ_DELIM}
-Version:   1.16.1
+Version:   1.16.5
 Release:   %{?dist}.1
 License:   GNU GPL
 Group:     %{PROJ_NAME}/dev-tools


### PR DESCRIPTION
To correctly work with the latest Intel compiler hdf5 needs autoreconf from autoconf >= 2.70.