### PR TITLE
Add hwloc-ohpc to head node to fix issue #1818

### DIFF
--- a/docs/recipes/install/common/install_provisioning_intro.tex
+++ b/docs/recipes/install/common/install_provisioning_intro.tex
@@ -14,6 +14,7 @@ of a common base package followed by the Warewulf provisioning system.
 # Install base meta-packages
 [sms](*\#*) (*\install*) ohpc-base
 [sms](*\#*) (*\install*) ohpc-warewulf
+[sms](*\#*) (*\install*) hwloc-ohpc
 \end{lstlisting}
 % end_ohpc_run
 


### PR DESCRIPTION
Patch for issue #1818,  hwlock not on compute node.
