### PR TITLE
Filter out Slurm settings which have custom/specific values for OHPC builds

### DIFF
--- a/components/rms/slurm/SPECS/slurm.spec
+++ b/components/rms/slurm/SPECS/slurm.spec
@@ -484,7 +484,7 @@ install -D -m755 contribs/sjstat %{buildroot}/%{_bindir}/sjstat
 
 # 9/8/14 karl.w.schulz@intel.com - provide starting config file
 %if 0%{?OHPC_BUILD}
-head -n -2 $RPM_BUILD_ROOT/%{_sysconfdir}/slurm.conf.example | grep -v ReturnToService > $RPM_BUILD_ROOT/%{_sysconfdir}/slurm.conf.ohpc
+head -n -2 $RPM_BUILD_ROOT/%{_sysconfdir}/slurm.conf.example | grep -vE "TaskPlugin=|PropagateResourceLimitsExcept=|PropagateResourceLimitsExcept=|JobCompType=|Epilog=|NodeName=|PartitionName=|SlurmctldParameters=|LaunchParameters=|ReturnToService=" > $RPM_BUILD_ROOT/%{_sysconfdir}/slurm.conf.ohpc
 echo "# OpenHPC default configuration" >> $RPM_BUILD_ROOT/%{_sysconfdir}/slurm.conf.ohpc
 # 10/2/18 brad.geltz@intel.com - Enabling the task/affinity plugin to add the --cpu-bind option to srun for GEOPM
 echo "TaskPlugin=task/affinity" >> $RPM_BUILD_ROOT/%{_sysconfdir}/slurm.conf.ohpc


### PR DESCRIPTION
Currently Slurm startup prints:
```
[root@c3 ~]# systemctl status slurmd
● slurmd.service - Slurm node daemon
     Loaded: loaded (/usr/lib/systemd/system/slurmd.service; disabled; vendor preset: disabled)
     Active: active (running) since Thu 2023-05-18 15:40:52 CST; 48min ago
   Main PID: 3397 (slurmd)
      Tasks: 1
     Memory: 3.6M
     CGroup: /system.slice/slurmd.service
             └─3397 /usr/sbin/slurmd -D -s --conf-server 192.168.1.220

May 18 15:40:52 c3 systemd[1]: Started Slurm node daemon.
May 18 15:40:52 c3 slurmd[3397]: slurmd: error: TaskPlugin 1 specified more than once, latest value used
May 18 15:40:52 c3 slurmd[3397]: slurmd: error: JobCompType 1 specified more than once, latest value used
May 18 15:40:52 c3 slurmd[3397]: error: TaskPlugin 1 specified more than once, latest value used
May 18 15:40:52 c3 slurmd[3397]: error: JobCompType 1 specified more than once, latest value used
```