### PR TITLE
Add "Requires: glibc-debuginfo" for Valgrind on  openEuler

### DIFF
--- a/components/dev-tools/valgrind/SPECS/valgrind.spec
+++ b/components/dev-tools/valgrind/SPECS/valgrind.spec
@@ -21,6 +21,9 @@ URL:       http://www.valgrind.org/
 Group:     %{PROJ_NAME}/dev-tools
 Source0:   https://sourceware.org/pub/%{pname}/%{pname}-%{version}.tar.bz2
 BuildRequires: gcc make perl
+%if 0%{?openEuler}
+Requires: glibc-debuginfo
+%endif
 
 # Default library install path
 %define install_path %{OHPC_UTILS}/%{pname}/%version


### PR DESCRIPTION
Without it the Valgrind tests fail with:
```
valgrind:  A must-be-redirected function
valgrind:  whose name matches the pattern:      strlen
valgrind:  in an object with soname matching:   ld-linux-aarch64.so.1
valgrind:  was not found whilst processing
valgrind:  symbols from the object with soname: ld-linux-aarch64.so.1
valgrind:
valgrind:  Possible fixes: (1, short term): install glibc's debuginfo
valgrind:  package on this machine.  (2, longer term): ask the packagers
valgrind:  for your Linux distribution to please in future ship a non-
valgrind:  stripped ld.so (or whatever the dynamic linker .so is called)
valgrind:  that exports the above-named function using the standard
valgrind:  calling conventions for this platform.  The package you need
valgrind:  to install for fix (1) is called
valgrind:
valgrind:    On Debian, Ubuntu:                 libc6-dbg
valgrind:    On SuSE, openSuSE, Fedora, RHEL:   glibc-debuginfo

```