### PR TITLE
Support spec files with '!?ohpc_mpi_dependent' 

### DIFF
--- a/misc/build_srpm.sh
+++ b/misc/build_srpm.sh
@@ -21,10 +21,16 @@ else
 	COMPILER_FAMILY=gnu12
 fi
 
-if [ $# -eq 3 ]; then
+if [ $# -ge 3 ]; then
 	MPI_FAMILY=$3
 else
 	MPI_FAMILY=openmpi4
+fi
+
+if [ $# -eq 4 ]; then
+	MPI_DEPENDENT=$4
+else
+	MPI_DEPENDENT=1
 fi
 
 if [ ! -e "${SPEC}" ]; then
@@ -54,16 +60,19 @@ echo "Building SRPM for ${SPEC}"
 prepare_git_tree "${DIR}"
 
 # Try to build the SRPM
-SRPM=$(build_srpm "${SPEC}" "${COMPILER_FAMILY}" "${MPI_FAMILY}")
+SRPM=$(build_srpm "${SPEC}" "${COMPILER_FAMILY}" "${MPI_FAMILY}" "${MPI_DEPENDENT}")
 RESULT=$?
-if [ "${RESULT}" == "1" ]; then
-	echo "Building the SRPM for ${BASE} failed."
-	echo "Trying to fetch Source0"
-	"${ROOT}"/misc/get_source.sh "${BASE}"
+if [ "${RESULT}" == "0" ]; then
+	echo "${SRPM}"
+	exit 0
 fi
 
+echo "Building the SRPM for ${BASE} failed."
+echo "Trying to fetch Source0"
+"${ROOT}"/misc/get_source.sh "${BASE}"
+
 # Let's hope fetching the sources worked and retry building the SRPM
-SRPM=$(build_srpm "${SPEC}" "${COMPILER_FAMILY}" "${MPI_FAMILY}")
+SRPM=$(build_srpm "${SPEC}" "${COMPILER_FAMILY}" "${MPI_FAMILY}" "${MPI_DEPENDENT}")
 RESULT=$?
 
 if [ "${RESULT}" == "1" ]; then

--- a/misc/shell-functions
+++ b/misc/shell-functions
@@ -27,10 +27,17 @@ build_srpm() {
 	local DIR
 	local COMPILER_FAMILY=${2}
 	local MPI_FAMILY=${3}
+        local MPI_DEPENDENT=${4}
+
+        if [ "${MPI_DEPENDENT}" -eq "0" ]; then
+                MPI_DEPENDENT=(--define 'ohpc_mpi_dependent 0')
+        else
+                MPI_DEPENDENT=()
+        fi
 
 	DIR=$(dirname "${1}")
 
-	SRPM=$(rpmbuild -bs --nodeps --define "_sourcedir ${DIR}/../SOURCES" --define "compiler_family ${COMPILER_FAMILY}" --define "mpi_family ${MPI_FAMILY}" "${SPEC}" 2>/dev/null)
+	SRPM=$(rpmbuild -bs --nodeps --define "_sourcedir ${DIR}/../SOURCES" --define "compiler_family ${COMPILER_FAMILY}" --define "mpi_family ${MPI_FAMILY}" "${MPI_DEPENDENT[@]}" "${SPEC}" 2>/dev/null)
 	RESULT=$?
 
 	echo "${SRPM}" | tail -1 | awk -F\  '{ print $2 }'

--- a/tests/ci/run_build.py
+++ b/tests/ci/run_build.py
@@ -123,6 +123,15 @@ def loop_command(command, max_attempts=5):
 
 
 def build_srpm_and_rpm(command, mpi_family=None, compiler_family=None):
+    # Build SRPM
+    command = [
+        'misc/build_srpm.sh',
+        spec,
+    ]
+    if compiler_family:
+        command.append(compiler_family)
+    if compiler_family and mpi_family:
+        command.append(mpi_family)
     success, output = run_command(command)
     if not success:
         # First check if the architecture is not supported
@@ -254,15 +263,8 @@ for spec in args.specfiles:
         for family in families:
             if family == 'mvapich2' and os.uname().machine == 'aarch64':
                 continue
-            # Build SRPM
-            command = [
-                'misc/build_srpm.sh',
-                spec,
-                args.compiler_family,
-                family,
-            ]
             if not build_srpm_and_rpm(
-                    command,
+                    spec,
                     mpi_family=family,
                     compiler_family=args.compiler_family,
             ):
@@ -273,14 +275,8 @@ for spec in args.specfiles:
                     (just_spec, args.compiler_family, family))
 
     elif 'ohpc_compiler_dependent' in contents:
-        # Build SRPM
-        command = [
-            'misc/build_srpm.sh',
-            spec,
-            args.compiler_family,
-        ]
         if not build_srpm_and_rpm(
-                command,
+                spec,
                 compiler_family=args.compiler_family,
         ):
             failed.append(just_spec)
@@ -290,12 +286,7 @@ for spec in args.specfiles:
                 (just_spec, args.compiler_family))
 
     else:
-        # Build SRPM
-        command = [
-            'misc/build_srpm.sh',
-            spec,
-        ]
-        if not build_srpm_and_rpm(command):
+        if not build_srpm_and_rpm(spec):
             failed.append(just_spec)
         else:
             rebuild_success.append(just_spec)


### PR DESCRIPTION
Having spec files that can be built with and without MPI support requires changes to the test scripts to always build both variants (with and without MPI support).