### PR TITLE
CI: only run test analysis on 3.x

### DIFF
--- a/.github/workflows/test-analysis.yml
+++ b/.github/workflows/test-analysis.yml
@@ -5,6 +5,9 @@ on:
     workflows: [Validate]
     types:
       - completed
+    branches:
+      - '3.x'
+
 permissions: {}
 
 jobs:


### PR DESCRIPTION
The test analysis setup for GitHub PRs only works on 3.x. Change trigger to only look for 3.x.