### PR TITLE
Fix the urls to the openEuler repos in the documentation.

### DIFF
--- a/docs/recipes/install/common/openeuler_repos.tex
+++ b/docs/recipes/install/common/openeuler_repos.tex
@@ -8,17 +8,17 @@ for which mirrors are freely available online:
 
 \begin{itemize*}
 \item OS
-  (e.g. \href{http://repo.openeuler.org/openeuler/openEuler-22.03-LTS/OS/}
-             {\color{blue}{http://repo.openeuler.org/openeuler/openEuler-22.03-LTS/OS/}} )
+  (e.g. \href{http://repo.openeuler.org/openEuler-22.03-LTS/OS/}
+            {\color{blue}{http://repo.openeuler.org/openEuler-22.03-LTS/OS/}} )
 \item Everything
-  (e.g. \href{http://repo.openeuler.org/openeuler/openEuler-22.03-LTS/everything/}
-            {\color{blue}{repo.openeuler.org/openeuler/openEuler-22.03-LTS/everything/}} )
+  (e.g. \href{http://repo.openeuler.org/openEuler-22.03-LTS/everything/}
+            {\color{blue}{http://repo.openeuler.org/openEuler-22.03-LTS/everything/}} )
 \item EPOL-main
-  (e.g. \href{http://repo.openeuler.org/openeuler/openEuler-22.03-LTS/EPOL/main/}
-            {\color{blue}{http://repo.openeuler.org/openeuler/openEuler-22.03-LTS/EPOL/main/}} )
+  (e.g. \href{http://repo.openeuler.org/openEuler-22.03-LTS/EPOL/main/}
+            {\color{blue}{http://repo.openeuler.org/openEuler-22.03-LTS/EPOL/main/}} )
 \item EPOL-update
-  (e.g. \href{http://repo.openeuler.org/openeuler/openEuler-22.03-LTS/EPOL/update/main}
-            {\color{blue}{http://repo.openeuler.org/openeuler/openEuler-22.03-LTS/EPOL/update/main}} )
+  (e.g. \href{http://repo.openeuler.org/openEuler-22.03-LTS/EPOL/update/main}
+            {\color{blue}{http://repo.openeuler.org/openEuler-22.03-LTS/EPOL/update/main}} )
 \end{itemize*}
 
 One might replace {\color{blue}{http://repo.openeuler.org}} with any of the mirrors listed


### PR DESCRIPTION
Use LaTeX "verbatim" instead of "itemize" - it should be easier for the reader to copy/paste.

The itemized urls were wrong (giving 404) because of the extra `openeuler/" in the middle of the urls.