### PR TITLE
ci: Support for building docs-ohpc.rpm at simple CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,6 @@ env:
     components/compiler-families/intel-compilers-devel/SPECS/intel-compilers-devel.spec
     components/mpi-families/impi-devel/SPECS/intel-mpi.spec
     components/parallel-libs/trilinos/SPECS/trilinos.spec
-    components/admin/docs/SPECS/docs.spec
 
 task:
   name: RHEL/Rocky on aarch64

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,7 +12,6 @@ env:
   SKIP_CI_SPECS: |
     components/fs/lustre-client/SPECS/lustre.spec
     components/parallel-libs/trilinos/SPECS/trilinos.spec
-    components/admin/docs/SPECS/docs.spec
 
 jobs:
   check_spec:

--- a/components/admin/docs/SOURCES/get_source.sh
+++ b/components/admin/docs/SOURCES/get_source.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 
+set -x
+
 # Note: The current working directory is the component's SPEC folder
+OHPC_ROOT_FOLDER="../../../.."
 
 # The folder that will contain the .git/ and docs/ folders
 DOCS_OHPC_FOLDER=docs-ohpc
-# A folder that contains the full Git history of the project
-# Full history is needed for the usage of `git archive` command
-COMPLETE_OHPC_FOLDER=$(mktemp -d)
 
 cleanup() {
-    rm -rf ${DOCS_OHPC_FOLDER} ${COMPLETE_OHPC_FOLDER}
+    rm -rf ${DOCS_OHPC_FOLDER}
+    find ${OHPC_ROOT_FOLDER}/docs/recipes/install/ -name "vc.tex" -delete
 }
 trap cleanup EXIT
 
@@ -17,15 +18,41 @@ trap cleanup EXIT
 cleanup
 mkdir -p ${DOCS_OHPC_FOLDER}
 
-# 2. Fetch the full Git history so that `git describe` works later
-git clone https://github.com/openhpc/ohpc ${COMPLETE_OHPC_FOLDER}
-cp -r ${COMPLETE_OHPC_FOLDER}/.git ${DOCS_OHPC_FOLDER}
+# 2. Copy the Git metadata
+cp -r ${OHPC_ROOT_FOLDER}/.git ${DOCS_OHPC_FOLDER}
 
 # 3. Copy the local docs/
-cp -r ../../../../docs ${DOCS_OHPC_FOLDER}
+cp -r ${OHPC_ROOT_FOLDER}/docs ${DOCS_OHPC_FOLDER}
 
-# 4. Create docs-ohpc.tar
+# 4. Add dummy vc.tex to the docs
+for makefile in `find ${DOCS_OHPC_FOLDER}/docs/recipes/install/ -name "Makefile"`; do
+    folder=$(dirname ${makefile})
+    cat <<'EOF' > ${folder}/vc.tex
+%%% Define Git specific macros.
+\gdef\GITHash{5ffbf3e2ed0ed558c1ae5672f7e5023298b7c2a9}%
+\gdef\GITAbrHash{5ffbf3e}%
+\gdef\GITParentHashes{}%
+\gdef\GITAbrParentHashes{}%
+\gdef\GITAuthorName{CI Docs author}%
+\gdef\GITAuthorEmail{simple_ci@docs.com}%
+\gdef\GITAuthorDate{2024-02-29 14:00:35 +0100}%
+\gdef\GITCommitterName{CI Docs author}%
+\gdef\GITCommitterEmail{simple_ci@docs.com}%
+\gdef\GITCommitterDate{2024-02-29 14:00:35 +0100}%
+%%% Define generic version control macros.
+\gdef\VCRevision{\GITAbrHash}%
+\gdef\VCAuthor{\GITAuthorName}%
+\gdef\VCDateRAW{2024-02-29}%
+\gdef\VCDateISO{2024-02-29}%
+\gdef\VCDateTEX{2024/02/29}%
+\gdef\VCTime{14:00:35 +0100}%
+\gdef\VCModifiedText{\textcolor{red}{with local modifications!}}%
+%%% Assume clean working copy.
+\gdef\VCModified{0}%
+\gdef\VCRevisionMod{\VCRevision}%
+EOF
+
+done
+
+# 5. Create docs-ohpc.tar
 tar cf ../SOURCES/docs-ohpc.tar ${DOCS_OHPC_FOLDER}
-
-# 5. Cleanup
-cleanup

--- a/components/admin/docs/SOURCES/get_source.sh
+++ b/components/admin/docs/SOURCES/get_source.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Note: The current working directory is the component's SPEC folder
+
+# The folder that will contain the .git/ and docs/ folders
+DOCS_OHPC_FOLDER=docs-ohpc
+# A folder that contains the full Git history of the project
+# Full history is needed for the usage of `git archive` command
+COMPLETE_OHPC_FOLDER=$(mktemp -d)
+
+cleanup() {
+    rm -rf ${DOCS_OHPC_FOLDER} ${COMPLETE_OHPC_FOLDER}
+}
+trap cleanup EXIT
+
+# 1. Prepare
+cleanup
+mkdir -p ${DOCS_OHPC_FOLDER}
+
+# 2. Fetch the full Git history so that `git describe` works later
+git clone https://github.com/openhpc/ohpc ${COMPLETE_OHPC_FOLDER}
+cp -r ${COMPLETE_OHPC_FOLDER}/.git ${DOCS_OHPC_FOLDER}
+
+# 3. Copy the local docs/
+cp -r ../../../../docs ${DOCS_OHPC_FOLDER}
+
+# 4. Create docs-ohpc.tar
+tar cf ../SOURCES/docs-ohpc.tar ${DOCS_OHPC_FOLDER}
+
+# 5. Cleanup
+cleanup

--- a/docs/recipes/install/openeuler22.03/aarch64/warewulf/openpbs/steps.tex
+++ b/docs/recipes/install/openeuler22.03/aarch64/warewulf/openpbs/steps.tex
@@ -277,6 +277,8 @@
 \input{manifest}
 \input{common/signature}
 
+\section{TESTING PR 1878}
+THIS IS A TEMPORARY CHANGE TO TEST THE BUILD OF DOCS WHEN A .TEX FILE IS MODIFIED
 
 \end{document}
 

--- a/docs/recipes/install/openeuler22.03/aarch64/warewulf/openpbs/steps.tex
+++ b/docs/recipes/install/openeuler22.03/aarch64/warewulf/openpbs/steps.tex
@@ -277,8 +277,6 @@
 \input{manifest}
 \input{common/signature}
 
-\section{TESTING PR 1878}
-THIS IS A TEMPORARY CHANGE TO TEST THE BUILD OF DOCS WHEN A .TEX FILE IS MODIFIED
 
 \end{document}
 

--- a/misc/get_source.sh
+++ b/misc/get_source.sh
@@ -14,23 +14,6 @@ fi
 
 PATTERN=${1}
 
-prepare_docs_ohpc_tar() {
-	rm -rf docs-ohpc /tmp/ohpc-for-docs
-	mkdir -p docs-ohpc
-	# Fetch the full Git history so that `git describe` works later
-	git clone https://github.com/openhpc/ohpc /tmp/ohpc-for-docs
-	cp -r /tmp/ohpc-for-docs/.git docs-ohpc/
-	# Copy the local docs/
-	cp -r docs docs-ohpc/
-	
-	tar cf components/admin/docs/SOURCES/docs-ohpc.tar docs-ohpc
-	rm -rf docs-ohpc
-}
-
-if [[ "${PATTERN}" == "docs.spec" ]]; then
-	prepare_docs_ohpc_tar
-fi
-
 IFS=$'\n'
 
 find . -name "${PATTERN}" -print0 | while IFS= read -r -d '' file
@@ -44,6 +27,12 @@ do
 
 	DIR=$(dirname "${file}")
 	pushd "${DIR}" > /dev/null || exit 1
+
+	# .../SOURCES/get_source.sh is an optional "plugin" that could build/fetch component's sources on the fly
+	if [ -f ../SOURCES/get_source.sh ]; then
+		bash ../SOURCES/get_source.sh
+	fi
+
 	BASE=$(basename "${file}")
 
 	SOURCES=$(rpmspec --parse --define '_sourcedir ../../..' "${FLAGS[@]}" "${BASE}" | grep Source)

--- a/misc/get_source.sh
+++ b/misc/get_source.sh
@@ -14,6 +14,23 @@ fi
 
 PATTERN=${1}
 
+prepare_docs_ohpc_tar() {
+	rm -rf docs-ohpc /tmp/ohpc-for-docs
+	mkdir -p docs-ohpc
+	# Fetch the full Git history so that `git describe` works later
+	git clone https://github.com/openhpc/ohpc /tmp/ohpc-for-docs
+	cp -r /tmp/ohpc-for-docs/.git docs-ohpc/
+	# Copy the local docs/
+	cp -r docs docs-ohpc/
+	
+	tar cf components/admin/docs/SOURCES/docs-ohpc.tar docs-ohpc
+	rm -rf docs-ohpc
+}
+
+if [[ "${PATTERN}" == "docs.spec" ]]; then
+	prepare_docs_ohpc_tar
+fi
+
 IFS=$'\n'
 
 find . -name "${PATTERN}" -print0 | while IFS= read -r -d '' file

--- a/tests/ci/run_build.py
+++ b/tests/ci/run_build.py
@@ -237,9 +237,17 @@ skipped = []
 failed = []
 rebuild_success = []
 total = 0
+docs_spec_executed = False
 
 for spec in args.specfiles:
-    if not spec.endswith('.spec'):
+    if 'components/admin/docs/SPECS/docs.spec' == spec:
+        if docs_spec_executed:
+            continue
+        docs_spec_executed = True
+    elif not docs_spec_executed and 'docs/recipes/install/' in spec:
+        docs_spec_executed = True
+        spec = 'components/admin/docs/SPECS/docs.spec'
+    elif not spec.endswith('.spec'):
         continue
     just_spec = os.path.basename(spec)
     total += 1

--- a/tests/ci/run_build.py
+++ b/tests/ci/run_build.py
@@ -240,13 +240,19 @@ total = 0
 docs_spec_executed = False
 
 for spec in args.specfiles:
+    # if more than one docs related file are modified then
+    # build the docs.spec just once
+    # START OF LOGIC FOR DOCS
     if 'components/admin/docs/SPECS/docs.spec' == spec:
         if docs_spec_executed:
             continue
         docs_spec_executed = True
-    elif not docs_spec_executed and 'docs/recipes/install/' in spec:
+    elif not docs_spec_executed and \
+        ('docs/recipes/install/' in spec
+            or 'components/admin/docs/SOURCES/' in spec):
         docs_spec_executed = True
         spec = 'components/admin/docs/SPECS/docs.spec'
+    # END OF LOGIC FOR DOCS
     elif not spec.endswith('.spec'):
         continue
     just_spec = os.path.basename(spec)


### PR DESCRIPTION
Create dosc-ohpc.tar on the fly.
Clones the complete Git repo to be able to run `git describe` later in the Makefile`s