### PR TITLE
Intel compiler and MPI devel package updates

### DIFF
--- a/components/mpi-families/impi-devel/SPECS/intel-mpi.spec
+++ b/components/mpi-families/impi-devel/SPECS/intel-mpi.spec
@@ -141,15 +141,6 @@ EOF
 
     md5sum ${modname} >> %{oneapi_manifest}
 
-    modname=$(testfile %{OHPC_MODULEDEPS}/intel/impi/.version.$ver)
-
-    cat << EOF > ${modname}
-#%Module1.0#####################################################################
-set     ModulesVersion      "$ver"
-EOF
-
-    md5sum ${modname} >> %{oneapi_manifest}
-
     modname=$(testfile %{OHPC_MODULEDEPS}/gnu/impi/$ver)
 
     cat << EOF > ${modname}
@@ -192,22 +183,32 @@ EOF
     sed -i "s,%{OHPC_MODULEDEPS}/gnu-impi,%{OHPC_MODULEDEPS}/gnu%{gnu_major_ver}-impi," ${modname}
     md5sum ${modname} >> %{oneapi_manifest}
 
-    modname=$(testfile %{OHPC_MODULEDEPS}/gnu/impi/.version.$ver)
-
-    cat << EOF > ${modname}
-#%Module1.0#####################################################################
-set     ModulesVersion      "$ver"
-EOF
-
-    md5sum ${modname} >> %{oneapi_manifest}
-
-    # support for gnu major version
-    orig_modname=$modname
-    modname=$(testfile  %{OHPC_MODULEDEPS}/gnu%{gnu_major_ver}/impi/.version.$ver)
-    cp ${orig_modname} ${modname}
-    md5sum ${modname} >> %{oneapi_manifest}
 done
 
+# Default Intel(R) MPI Versions to match OpenHPC build version
+modname=$(testfile %{OHPC_MODULEDEPS}/intel/impi/.version)
+
+cat << EOF > ${modname}
+#%Module1.0#####################################################################
+set     ModulesVersion      "%{exact_intel_ver}"
+EOF
+
+md5sum ${modname} >> %{oneapi_manifest}
+
+modname=$(testfile %{OHPC_MODULEDEPS}/gnu/impi/.version)
+
+cat << EOF > ${modname}
+#%Module1.0#####################################################################
+set     ModulesVersion      "%{exact_intel_ver}"
+EOF
+
+md5sum ${modname} >> %{oneapi_manifest}
+
+# support for gnu major version
+orig_modname=$modname
+modname=$(testfile  %{OHPC_MODULEDEPS}/gnu%{gnu_major_ver}/impi/.version)
+cp ${orig_modname} ${modname}
+md5sum ${modname} >> %{oneapi_manifest}
 
 %preun -p /bin/bash
 # Check current files against the manifest


### PR DESCRIPTION
Updates intel-compiler-devel-ohpc and intel-mpi-devel-ohpc packages. Changes the default version of the compilers and MPI to the same required version used to build packages on OBS.

Currently, modules always default to the latest available version.

Tested on Rocky 9.2.