### PR TITLE
Update Intel-compiler-based tests to use icx/ifx

### DIFF
--- a/tests/common/functions
+++ b/tests/common/functions
@@ -142,9 +142,9 @@ check_compiler_family()
     local myFC=""
     
     if [ $LMOD_FAMILY_COMPILER == "intel" ];then
-	myCC=icc
-	myCXX=icpc
-	myFC=ifort
+	myCC=icx
+	myCXX=icpx
+	myFC=ifx
   elif [[ $LMOD_FAMILY_COMPILER =~ "arm" ]];then
         myCC=armclang
         myCXX=armclang++

--- a/tests/compilers/tests/man_pages
+++ b/tests/compilers/tests/man_pages
@@ -24,7 +24,7 @@ family=$LMOD_FAMILY_COMPILER
     if [[ "$family" =~ "llvm" ]];then
 	run $CXX -help
     elif [[ "$family" =~ "intel" ]];then
-	# intel oneapi now only provides one man page (icc)
+	# intel oneapi now only provides one man page (icx)
 	run man -w $CC
 	assert_success
     else

--- a/tests/compilers/tests/version_match
+++ b/tests/compilers/tests/version_match
@@ -7,60 +7,53 @@ source ../../common/functions || exit 1
 family=$LMOD_FAMILY_COMPILER
 
 @test "[Compilers] compiler module loaded ($family)" {
-    module list $family >& .cmd_output || exit 1
-    local my_module=`cat .cmd_output | sed '/^\s*$/d' | sed 's/^[ \t]*//' | tail -1`
-    echo $my_module | grep -q "1) $family/" || exit 1
-}
+    module list $family >&.cmd_output || exit 1
+    local my_module=$(cat .cmd_output | sed '/^\s*$/d' | sed 's/^[ \t]*//' | tail -1)
+    echo $my_module | grep -q "1) $family/" || exit 1 }
 
 @test "[Compilers] compiler module version available ($family)" {
-    module list $family >& .cmd_output || exit 1
-    local my_version=`cat .cmd_output | sed '/^\s*$/d' | sed 's/^[ \t]*//' | tail -1 | awk -F "$family/" '{print $2}'`
+    module list $family >&.cmd_output || exit 1
+    local my_version=$(cat .cmd_output | sed '/^\s*$/d' | sed 's/^[ \t]*//' | tail -1 | awk -F "$family/" '{print $2}')
 
-    if [ -z "$my_version" ];then
-	flunk "ERROR: unable to ascertain module version ($my_version)"
+    if [ -z "$my_version" ]; then
+        flunk "ERROR: unable to ascertain module version ($my_version)"
     fi
-    rm -f .cmd_output
-}
+    rm -f .cmd_output }
 
 @test "[Compilers] C, C++, and Fortran versions match module ($family)" {
     local my_family
-    if  [[ "$family" =~ "acfl" ]]; then
+    if [[ "$family" =~ "acfl" ]]; then
         # The arm compiler package set "acfl".
         # OpenHPC expects "arm1".
         my_family="arm1"
     else
         my_family="$family"
     fi
-    module list $my_family >& .cmd_output || exit 1
-    local my_mod_version=`cat .cmd_output | sed '/^\s*$/d' | sed 's/^[ \t]*//' | tail -1 | awk -F "$my_family/" '{print $2}'`
+    module list $my_family >&.cmd_output || exit 1
+    local my_mod_version=$(cat .cmd_output | sed '/^\s*$/d' | sed 's/^[ \t]*//' | tail -1 | awk -F "$my_family/" '{print $2}')
 
-    if [[ "$my_family" = "intel" ]];then
-	# intel has no consistency here, have to punt
-## 	compiler=`which icc`
-## 	version=`icc --version | head -1 | awk '{print $3}'`
-## 	assert_equal "$my_mod_version" "$version"
-	version="assuming all is good"
-  elif [[ "$my_family" =~ "arm1" ]];then
-	assert_equal "$my_mod_version" "compat"
-    elif [[ "$my_family" =~ "gnu"  ]];then
-	version=`gcc --version | head -1 | awk '{print $3}'`
-	assert_equal "$my_mod_version" "$version"
-	version=`g++ --version | head -1 | awk '{print $3}'`
-	assert_equal "$my_mod_version" "$version"
-	version=`gfortran --version | head -1 | awk '{print $4}'`
-	assert_equal "$my_mod_version" "$version"
-    elif [[ "$my_family" =~ "llvm"  ]];then
-	version=`clang --version | head -1 | awk '{print $3}'`
-	assert_equal "$my_mod_version" "$version"
-	version=`clang++ --version | head -1 | awk '{print $3}'`
-	assert_equal "$my_mod_version" "$version"
-	version=`flang --version | head -1 | awk '{print $3}'`
-	assert_equal "$my_mod_version" "$version"
+    if [[ "$my_family" = "intel" ]]; then
+        compiler=$(which icx)
+        version=$(icx --version | awk 'sub(/^.* 202/,"202",$0){print $1;exit}')
+        assert_equal "$my_mod_version" "$version"
+    elif [[ "$my_family" =~ "arm1" ]]; then
+        assert_equal "$my_mod_version" "compat"
+    elif [[ "$my_family" =~ "gnu" ]]; then
+        version=$(gcc --version | head -1 | awk '{print $3}')
+        assert_equal "$my_mod_version" "$version"
+        version=$(g++ --version | head -1 | awk '{print $3}')
+        assert_equal "$my_mod_version" "$version"
+        version=$(gfortran --version | head -1 | awk '{print $4}')
+        assert_equal "$my_mod_version" "$version"
+    elif [[ "$my_family" =~ "llvm" ]]; then
+        version=$(clang --version | head -1 | awk '{print $3}')
+        assert_equal "$my_mod_version" "$version"
+        version=$(clang++ --version | head -1 | awk '{print $3}')
+        assert_equal "$my_mod_version" "$version"
+        version=$(flang --version | head -1 | awk '{print $3}')
+        assert_equal "$my_mod_version" "$version"
     else
-	flunk "Unsupported compiler toolchain"
+        flunk "Unsupported compiler toolchain"
     fi
 
-    rm -f .cmd_output
-}
-
-
+    rm -f .cmd_output }

--- a/tests/libs/boost/tests/module/test_module
+++ b/tests/libs/boost/tests/module/test_module
@@ -121,7 +121,7 @@ header=boost/version.hpp
     fi
 
     if [ $LMOD_FAMILY_COMPILER == "intel" ];then
-        CXX=icpc
+        CXX=icpx
     elif [[ $LMOD_FAMILY_COMPILER =~ "gnu" ]];then
         CXX=g++
     elif [[ $LMOD_FAMILY_COMPILER =~ "acfl" ]];then

--- a/tests/libs/hdf5/test-env-variables-new/config/toolchain/intel.cmake
+++ b/tests/libs/hdf5/test-env-variables-new/config/toolchain/intel.cmake
@@ -4,14 +4,14 @@
 set(CMAKE_COMPILER_VENDOR "intel")
 
 if(USE_SANITIZER)
-  set(CMAKE_C_COMPILER icl)
-  set(CMAKE_CXX_COMPILER icl++)
-  set(CMAKE_Fortran_COMPILER ifort)
+  set(CMAKE_C_COMPILER icx-cl)
+  set(CMAKE_CXX_COMPILER icx-cl)
+  set(CMAKE_Fortran_COMPILER ifx)
   set(INTEL_CLANG ON)
 else ()
-  set(CMAKE_C_COMPILER icc)
-  set(CMAKE_CXX_COMPILER icpc)
-  set(CMAKE_Fortran_COMPILER ifort)
+  set(CMAKE_C_COMPILER icx)
+  set(CMAKE_CXX_COMPILER icpx)
+  set(CMAKE_Fortran_COMPILER ifx)
 endif ()
 
 # the following is used if cross-compiling

--- a/tests/libs/hdf5/test-h5-wrappers-new/config/toolchain/intel.cmake
+++ b/tests/libs/hdf5/test-h5-wrappers-new/config/toolchain/intel.cmake
@@ -4,14 +4,14 @@
 set(CMAKE_COMPILER_VENDOR "intel")
 
 if(USE_SANITIZER)
-  set(CMAKE_C_COMPILER icl)
-  set(CMAKE_CXX_COMPILER icl++)
-  set(CMAKE_Fortran_COMPILER ifort)
+  set(CMAKE_C_COMPILER icx-cl)
+  set(CMAKE_CXX_COMPILER icx-cl)
+  set(CMAKE_Fortran_COMPILER icx)
   set(INTEL_CLANG ON)
 else ()
-  set(CMAKE_C_COMPILER icc)
-  set(CMAKE_CXX_COMPILER icpc)
-  set(CMAKE_Fortran_COMPILER ifort)
+  set(CMAKE_C_COMPILER icx)
+  set(CMAKE_CXX_COMPILER icpx)
+  set(CMAKE_Fortran_COMPILER icx)
 endif ()
 
 # the following is used if cross-compiling

--- a/tests/libs/hypre/configure.ac
+++ b/tests/libs/hypre/configure.ac
@@ -32,7 +32,7 @@ AC_C_CONST
 
 if test "x$LMOD_FAMILY_COMPILER" = "xintel"; then
   CFLAGS="-DHYPRE_TIMING -I ${HYPRE_INC} -I ${MKLROOT}/include ${CFLAGS}"
-  CXXFLAGS="-DHYPRE_TIMING -I ${HYPRE_INC} -I ${MKLROOT}/include ${CXXFLAGS} -fopenmp"
+  CXXFLAGS="-DHYPRE_TIMING -I ${HYPRE_INC} -I ${MKLROOT}/include ${CXXFLAGS} -qopenmp"
   FFLAGS="-I ${HYPRE_INC} -I ${MKLROOT}/include ${FFLAGS}"
   LDFLAGS="-L${HYPRE_LIB} -lHYPRE -L$MKLROOT/lib/intel64 -lmkl_rt -lm ${LDFLAGS}"
 elif test "x$LMOD_FAMILY_COMPILER" = "xacfl"; then

--- a/tests/libs/plasma/configure.ac
+++ b/tests/libs/plasma/configure.ac
@@ -26,8 +26,8 @@ AC_PROG_FC
 AC_C_CONST
 
 if test "x$LMOD_FAMILY_COMPILER" = "xintel"; then
-  CFLAGS="-I ${PLASMA_INC} -I ${MKLROOT}/include ${CFLAGS} -fopenmp"
-  FFLAGS="-I ${PLASMA_INC} -I ${MKLROOT}/include ${FFLAGS} -fopenmp"
+  CFLAGS="-I ${PLASMA_INC} -I ${MKLROOT}/include ${CFLAGS} -qopenmp"
+  FFLAGS="-I ${PLASMA_INC} -I ${MKLROOT}/include ${FFLAGS} -qopenmp"
   FCFLAGS="-I ${PLASMA_INC} -I ${MKLROOT}/include ${FFLAGS}"
   LDFLAGS="-L${PLASMA_LIB} -lplasma -lcoreblas -lmkl_rt -lpthread -lifcore ${LDFLAGS}"
 else

--- a/tests/m4/compiler_family.m4
+++ b/tests/m4/compiler_family.m4
@@ -49,9 +49,9 @@ elif test "x$LMOD_FAMILY_COMPILER" = "xllvm9"; then
    FC=gfortran
    AC_MSG_RESULT([llvm9])
 elif test "x$LMOD_FAMILY_COMPILER" = "xintel"; then
-   CC=icc
-   CXX=icpc
-   FC=ifort
+   CC=icx
+   CXX=icpx
+   FC=ifx
    AC_MSG_RESULT([intel])
    OHPC_BLAS="-L${MKLROOT}/lib/intel64 -lmkl_rt"
 elif test "x$LMOD_FAMILY_COMPILER" = "xacfl"; then

--- a/tests/perf-tools/geopm/configure.ac
+++ b/tests/perf-tools/geopm/configure.ac
@@ -34,7 +34,11 @@ AC_C_CONST
 
 # OMP_FLAGS: Flags for enabling OpenMP
 if test "x$OMP_FLAGS" = "x"; then
-    OMP_FLAGS="-fopenmp"
+    if test "x$LMOD_FAMILY_COMPILER" = "xintel"; then
+        OMP_FLAGS="-qopenmp"
+    else
+        OMP_FLAGS="-fopenmp"
+    fi
 fi
 
 if test "x$LMOD_FAMILY_COMPILER" = "xintel"; then

--- a/tests/perf-tools/scalasca/configure.ac
+++ b/tests/perf-tools/scalasca/configure.ac
@@ -46,17 +46,19 @@ CXX='scorep mpicxx'
 FC='scorep mpif90'
 F77='scorep mpif90'
 
-CFLAGS="${CFLAGS} -fopenmp"
-CXXFLAGS="${CXXFLAGS} -fopenmp"
-FCFLAGS="${FCLAGS}"
-FFLAGS="${FCLAGS}"
-LDFLAGS="${LDFLAGS}"
-
 if test "x$LMOD_FAMILY_COMPILER" = "xintel" ; then
+   CFLAGS="${CFLAGS} -qopenmp"
+   CXXFLAGS="${CXXFLAGS} -qopenmp"
    if test "x$LMOD_FAMILY_MPI" = "xmvapich2" ;then
       LDFLAGS="$LDFLAGS -lfmpich"
    fi
+else
+  CFLAGS="${CFLAGS} -fopenmp"
+  CXXFLAGS="${CXXFLAGS} -fopenmp"
 fi
+FCFLAGS="${FCLAGS}"
+FFLAGS="${FCLAGS}"
+LDFLAGS="${LDFLAGS}"
 
 # Set subdirectories
 AC_CONFIG_FILES(Makefile tests/Makefile)


### PR DESCRIPTION
Changes the 3.x test framework to use the latest Intel compilers. Testing is still in progress and I wanted to get these changes available for review ASAP.

The apps subdirectory was not changed, as these need to be updated with new upstream sources.

Some lib tests have been updated. Currently, oneAPI compilers still support -fopenmp, but it may be dropped at any time. The correct option is -qopenmp or -fiopenmp.