### PR TITLE
[tau] Do not run some TAU tests on SIMPLE_CI

### DIFF
--- a/tests/ci/spec_to_test_mapping.py
+++ b/tests/ci/spec_to_test_mapping.py
@@ -141,12 +141,12 @@ test_map = {
     'components/perf-tools/geopm/SPECS/geopm.spec': [
         'geopm',
         '',
-        ''
+        'lmod-defaults-gnu13-openmpi5-ohpc'
     ],
     'components/perf-tools/likwid/SPECS/likwid.spec': [
         'likwid',
         '',
-        ''
+        'lmod-defaults-gnu13-openmpi5-ohpc'
     ],
     'components/perf-tools/papi/SPECS/papi.spec': [
         'papi',
@@ -161,7 +161,7 @@ test_map = {
     'components/perf-tools/tau/SPECS/tau.spec': [
         'tau',
         '',
-        ''
+        'lmod-defaults-gnu13-openmpi5-ohpc man bc'
     ],
     'components/mpi-families/openmpi/SPECS/openmpi5.spec': [
         'slurm',

--- a/tests/perf-tools/tau/ohpc-tests/test_mpi_families
+++ b/tests/perf-tools/tau/ohpc-tests/test_mpi_families
@@ -28,7 +28,7 @@ for compiler in $COMPILER_FAMILIES ; do
 	echo "-------------------------------------------------------"
 
 	module purge          || exit 1
-        module load prun      || exit 1
+	module load prun      || exit 1
 	module load $compiler || exit 1
 	module load $mpi      || exit 1
 	module load tau       || exit 1

--- a/tests/perf-tools/tau/tests/rm_execution
+++ b/tests/perf-tools/tau/tests/rm_execution
@@ -34,8 +34,11 @@ unset OMP_NUM_THREADS
 }
 
 @test "[libs/TAU] MPI C++ binary runs under resource manager ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
+    if [ ! -z "$SIMPLE_CI" ];then
+        skip "Not supported on SIMPLE_CI"
+    fi
     if [ "x$ARCH" == "xx86_64" ];then
-	export TAU_METRICS=PAPI_LD_INS
+        export TAU_METRICS=PAPI_LD_INS
     fi
     if [ ! -s CXX_mpi_test ];then
     flunk "CXX_mpi_test binary does not exist"
@@ -51,11 +54,14 @@ unset OMP_NUM_THREADS
 }
 
 @test "[libs/TAU] Hybrid OpenMP/MPI C binary runs under resource manager ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
+    if [ ! -z "$SIMPLE_CI" ];then
+        skip "Not supported on SIMPLE_CI"
+    fi
     if [ "$LMOD_FAMILY_COMPILER" == "intel" ];then
 	skip "intel"
     fi
     if [ "x$ARCH" == "xx86_64" ];then
-	export TAU_METRICS=PAPI_L1_DCM
+        export TAU_METRICS=PAPI_L1_DCM
     fi
     if [ ! -s C_hybrid_test ];then
 	flunk "C_hybrid_test binary does not exist"

--- a/tests/perf-tools/tau/tests/run_CXX_mpi_test.sh
+++ b/tests/perf-tools/tau/tests/run_CXX_mpi_test.sh
@@ -1,3 +1,13 @@
 #!/bin/bash
 
-tau_exec ./CXX_mpi_test 500 500 2 4 4
+ARGS=$1
+NODES=${2:-2}
+TASKS=${3:-4}
+
+dimX=500
+dimY=500
+numGridsX=$NODES
+numGridsY=$TASKS
+numInitPerturbations=4
+
+tau_exec ./CXX_mpi_test ${dimX} ${dimY} ${numGridsX} ${numGridsY} ${numInitPerturbations}


### PR DESCRIPTION
Improve some TAU tests by adding their dependencies for SIMPLE_CI (Github Actions and CirrusCI).
Disable some other TAU tests which could not run on SIMPLE_CI.

<!--
libjogl_cg.so comes pre-built in TAU sources.
It depends on libCg.so and LibCgGL.so (provided by Nvidia CG_Toolkit)
which are not available on the build systems.

Trying to install tau-gnu12-openmpi4-ohpc on openEuler 22.03 x86_64 fails with:
```
Error:
  Problem 1: package ohpc-gnu12-openmpi4-perf-tools-3.0-300.ohpc.4.1.x86_64 requires tau-gnu12-openmpi4-ohpc, but none of the providers can be installed
   - cannot install the best candidate for the job
   - nothing provides libCg.so()(64bit) needed by tau-gnu12-openmpi4-ohpc-2.31.1-300.ohpc.3.1.x86_64
   - nothing provides libCg.so(VERSION)(64bit) needed by tau-gnu12-openmpi4-ohpc-2.31.1-300.ohpc.3.1.x86_64
   - nothing provides libCgGL.so()(64bit) needed by tau-gnu12-openmpi4-ohpc-2.31.1-300.ohpc.3.1.x86_64
   - nothing provides libCgGL.so(VERSION)(64bit) needed by tau-gnu12-openmpi4-ohpc-2.31.1-300.ohpc.3.1.x86_64
```

```
$ ldd libjogl_cg.so
	linux-vdso.so.1 (0x00007fff64de4000)
	libGL.so.1 => /lib/x86_64-linux-gnu/libGL.so.1 (0x00007fe347579000)
	libX11.so.6 => /lib/x86_64-linux-gnu/libX11.so.6 (0x00007fe347439000)
	libCg.so => not found
	libCgGL.so => not found
```

During RPM build time the build systems use `/usr/lib/rpm/elfdeps --requires libjogl_cg.so` (via find-requires)
 to collect the runtime requirements.
rpm-build 4.17+ lists the same dependencies as `ldd` does.

RHEL 9.x (tested with Rocky 9 and Almalinux 9) uses rpm 4.16 which does not list any dependencies.
LEAP 15.5 uses rpm 4.14 which also does not list any dependencies.
openEuler 22.03 uses rpm 4.17 and lists the same dependencies as `ldd`.
Fedora 36 (rpm 4.17) and Fedora 38 (rpm 4.18) behave as openEuler.

This commit deletes all occurrences of libjogl_cg.so for all CPU
architectures at %install, so that it is not used as a source while
collecting the "Requires"
-->