### PR TITLE
updating rocky and alama recipes to the proper name for the CRB repo

### DIFF
--- a/docs/recipes/install/common/almalinux_repos.tex
+++ b/docs/recipes/install/common/almalinux_repos.tex
@@ -21,5 +21,5 @@ disabled in a standard install, but can be enabled from EPEL as follows:
 
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true]
 [sms](*\#*) yum install dnf-plugins-core
-[sms](*\#*) yum config-manager --set-enabled CRB
+[sms](*\#*) yum config-manager --set-enabled crb
 \end{lstlisting}

--- a/docs/recipes/install/common/rocky_repos.tex
+++ b/docs/recipes/install/common/rocky_repos.tex
@@ -21,5 +21,5 @@ disabled in a standard install, but can be enabled from EPEL as follows:
 
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true]
 [sms](*\#*) yum install dnf-plugins-core
-[sms](*\#*) yum config-manager --set-enabled CRB
+[sms](*\#*) yum config-manager --set-enabled crb
 \end{lstlisting}


### PR DESCRIPTION
Actual repo for the yum config-manager command uses lowercase for crb and not uppercase. 