### PR TITLE
incremeting pmix to latest release (4.2.4) and enabled pmix in openmpi

### DIFF
--- a/components/mpi-families/openmpi/SPECS/openmpi.spec
+++ b/components/mpi-families/openmpi/SPECS/openmpi.spec
@@ -32,7 +32,7 @@
 %{!?with_lustre: %define with_lustre 0}
 %{!?with_slurm: %define with_slurm 0}
 %{!?with_tm: %global with_tm 1}
-%{!?with_pmix: %define with_pmix 0}
+%{!?with_pmix: %define with_pmix 1}
 %{!?with_ofi: %define with_ofi 1}
 %{!?with_ucx: %define with_ucx 1}
 

--- a/components/rms/pmix/SPECS/pmix.spec
+++ b/components/rms/pmix/SPECS/pmix.spec
@@ -13,7 +13,7 @@
 
 Summary: An extended/exascale implementation of PMI
 Name: %{pname}%{PROJ_DELIM}
-Version: 4.2.1
+Version: 4.2.4
 Release: 1%{?dist}
 License: BSD
 URL: https://pmix.github.io/pmix/


### PR DESCRIPTION
This is a simplified PR for re-enabling PMIX for OpenMPI as well as updating pmix to the latest release.

