### PR TITLE
Use env var for `arch` instead of the LaTeX command

### DIFF
--- a/docs/recipes/install/common/openeuler_repos.tex
+++ b/docs/recipes/install/common/openeuler_repos.tex
@@ -13,11 +13,11 @@ command:
 % begin_ohpc_run
 % ohpc_command if [[ ${enable_epol_updates} -eq 1 ]];then
 % ohpc_indent 5
-\begin{lstlisting}[language=bash,keywords={},basicstyle=\fontencoding{T1}\fontsize{7.6}{10}\ttfamily,
-	literate={ARCH}{\arch{}}1 {-}{-}1]
+\begin{lstlisting}[language=bash,keywords={},basicstyle=\fontencoding{T1}\fontsize{7.6}{10}\ttfamily]
 [sms](*\#*) export repo=https://eur.openeuler.openatom.cn/results/mgrigorov/OpenHPC
+[sms](*\#*) export arch=$(uname -m)
 [sms](*\#*) (*\install*) \
-  ${repo}/openeuler-22.03_LTS-ARCH/00091098-openeuler-extra-repos/openeuler-extra-repos-22.03-LTS.noarch.rpm
+  ${repo}/openeuler-22.03_LTS-${arch}/00091098-openeuler-extra-repos/openeuler-extra-repos-22.03-LTS.noarch.rpm
 \end{lstlisting}
 % ohpc_indent 0
 % ohpc_command fi


### PR DESCRIPTION
The LaTeX command got broken somehow with https://github.com/openhpc/ohpc/commit/9af8dbde7f442c2b3de03d20c424931f85af3980