### PR TITLE
Exclude Intel libraries from RPM requires

### DIFF
--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -106,6 +106,8 @@ Requires:      gnu9-compilers%{PROJ_DELIM} >= 9.2.0
 %if "%{compiler_family}" == "intel"
 BuildRequires: gcc-c++ intel-compilers-devel%{PROJ_DELIM}
 Requires:      gcc-c++ intel-compilers-devel%{PROJ_DELIM}
+
+%global __requires_exclude ^lib(cilkrts|ifcoremt|ifport|imf|intlc|iomp5|irc|irng|mkl_.*|svml)\\.so(\\.[25])?\\(\\)\\(64bit\\)$
 %endif
 
 %if "%{compiler_family}" == "arm1"


### PR DESCRIPTION
OpenHPC packages should not explicitly require Intel runtime libraries.  See https://lists.openhpc.community/g/devel/message/318 