### PR TITLE
compiler-families/gnu-compilers: add gcc 13 in parallel

### DIFF
--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -86,6 +86,11 @@ BuildRequires: ohpc-buildroot
 # Compiler dependencies
 %if 0%{?ohpc_compiler_dependent} == 1
 
+%if "%{compiler_family}" == "gnu13"
+BuildRequires: gnu13-compilers%{PROJ_DELIM} >= 13.1.0
+Requires:      gnu13-compilers%{PROJ_DELIM} >= 13.1.0
+%global gnu_family gnu13
+%endif
 %if "%{compiler_family}" == "gnu12"
 BuildRequires: gnu12-compilers%{PROJ_DELIM} >= 12.1.0
 Requires:      gnu12-compilers%{PROJ_DELIM} >= 12.1.0

--- a/components/OHPC_setup_compiler
+++ b/components/OHPC_setup_compiler
@@ -41,6 +41,13 @@ elif [ "${OHPC_COMPILER_FAMILY}" = "gnu12" ]; then
     export F77=gfortran
     module purge
     module load gnu12
+elif [ "${OHPC_COMPILER_FAMILY}" = "gnu13" ]; then
+    export CC=gcc
+    export CXX=g++
+    export FC=gfortran
+    export F77=gfortran
+    module purge
+    module load gnu13
 elif [ "${OHPC_COMPILER_FAMILY}" = "gnu9" ]; then
     export CC=gcc
     export CXX=g++
@@ -93,21 +100,22 @@ echo " "
 
 arch=$(uname -m)
 
-if [ "${toolset}" == "gcc" ];then
-    DEFAULT_OPTS="-O3 -g -pipe -Wall -fexceptions -fstack-protector-strong -grecord-gcc-switches -mtune=generic"
-    if [ "${arch}" == "x86_64" ];then
-        DEFAULT_OPTS="${DEFAULT_OPTS} -m64"
-        if [ -e /etc/os-release ]; then
-            # shellcheck disable=SC1091
-            . /etc/os-release
-            if [ -n "${PLATFORM_ID}" ] && [ "${PLATFORM_ID}" == "platform:el9" ]; then
-                # Only RHEL 9 has switched to the optimization baseline 'x86-64-v2'
-                DEFAULT_OPTS="${DEFAULT_OPTS} -march=x86-64-v2"
-            fi
+if [ "${arch}" == "x86_64" ];then
+    ARCH_OPTS="-m64"
+    if [ -e /etc/os-release ]; then
+        # shellcheck disable=SC1091
+        . /etc/os-release
+        if [ -n "${PLATFORM_ID}" ] && [ "${PLATFORM_ID}" == "platform:el9" ]; then
+            # Only RHEL 9 has switched to the optimization baseline 'x86-64-v2'
+            ARCH_OPTS="${ARCH_OPTS} -march=x86-64-v2"
         fi
     fi
+fi
+
+if [ "${toolset}" == "gcc" ];then
+    DEFAULT_OPTS="-O3 -g -pipe -Wall -fexceptions -fstack-protector-strong -grecord-gcc-switches -mtune=generic ${ARCH_OPTS}"
 elif [ "${toolset}" == "intel" ];then
-    DEFAULT_OPTS="-O3 -g -m64 -fexceptions -fstack-protector-strong -mtune=generic"
+    DEFAULT_OPTS="-O3 -g -fexceptions -fstack-protector-strong -mtune=generic ${ARCH_OPTS}"
 elif [ "${toolset}" == "arm" ];then
     DEFAULT_OPTS="-O3 -g -Wall -fexceptions -fstack-protector-strong -mtune=generic"
 fi

--- a/components/compiler-families/gnu-compilers/SPECS/gnu-compilers.spec
+++ b/components/compiler-families/gnu-compilers/SPECS/gnu-compilers.spec
@@ -10,14 +10,36 @@
 
 %include %{_sourcedir}/OHPC_macros
 
-%global gnu_version 12.2.0
-%global gnu_major_ver gnu12
-%global pname %{gnu_major_ver}-compilers
+%global gnu12_version 12.2.0
+%global gnu12_gmp_version 6.2.1
+%global gnu12_mpc_version 1.2.1
+%global gnu12_mpfr_version 4.1.0
 
-# Define subcomponent versions required for build
-%global gmp_version 6.2.1
-%global mpc_version 1.2.1
-%global mpfr_version 4.1.0
+%global gnu13_version 13.1.0
+%global gnu13_gmp_version 6.2.1
+%global gnu13_mpc_version 1.3.1
+%global gnu13_mpfr_version 4.2.0
+
+%if "%{compiler_family}" == "gnu12"
+%global gnu_major_ver gnu12
+%global gnu_version %{gnu12_version}
+%endif
+%if "%{compiler_family}" == "gnu13"
+%global gnu_major_ver gnu13
+%global gnu_version %{gnu13_version}
+%endif
+
+Source0:   https://ftp.gnu.org/gnu/gcc/gcc-%{gnu12_version}/gcc-%{gnu12_version}.tar.xz
+Source1:   https://ftp.gnu.org/gnu/gmp/gmp-%{gnu12_gmp_version}.tar.bz2
+Source2:   https://ftp.gnu.org/gnu/mpc/mpc-%{gnu12_mpc_version}.tar.gz
+Source3:   https://ftp.gnu.org/gnu/mpfr/mpfr-%{gnu12_mpfr_version}.tar.gz
+
+Source4:   https://ftp.gnu.org/gnu/gcc/gcc-%{gnu13_version}/gcc-%{gnu13_version}.tar.xz
+Source5:   https://ftp.gnu.org/gnu/gmp/gmp-%{gnu13_gmp_version}.tar.bz2
+Source6:   https://ftp.gnu.org/gnu/mpc/mpc-%{gnu13_mpc_version}.tar.gz
+Source7:   https://ftp.gnu.org/gnu/mpfr/mpfr-%{gnu13_mpfr_version}.tar.gz
+
+%global pname %{gnu_major_ver}-compilers
 
 Summary:   The GNU C Compiler and Support Files
 Name:      %{pname}%{PROJ_DELIM}
@@ -26,10 +48,6 @@ Release:   1%{?dist}
 License:   GPLv3 and GPLv3+ with exceptions and LGPLv3 and GPLv2 and LGPLv2+
 Group:     %{PROJ_NAME}/compiler-families
 URL:       http://gcc.gnu.org/
-Source0:   https://ftp.gnu.org/gnu/gcc/gcc-%{gnu_version}/gcc-%{gnu_version}.tar.xz
-Source1:   https://ftp.gnu.org/gnu/gmp/gmp-%{gmp_version}.tar.bz2
-Source2:   https://ftp.gnu.org/gnu/mpc/mpc-%{mpc_version}.tar.gz
-Source3:   https://ftp.gnu.org/gnu/mpfr/mpfr-%{mpfr_version}.tar.gz
 
 # Requirements from https://gcc.gnu.org/install/prerequisites.htmlzypper
 BuildRequires:  gcc-c++
@@ -56,12 +74,21 @@ frontend.
 
 
 %prep
-%setup -q -n gcc-%{version} -a1 -a2 -a3
+%if "%{compiler_family}" == "gnu12"
+%setup -T -q -n gcc-%{version} -b0 -a1 -a2 -a3
 
-ln -s gmp-%{gmp_version} gmp
-ln -s mpc-%{mpc_version} mpc
-ln -s mpfr-%{mpfr_version} mpfr
+ln -s gmp-%{gnu12_gmp_version} gmp
+ln -s mpc-%{gnu12_mpc_version} mpc
+ln -s mpfr-%{gnu12_mpfr_version} mpfr
+%endif
 
+%if "%{compiler_family}" == "gnu13"
+%setup -T -q -n gcc-%{version} -b4 -a5 -a6 -a7
+
+ln -s gmp-%{gnu13_gmp_version} gmp
+ln -s mpc-%{gnu13_mpc_version} mpc
+ln -s mpfr-%{gnu13_mpfr_version} mpfr
+%endif
 
 %build
 mkdir obj
@@ -78,7 +105,7 @@ make %{?_smp_mflags}
 cd obj
 make %{?_smp_mflags} DESTDIR=$RPM_BUILD_ROOT install
 
-%if 0%{?sle_version} || 0%{?suse_version}
+%if 0%{?sle_version}
 %fdupes -s $RPM_BUILD_ROOT/%{install_path}/include
 %fdupes -s $RPM_BUILD_ROOT/%{install_path}/lib
 %fdupes -s $RPM_BUILD_ROOT/%{install_path}/install-tools


### PR DESCRIPTION
The changes of the spec file are a bit more complicated than expected due to the way OBS parses the spec file to download the sources.

This does not switch the default compiler to gcc 13, yet.