### PR TITLE
Enhance CI script to specify compiler and mpi family

### DIFF
--- a/misc/build_srpm.sh
+++ b/misc/build_srpm.sh
@@ -15,8 +15,14 @@
 
 SPEC=$1
 
-if [ $# -eq 2 ]; then
-	MPI_FAMILY=$2
+if [ $# -ge 2 ]; then
+	COMPILER_FAMILY=$2
+else
+	COMPILER_FAMILY=gnu12
+fi
+
+if [ $# -eq 3 ]; then
+	MPI_FAMILY=$3
 else
 	MPI_FAMILY=openmpi4
 fi
@@ -48,7 +54,7 @@ echo "Building SRPM for ${SPEC}"
 prepare_git_tree "${DIR}"
 
 # Try to build the SRPM
-SRPM=$(build_srpm "${SPEC}" "${MPI_FAMILY}")
+SRPM=$(build_srpm "${SPEC}" "${COMPILER_FAMILY}" "${MPI_FAMILY}")
 RESULT=$?
 if [ "${RESULT}" == "1" ]; then
 	echo "Building the SRPM for ${BASE} failed."
@@ -57,7 +63,7 @@ if [ "${RESULT}" == "1" ]; then
 fi
 
 # Let's hope fetching the sources worked and retry building the SRPM
-SRPM=$(build_srpm "${SPEC}" "${MPI_FAMILY}")
+SRPM=$(build_srpm "${SPEC}" "${COMPILER_FAMILY}" "${MPI_FAMILY}")
 RESULT=$?
 
 if [ "${RESULT}" == "1" ]; then

--- a/misc/shell-functions
+++ b/misc/shell-functions
@@ -25,11 +25,12 @@ prepare_git_tree() {
 build_srpm() {
 	local SPEC=${1}
 	local DIR
-	local MPI_FAMILY=${2}
+	local COMPILER_FAMILY=${2}
+	local MPI_FAMILY=${3}
 
 	DIR=$(dirname "${1}")
 
-	SRPM=$(rpmbuild -bs --nodeps --define "_sourcedir ${DIR}/../SOURCES" --define "mpi_family ${MPI_FAMILY}" "${SPEC}" 2>/dev/null)
+	SRPM=$(rpmbuild -bs --nodeps --define "_sourcedir ${DIR}/../SOURCES" --define "compiler_family ${COMPILER_FAMILY}" --define "mpi_family ${MPI_FAMILY}" "${SPEC}" 2>/dev/null)
 	RESULT=$?
 
 	echo "${SRPM}" | tail -1 | awk -F\  '{ print $2 }'


### PR DESCRIPTION
This adds to parameters to tests/ci/run_build.py which offer the possibility to specify a certain compiler or mpi family:

  --compiler-family COMPILER_FAMILY
    compiler family name to use for rebuild
  --mpi-family MPI_FAMILY
    mpi family name to use for rebuild (defaults to openmpi4, mpich, mvapich2)

This enables quick rebuilds outside of CI with a certain compiler and mpi combination without multiple local commands:

```
 $ tests/ci/run_build.py ohpc  components/parallel-libs/hypre/SPECS/hypre.spec  \
      --compiler-family intel --mpi-family mvapich2
```

Will do a single rebuild with the Intel compiler and mvapich2:

```
2023-04-21 12:38:42,275 Found 1 spec file(s)
2023-04-21 12:38:42,275 --> 1 rebuild successfully
2023-04-21 12:38:42,276 ----> hypre.spec (intel, mvapich2)
2023-04-21 12:38:42,276 --> 0 rebuilds skipped
2023-04-21 12:38:42,276 No errors found. Exiting.
```