### PR TITLE
Update oneAPI to fixed build release

### DIFF
--- a/components/compiler-families/intel-compilers-devel/SPECS/intel-compilers-devel.spec
+++ b/components/compiler-families/intel-compilers-devel/SPECS/intel-compilers-devel.spec
@@ -18,9 +18,8 @@
 # install newer versions during build time. If the user has the minimum
 # version, but the build system was already using a newer version, then
 # the resulting binaries might rely on symbols which are not present
-# in the minimum version.
+# in the minimum version.  Newer versions may still be installed in parallel.
 %define exact_intel_ver 2023.1.0
-
 
 Summary:   OpenHPC compatibility package for Intel(R) oneAPI HPC Toolkit
 Name:      %{pname}%{PROJ_DELIM}
@@ -38,11 +37,12 @@ Source2:   oneAPI.repo
 #!BuildIgnore: post-build-checks
 
 Requires: gcc libstdc++-devel
-Requires(pre): intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic = %{exact_intel_ver}
-Requires: intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic = %{exact_intel_ver}
-Requires: intel-oneapi-mkl intel-oneapi-mkl-devel
-Requires: intel-oneapi-compiler-fortran
-Recommends: intel-hpckit = %{exact_intel_ver}
+Requires(pre): intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-%{exact_intel_ver}
+Requires: intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-%{exact_intel_ver}
+Requires: intel-oneapi-dpcpp-cpp-%{exact_intel_ver}
+Requires: intel-oneapi-mkl-devel-%{exact_intel_ver}
+Requires: intel-oneapi-compiler-fortran-%{exact_intel_ver}
+Recommends: intel-hpckit >= %{exact_intel_ver}
 
 %description
 Provides OpenHPC-style compatible modules for use with the Intel(R) oneAPI

--- a/components/mpi-families/impi-devel/SPECS/intel-mpi.spec
+++ b/components/mpi-families/impi-devel/SPECS/intel-mpi.spec
@@ -14,12 +14,16 @@
 %define gnu_major_ver 12
 %define oneapi_manifest %{OHPC_MODULEDEPS}/intel/impi/.rpm-manifest
 %define psxe_manifest %{OHPC_MODULEDEPS}/intel/impi/.manifest
-%define min_intel_ver 2021.4.0
-
+# Using a minimum version has been problematic as DNF will happily
+# install newer versions during build time. If the user has the minimum
+# version, but the build system was already using a newer version, then
+# the resulting binaries might rely on symbols which are not present
+# in the minimum version. Newer versions may still be installed in parallel.
+%define exact_intel_ver 2021.9.0
 
 Summary:   OpenHPC compatibility package for Intel(R) oneAPI MPI Library
 Name:      %{pname}%{PROJ_DELIM}
-Version:   2021.1
+Version:   2023.1
 Release:   1
 License:   Apache-2.0
 URL:       https://github.com/openhpc/ohpc
@@ -32,10 +36,10 @@ Source1:   mod_generator_impi.sh
 #!BuildIgnore: post-build-checks
 
 Requires: sed
-Requires(pre): intel-compilers-devel%{PROJ_DELIM} >= 2021
-Requires(pre): intel-oneapi-mpi-devel >= %{min_intel_ver}
-Requires: intel-oneapi-mpi-devel >= %{min_intel_ver}
-Requires: intel-compilers-devel%{PROJ_DELIM} >= 2021
+Requires(pre): intel-compilers-devel%{PROJ_DELIM} = %{version}
+Requires(pre): intel-oneapi-mpi-devel-%{min_intel_ver}
+Requires: intel-oneapi-mpi-devel-%{min_intel_ver}
+Requires: intel-compilers-devel%{PROJ_DELIM} = %{version}
 Requires: prun%{PROJ_DELIM}
 
 %description


### PR DESCRIPTION
Updates oneAPI to use a fixed release -- this keeps a common version used for all OpenHPC builds and validation. Additional versions of oneAPI can be installed in parallel; this should happen automatically if recommended packages are enabled.