### PR TITLE
Remove GCC specific flags for Intel and Arm compilers

### DIFF
--- a/components/OHPC_setup_compiler
+++ b/components/OHPC_setup_compiler
@@ -98,10 +98,10 @@ if [ "$toolset" == "gcc" ];then
     if [ "$arch" == "x86_64" ];then
 	DEFAULT_OPTS="$DEFAULT_OPTS -m64"
     fi
-elif [ "$toolset" == "intel" ];then
-    DEFAULT_OPTS="-O3 -g -m64 -fexceptions -fstack-protector-strong -grecord-gcc-switches -mtune=generic"
-elif [ "$toolset" == "arm" ];then
-    DEFAULT_OPTS="-O3 -g -Wall -fexceptions -fstack-protector-strong -grecord-gcc-switches -mtune=generic"
+elif [ "${toolset}" == "intel" ];then
+    DEFAULT_OPTS="-O3 -g -m64 -fexceptions -fstack-protector-strong -mtune=generic"
+elif [ "${toolset}" == "arm" ];then
+    DEFAULT_OPTS="-O3 -g -Wall -fexceptions -fstack-protector-strong -mtune=generic"
 fi
 
 if [ -z "$OHPC_CFLAGS" ];then


### PR DESCRIPTION
Fixes #1833

(cherry picked from commit 5dd866a9a12dea7d59f34269b625d08f7dc533fa)