### PR TITLE
Fix LaTeX `\install` command syntax for openeuler_repos.tex

### DIFF
--- a/docs/recipes/install/common/openeuler_repos.tex
+++ b/docs/recipes/install/common/openeuler_repos.tex
@@ -12,7 +12,7 @@ To enable {\color{purple}{EPOL update}} repository on openEuler-22.03, run the f
 % begin_ohpc_run
 \begin{lstlisting}[language=bash,keywords={},basicstyle=\fontencoding{T1}\fontsize{7.6}{10}\ttfamily,
 	literate={ARCH}{\arch{}}1 {-}{-}1]
-[sms](*\#*) \install https://eur.openeuler.openatom.cn/results/mgrigorov/OpenHPC/openeuler-22.03_LTS-ARCH/00091098-openeuler-extra-repos/openeuler-extra-repos-22.03-LTS.noarch.rpm
+[sms](*\#*) (*\install*) https://eur.openeuler.openatom.cn/results/mgrigorov/OpenHPC/openeuler-22.03_LTS-ARCH/00091098-openeuler-extra-repos/openeuler-extra-repos-22.03-LTS.noarch.rpm
 \end{lstlisting}
 % end_ohpc_run
 


### PR DESCRIPTION
http://test.openhpc.community:8080/job/Install%20Cluster%20Huawei/215/consoleFull fails with:
```
+ install https://eur.openeuler.openatom.cn/results/mgrigorov/OpenHPC/openeuler-22.03_LTS-aarch64/00091098-openeuler-extra-repos/openeuler-extra-repos-22.03-LTS.noarch.rpm
install: missing destination file operand after 'https://eur.openeuler.openatom.cn/results/mgrigorov/OpenHPC/openeuler-22.03_LTS-aarch64/00091098-openeuler-extra-repos/openeuler-extra-repos-22.03-LTS.noarch.rpm'
Try 'install --help' for more information.
```
i.e. it tries to `install` the .rpm, not to `yum -y install` it.