### PR TITLE
Remove hardcoded values for num_nodes, compute_prefix, allow overrides for input.local values

### DIFF
--- a/docs/recipes/install/almalinux9/input.local.template
+++ b/docs/recipes/install/almalinux9/input.local.template
@@ -72,7 +72,6 @@ enable_arm1_packages="${enable_arm1_packages:-0}"
 
 nagios_web_password="${nagios_web_password:-unknown}"
 update_slurm_nodeconfig="${update_slurm_nodeconfig:-0}"
-slurm_node_config="${slurm_node_config:-c[1-4] Sockets=2 CoresPerSocket=12 ThreadsPerCore=2}"
 
 # -------------------------
 # compute node settings
@@ -86,28 +85,31 @@ compute_regex="${compute_regex:-c*}"
 compute_prefix="${compute_prefix:-c}"
 
 # compute hostnames
-c_name[0]=c1
-c_name[1]=c2
-c_name[2]=c3
-c_name[3]=c4
+c_name[0]=${c_name[0]:-c1}
+c_name[1]=${c_name[1]:-c2}
+c_name[2]=${c_name[2]:-c3}
+c_name[3]=${c_name[3]:-c4}
 
 # compute node IP addresses
-c_ip[0]=172.16.1.1
-c_ip[1]=172.16.1.2
-c_ip[2]=172.16.1.3
-c_ip[3]=172.16.1.4
+c_ip[0]=${c_ip[0]:-172.16.1.1}
+c_ip[1]=${c_ip[1]:-172.16.1.2}
+c_ip[2]=${c_ip[2]:-172.16.1.3}
+c_ip[3]=${c_ip[3]:-172.16.1.4}
 
 # compute node MAC addreses for provisioning interface
-c_mac[0]=00:1a:2b:3c:4f:56
-c_mac[1]=00:1a:2b:3c:4f:56
-c_mac[2]=00:1a:2b:3c:4f:56
-c_mac[3]=00:1a:2b:3c:4f:56
+c_mac[0]=${c_mac[0]:-00:1a:2b:3c:4f:56}
+c_mac[1]=${c_mac[1]:-00:1a:2b:3c:4f:56}
+c_mac[2]=${c_mac[2]:-00:1a:2b:3c:4f:56}
+c_mac[3]=${c_mac[3]:-00:1a:2b:3c:4f:56}
 
 # compute node BMC addresses
-c_bmc[0]=10.16.1.1
-c_bmc[1]=10.16.1.2
-c_bmc[2]=10.16.1.3
-c_bmc[3]=10.16.1.4
+c_bmc[0]=${c_bmc[0]:-10.16.1.1}
+c_bmc[1]=${c_bmc[1]:-10.16.1.2}
+c_bmc[2]=${c_bmc[2]:-10.16.1.3}
+c_bmc[3]=${c_bmc[3]:-10.16.1.4}
+
+# Slurm node config
+slurm_node_config="${slurm_node_config:-${compute_prefix}[1-${num_computes}] Sockets=2 CoresPerSocket=12 ThreadsPerCore=2}"
 
 #-------------------
 # Optional settings
@@ -132,7 +134,7 @@ ipoib_netmask="${ipoib_netmask:-255.255.0.0}"
 sms_ipoib="${sms_ipoib:-192.168.0.1}"
 
 # IPoIB addresses for computes
-c_ipoib[0]=192.168.1.1		            
-c_ipoib[1]=192.168.1.2
-c_ipoib[2]=192.168.1.3
-c_ipoib[3]=192.168.1.4
+c_ipoib[0]=${c_ipoib[0]:-192.168.1.1}
+c_ipoib[1]=${c_ipoib[1]:-192.168.1.2}
+c_ipoib[2]=${c_ipoib[2]:-192.168.1.3}
+c_ipoib[3]=${c_ipoib[3]:-192.168.1.4}

--- a/docs/recipes/install/almalinux9/input.local.template
+++ b/docs/recipes/install/almalinux9/input.local.template
@@ -98,9 +98,9 @@ c_ip[3]=${c_ip[3]:-172.16.1.4}
 
 # compute node MAC addreses for provisioning interface
 c_mac[0]=${c_mac[0]:-00:1a:2b:3c:4f:56}
-c_mac[1]=${c_mac[1]:-00:1a:2b:3c:4f:56}
-c_mac[2]=${c_mac[2]:-00:1a:2b:3c:4f:56}
-c_mac[3]=${c_mac[3]:-00:1a:2b:3c:4f:56}
+c_mac[1]=${c_mac[1]:-00:1a:2b:3c:4f:57}
+c_mac[2]=${c_mac[2]:-00:1a:2b:3c:4f:58}
+c_mac[3]=${c_mac[3]:-00:1a:2b:3c:4f:59}
 
 # compute node BMC addresses
 c_bmc[0]=${c_bmc[0]:-10.16.1.1}

--- a/docs/recipes/install/centos8/input.local.template
+++ b/docs/recipes/install/centos8/input.local.template
@@ -72,7 +72,6 @@ enable_arm1_packages="${enable_arm1_packages:-0}"
 
 nagios_web_password="${nagios_web_password:-unknown}"
 update_slurm_nodeconfig="${update_slurm_nodeconfig:-0}"
-slurm_node_config="${slurm_node_config:-c[1-4] Sockets=2 CoresPerSocket=12 ThreadsPerCore=2}"
 
 # -------------------------
 # compute node settings
@@ -86,28 +85,31 @@ compute_regex="${compute_regex:-c*}"
 compute_prefix="${compute_prefix:-c}"
 
 # compute hostnames
-c_name[0]=c1
-c_name[1]=c2
-c_name[2]=c3
-c_name[3]=c4
+c_name[0]=${c_name[0]:-c1}
+c_name[1]=${c_name[1]:-c2}
+c_name[2]=${c_name[2]:-c3}
+c_name[3]=${c_name[3]:-c4}
 
 # compute node IP addresses
-c_ip[0]=172.16.1.1
-c_ip[1]=172.16.1.2
-c_ip[2]=172.16.1.3
-c_ip[3]=172.16.1.4
+c_ip[0]=${c_ip[0]:-172.16.1.1}
+c_ip[1]=${c_ip[1]:-172.16.1.2}
+c_ip[2]=${c_ip[2]:-172.16.1.3}
+c_ip[3]=${c_ip[3]:-172.16.1.4}
 
 # compute node MAC addreses for provisioning interface
-c_mac[0]=00:1a:2b:3c:4f:56
-c_mac[1]=00:1a:2b:3c:4f:56
-c_mac[2]=00:1a:2b:3c:4f:56
-c_mac[3]=00:1a:2b:3c:4f:56
+c_mac[0]=${c_mac[0]:-00:1a:2b:3c:4f:56}
+c_mac[1]=${c_mac[1]:-00:1a:2b:3c:4f:56}
+c_mac[2]=${c_mac[2]:-00:1a:2b:3c:4f:56}
+c_mac[3]=${c_mac[3]:-00:1a:2b:3c:4f:56}
 
 # compute node BMC addresses
-c_bmc[0]=10.16.1.1
-c_bmc[1]=10.16.1.2
-c_bmc[2]=10.16.1.3
-c_bmc[3]=10.16.1.4
+c_bmc[0]=${c_bmc[0]:-10.16.1.1}
+c_bmc[1]=${c_bmc[1]:-10.16.1.2}
+c_bmc[2]=${c_bmc[2]:-10.16.1.3}
+c_bmc[3]=${c_bmc[3]:-10.16.1.4}
+
+# Slurm node config
+slurm_node_config="${slurm_node_config:-${compute_prefix}[1-${num_computes}] Sockets=2 CoresPerSocket=12 ThreadsPerCore=2}"
 
 #-------------------
 # Optional settings
@@ -132,7 +134,7 @@ ipoib_netmask="${ipoib_netmask:-255.255.0.0}"
 sms_ipoib="${sms_ipoib:-192.168.0.1}"
 
 # IPoIB addresses for computes
-c_ipoib[0]=192.168.1.1		            
-c_ipoib[1]=192.168.1.2
-c_ipoib[2]=192.168.1.3
-c_ipoib[3]=192.168.1.4
+c_ipoib[0]=${c_ipoib[0]:-192.168.1.1}
+c_ipoib[1]=${c_ipoib[1]:-192.168.1.2}
+c_ipoib[2]=${c_ipoib[2]:-192.168.1.3}
+c_ipoib[3]=${c_ipoib[3]:-192.168.1.4}

--- a/docs/recipes/install/centos8/input.local.template
+++ b/docs/recipes/install/centos8/input.local.template
@@ -98,9 +98,9 @@ c_ip[3]=${c_ip[3]:-172.16.1.4}
 
 # compute node MAC addreses for provisioning interface
 c_mac[0]=${c_mac[0]:-00:1a:2b:3c:4f:56}
-c_mac[1]=${c_mac[1]:-00:1a:2b:3c:4f:56}
-c_mac[2]=${c_mac[2]:-00:1a:2b:3c:4f:56}
-c_mac[3]=${c_mac[3]:-00:1a:2b:3c:4f:56}
+c_mac[1]=${c_mac[1]:-00:1a:2b:3c:4f:57}
+c_mac[2]=${c_mac[2]:-00:1a:2b:3c:4f:58}
+c_mac[3]=${c_mac[3]:-00:1a:2b:3c:4f:59}
 
 # compute node BMC addresses
 c_bmc[0]=${c_bmc[0]:-10.16.1.1}

--- a/docs/recipes/install/common/install_slurm.tex
+++ b/docs/recipes/install/common/install_slurm.tex
@@ -51,7 +51,7 @@ for more detailed information on setting up a database configuration for \SLURM{
 % ohpc_command if [[ ${update_slurm_nodeconfig} -eq 1 ]];then
 % ohpc_indent 5
 % ohpc_command perl -pi -e "s/^NodeName=.+$/#/" /etc/slurm/slurm.conf
-% ohpc_command perl -pi -e "s/ Nodes=c\S+ / Nodes=c[1-$num_computes] /" /etc/slurm/slurm.conf
+% ohpc_command perl -pi -e "s/ Nodes=c\S+ / Nodes=${compute_prefix}[1-${num_computes}] /" /etc/slurm/slurm.conf
 % ohpc_command echo -e ${slurm_node_config} >> /etc/slurm/slurm.conf
 % ohpc_indent 0
 % ohpc_command fi

--- a/docs/recipes/install/common/openpbs_test_job.tex
+++ b/docs/recipes/install/common/openpbs_test_job.tex
@@ -35,7 +35,7 @@ propagate. However, you can also manually pull the changes from compute nodes
 via the following:
 % begin_ohpc_run
 \begin{lstlisting}[language=bash,keywords={}]
-[sms](*\#*) pdsh -w $compute_prefix[1-${num_computes}] /warewulf/bin/wwgetfiles
+[sms](*\#*) pdsh -w ${compute_prefix}[1-${num_computes}] /warewulf/bin/wwgetfiles
 \end{lstlisting}
 % end_ohpc_run
 \end{tcolorbox}

--- a/docs/recipes/install/common/reset_computes.tex
+++ b/docs/recipes/install/common/reset_computes.tex
@@ -25,7 +25,7 @@ on the newly imaged compute hosts using \texttt{pdsh}, execute the following:
 %\iftoggle{isCentOS}{\clearpage}
   
 \begin{lstlisting}[language=bash]
-[sms](*\#*) pdsh -w c[1-4] uptime
+[sms](*\#*) pdsh -w ${compute_prefix}[1-${num_computes}] uptime
 c1  05:03am  up   0:02,  0 users,  load average: 0.20, 0.13, 0.05
 c2  05:03am  up   0:02,  0 users,  load average: 0.20, 0.14, 0.06
 c3  05:03am  up   0:02,  0 users,  load average: 0.19, 0.15, 0.06

--- a/docs/recipes/install/common/reset_computes_xcat.tex
+++ b/docs/recipes/install/common/reset_computes_xcat.tex
@@ -42,4 +42,4 @@ c2:  12:56:50 up 13 min,  0 users,  load average: 0.00, 0.02, 0.05
 c3:  12:56:50 up 14 min,  0 users,  load average: 0.00, 0.02, 0.05
 c4:  12:56:50 up 14 min,  0 users,  load average: 0.00, 0.01, 0.04
 \end{lstlisting}
-Note that the equivalent \texttt{pdsh} command is \texttt{pdsh -w c[1-4] uptime}. 
+Note that the equivalent \texttt{pdsh} command is \texttt{pdsh -w ${compute_prefix}[1-${num_computes}] uptime}. 

--- a/docs/recipes/install/common/sensys.tex
+++ b/docs/recipes/install/common/sensys.tex
@@ -54,7 +54,7 @@ below:
         -omca db_postgres_user ohpc-test \
         -omca db_postgres_database sensys &
 # Launch Sensys on compute nodes
-[sms](*\#*) pdsh -w $compute_prefix[1-4] /opt/ohpc/admin/sensys/bin/orcmd -omca sensor heartbeat,coretemp \
+[sms](*\#*) pdsh -w ${compute_prefix}[1-${num_computes}] /opt/ohpc/admin/sensys/bin/orcmd -omca sensor heartbeat,coretemp \
         -omca sensor_base_sample_rate 30 &
 \end{lstlisting}
 % end_ohpc_run

--- a/docs/recipes/install/common/slurm_startup.tex
+++ b/docs/recipes/install/common/slurm_startup.tex
@@ -36,8 +36,8 @@ resource management under \SLURM{}.
 [sms](*\#*) systemctl start slurmctld
 
 # Start slurm clients on compute hosts
-[sms](*\#*) pdsh -w $compute_prefix[1-${num_computes}] systemctl start munge
-[sms](*\#*) pdsh -w $compute_prefix[1-${num_computes}] systemctl start slurmd
+[sms](*\#*) pdsh -w ${compute_prefix}[1-${num_computes}] systemctl start munge
+[sms](*\#*) pdsh -w ${compute_prefix}[1-${num_computes}] systemctl start slurmd
 \end{lstlisting}
 % end_ohpc_run
 

--- a/docs/recipes/install/common/slurm_test_job.tex
+++ b/docs/recipes/install/common/slurm_test_job.tex
@@ -35,7 +35,7 @@ propagate. However, you can also manually pull the changes from compute nodes
 via the following:
 % begin_ohpc_run
 \begin{lstlisting}[language=bash,keywords={}]
-[sms](*\#*) pdsh -w $compute_prefix[1-${num_computes}] /warewulf/bin/wwgetfiles
+[sms](*\#*) pdsh -w ${compute_prefix}[1-${num_computes}] /warewulf/bin/wwgetfiles
 \end{lstlisting}
 % end_ohpc_run
 \end{tcolorbox}

--- a/docs/recipes/install/leap15/input.local.template
+++ b/docs/recipes/install/leap15/input.local.template
@@ -88,9 +88,9 @@ c_ip[3]=${c_ip[3]:-172.16.1.4}
 
 # compute node MAC addreses for provisioning interface
 c_mac[0]=${c_mac[0]:-00:1a:2b:3c:4f:56}
-c_mac[1]=${c_mac[1]:-00:1a:2b:3c:4f:56}
-c_mac[2]=${c_mac[2]:-00:1a:2b:3c:4f:56}
-c_mac[3]=${c_mac[3]:-00:1a:2b:3c:4f:56}
+c_mac[1]=${c_mac[1]:-00:1a:2b:3c:4f:57}
+c_mac[2]=${c_mac[2]:-00:1a:2b:3c:4f:58}
+c_mac[3]=${c_mac[3]:-00:1a:2b:3c:4f:59}
 
 # compute node BMC addresses
 c_bmc[0]=${c_bmc[0]:-10.16.1.1}

--- a/docs/recipes/install/leap15/input.local.template
+++ b/docs/recipes/install/leap15/input.local.template
@@ -62,7 +62,6 @@ enable_arm1_packages="${enable_arm1_packages:-0}"
 
 nagios_web_password="${nagios_web_password:-unknown}"
 update_slurm_nodeconfig="${update_slurm_nodeconfig:-0}"
-slurm_node_config="${slurm_node_config:-c[1-4] Sockets=2 CoresPerSocket=12 ThreadsPerCore=2}"
 
 # -------------------------
 # compute node settings
@@ -76,28 +75,31 @@ compute_regex="${compute_regex:-c*}"
 compute_prefix="${compute_prefix:-c}"
 
 # compute hostnames
-c_name[0]=c1
-c_name[1]=c2
-c_name[2]=c3
-c_name[3]=c4
+c_name[0]=${c_name[0]:-c1}
+c_name[1]=${c_name[1]:-c2}
+c_name[2]=${c_name[2]:-c3}
+c_name[3]=${c_name[3]:-c4}
 
 # compute node IP addresses
-c_ip[0]=172.16.1.1
-c_ip[1]=172.16.1.2
-c_ip[2]=172.16.1.3
-c_ip[3]=172.16.1.4
+c_ip[0]=${c_ip[0]:-172.16.1.1}
+c_ip[1]=${c_ip[1]:-172.16.1.2}
+c_ip[2]=${c_ip[2]:-172.16.1.3}
+c_ip[3]=${c_ip[3]:-172.16.1.4}
 
 # compute node MAC addreses for provisioning interface
-c_mac[0]=00:1a:2b:3c:4f:56
-c_mac[1]=00:1a:2b:3c:4f:56
-c_mac[2]=00:1a:2b:3c:4f:56
-c_mac[3]=00:1a:2b:3c:4f:56
+c_mac[0]=${c_mac[0]:-00:1a:2b:3c:4f:56}
+c_mac[1]=${c_mac[1]:-00:1a:2b:3c:4f:56}
+c_mac[2]=${c_mac[2]:-00:1a:2b:3c:4f:56}
+c_mac[3]=${c_mac[3]:-00:1a:2b:3c:4f:56}
 
 # compute node BMC addresses
-c_bmc[0]=10.16.1.1
-c_bmc[1]=10.16.1.2
-c_bmc[2]=10.16.1.3
-c_bmc[3]=10.16.1.4
+c_bmc[0]=${c_bmc[0]:-10.16.1.1}
+c_bmc[1]=${c_bmc[1]:-10.16.1.2}
+c_bmc[2]=${c_bmc[2]:-10.16.1.3}
+c_bmc[3]=${c_bmc[3]:-10.16.1.4}
+
+# Slurm node config
+slurm_node_config="${slurm_node_config:-${compute_prefix}[1-${num_computes}] Sockets=2 CoresPerSocket=12 ThreadsPerCore=2}"
 
 #-------------------
 # Optional settings
@@ -122,7 +124,7 @@ ipoib_netmask="${ipoib_netmask:-255.255.0.0}"
 sms_ipoib="${sms_ipoib:-192.168.0.1}"
 
 # IPoIB addresses for computes
-c_ipoib[0]=192.168.1.1		            
-c_ipoib[1]=192.168.1.2
-c_ipoib[2]=192.168.1.3
-c_ipoib[3]=192.168.1.4
+c_ipoib[0]=${c_ipoib[0]:-192.168.1.1}
+c_ipoib[1]=${c_ipoib[1]:-192.168.1.2}
+c_ipoib[2]=${c_ipoib[2]:-192.168.1.3}
+c_ipoib[3]=${c_ipoib[3]:-192.168.1.4}

--- a/docs/recipes/install/openeuler22.03/input.local.template
+++ b/docs/recipes/install/openeuler22.03/input.local.template
@@ -73,7 +73,6 @@ enable_arm1_packages="${enable_arm1_packages:-0}"
 
 nagios_web_password="${nagios_web_password:-unknown}"
 update_slurm_nodeconfig="${update_slurm_nodeconfig:-0}"
-slurm_node_config="${slurm_node_config:-c[1-4] Sockets=2 CoresPerSocket=12 ThreadsPerCore=2}"
 
 # -------------------------
 # compute node settings
@@ -87,28 +86,31 @@ compute_regex="${compute_regex:-c*}"
 compute_prefix="${compute_prefix:-c}"
 
 # compute hostnames
-c_name[0]=c1
-c_name[1]=c2
-c_name[2]=c3
-c_name[3]=c4
+c_name[0]=${c_name[0]:-c1}
+c_name[1]=${c_name[1]:-c2}
+c_name[2]=${c_name[2]:-c3}
+c_name[3]=${c_name[3]:-c4}
 
 # compute node IP addresses
-c_ip[0]=172.16.1.1
-c_ip[1]=172.16.1.2
-c_ip[2]=172.16.1.3
-c_ip[3]=172.16.1.4
+c_ip[0]=${c_ip[0]:-172.16.1.1}
+c_ip[1]=${c_ip[1]:-172.16.1.2}
+c_ip[2]=${c_ip[2]:-172.16.1.3}
+c_ip[3]=${c_ip[3]:-172.16.1.4}
 
 # compute node MAC addreses for provisioning interface
-c_mac[0]=00:1a:2b:3c:4f:56
-c_mac[1]=00:1a:2b:3c:4f:56
-c_mac[2]=00:1a:2b:3c:4f:56
-c_mac[3]=00:1a:2b:3c:4f:56
+c_mac[0]=${c_mac[0]:-00:1a:2b:3c:4f:56}
+c_mac[1]=${c_mac[1]:-00:1a:2b:3c:4f:56}
+c_mac[2]=${c_mac[2]:-00:1a:2b:3c:4f:56}
+c_mac[3]=${c_mac[3]:-00:1a:2b:3c:4f:56}
 
 # compute node BMC addresses
-c_bmc[0]=10.16.1.1
-c_bmc[1]=10.16.1.2
-c_bmc[2]=10.16.1.3
-c_bmc[3]=10.16.1.4
+c_bmc[0]=${c_bmc[0]:-10.16.1.1}
+c_bmc[1]=${c_bmc[1]:-10.16.1.2}
+c_bmc[2]=${c_bmc[2]:-10.16.1.3}
+c_bmc[3]=${c_bmc[3]:-10.16.1.4}
+
+# Slurm node config
+slurm_node_config="${slurm_node_config:-${compute_prefix}[1-${num_computes}] Sockets=2 CoresPerSocket=12 ThreadsPerCore=2}"
 
 #-------------------
 # Optional settings
@@ -133,7 +135,7 @@ ipoib_netmask="${ipoib_netmask:-255.255.0.0}"
 sms_ipoib="${sms_ipoib:-192.168.0.1}"
 
 # IPoIB addresses for computes
-c_ipoib[0]=192.168.1.1		            
-c_ipoib[1]=192.168.1.2
-c_ipoib[2]=192.168.1.3
-c_ipoib[3]=192.168.1.4
+c_ipoib[0]=${c_ipoib[0]:-192.168.1.1}
+c_ipoib[1]=${c_ipoib[1]:-192.168.1.2}
+c_ipoib[2]=${c_ipoib[2]:-192.168.1.3}
+c_ipoib[3]=${c_ipoib[3]:-192.168.1.4}

--- a/docs/recipes/install/openeuler22.03/input.local.template
+++ b/docs/recipes/install/openeuler22.03/input.local.template
@@ -99,9 +99,9 @@ c_ip[3]=${c_ip[3]:-172.16.1.4}
 
 # compute node MAC addreses for provisioning interface
 c_mac[0]=${c_mac[0]:-00:1a:2b:3c:4f:56}
-c_mac[1]=${c_mac[1]:-00:1a:2b:3c:4f:56}
-c_mac[2]=${c_mac[2]:-00:1a:2b:3c:4f:56}
-c_mac[3]=${c_mac[3]:-00:1a:2b:3c:4f:56}
+c_mac[1]=${c_mac[1]:-00:1a:2b:3c:4f:57}
+c_mac[2]=${c_mac[2]:-00:1a:2b:3c:4f:58}
+c_mac[3]=${c_mac[3]:-00:1a:2b:3c:4f:59}
 
 # compute node BMC addresses
 c_bmc[0]=${c_bmc[0]:-10.16.1.1}

--- a/docs/recipes/install/rocky9/input.local.template
+++ b/docs/recipes/install/rocky9/input.local.template
@@ -72,7 +72,6 @@ enable_arm1_packages="${enable_arm1_packages:-0}"
 
 nagios_web_password="${nagios_web_password:-unknown}"
 update_slurm_nodeconfig="${update_slurm_nodeconfig:-0}"
-slurm_node_config="${slurm_node_config:-c[1-4] Sockets=2 CoresPerSocket=12 ThreadsPerCore=2}"
 
 # -------------------------
 # compute node settings
@@ -86,28 +85,31 @@ compute_regex="${compute_regex:-c*}"
 compute_prefix="${compute_prefix:-c}"
 
 # compute hostnames
-c_name[0]=c1
-c_name[1]=c2
-c_name[2]=c3
-c_name[3]=c4
+c_name[0]=${c_name[0]:-c1}
+c_name[1]=${c_name[1]:-c2}
+c_name[2]=${c_name[2]:-c3}
+c_name[3]=${c_name[3]:-c4}
 
 # compute node IP addresses
-c_ip[0]=172.16.1.1
-c_ip[1]=172.16.1.2
-c_ip[2]=172.16.1.3
-c_ip[3]=172.16.1.4
+c_ip[0]=${c_ip[0]:-172.16.1.1}
+c_ip[1]=${c_ip[1]:-172.16.1.2}
+c_ip[2]=${c_ip[2]:-172.16.1.3}
+c_ip[3]=${c_ip[3]:-172.16.1.4}
 
 # compute node MAC addreses for provisioning interface
-c_mac[0]=00:1a:2b:3c:4f:56
-c_mac[1]=00:1a:2b:3c:4f:56
-c_mac[2]=00:1a:2b:3c:4f:56
-c_mac[3]=00:1a:2b:3c:4f:56
+c_mac[0]=${c_mac[0]:-00:1a:2b:3c:4f:56}
+c_mac[1]=${c_mac[1]:-00:1a:2b:3c:4f:56}
+c_mac[2]=${c_mac[2]:-00:1a:2b:3c:4f:56}
+c_mac[3]=${c_mac[3]:-00:1a:2b:3c:4f:56}
 
 # compute node BMC addresses
-c_bmc[0]=10.16.1.1
-c_bmc[1]=10.16.1.2
-c_bmc[2]=10.16.1.3
-c_bmc[3]=10.16.1.4
+c_bmc[0]=${c_bmc[0]:-10.16.1.1}
+c_bmc[1]=${c_bmc[1]:-10.16.1.2}
+c_bmc[2]=${c_bmc[2]:-10.16.1.3}
+c_bmc[3]=${c_bmc[3]:-10.16.1.4}
+
+# Slurm node config
+slurm_node_config="${slurm_node_config:-${compute_prefix}[1-${num_computes}] Sockets=2 CoresPerSocket=12 ThreadsPerCore=2}"
 
 #-------------------
 # Optional settings
@@ -132,7 +134,7 @@ ipoib_netmask="${ipoib_netmask:-255.255.0.0}"
 sms_ipoib="${sms_ipoib:-192.168.0.1}"
 
 # IPoIB addresses for computes
-c_ipoib[0]=192.168.1.1		            
-c_ipoib[1]=192.168.1.2
-c_ipoib[2]=192.168.1.3
-c_ipoib[3]=192.168.1.4
+c_ipoib[0]=${c_ipoib[0]:-192.168.1.1}
+c_ipoib[1]=${c_ipoib[1]:-192.168.1.2}
+c_ipoib[2]=${c_ipoib[2]:-192.168.1.3}
+c_ipoib[3]=${c_ipoib[3]:-192.168.1.4}

--- a/docs/recipes/install/rocky9/input.local.template
+++ b/docs/recipes/install/rocky9/input.local.template
@@ -98,9 +98,9 @@ c_ip[3]=${c_ip[3]:-172.16.1.4}
 
 # compute node MAC addreses for provisioning interface
 c_mac[0]=${c_mac[0]:-00:1a:2b:3c:4f:56}
-c_mac[1]=${c_mac[1]:-00:1a:2b:3c:4f:56}
-c_mac[2]=${c_mac[2]:-00:1a:2b:3c:4f:56}
-c_mac[3]=${c_mac[3]:-00:1a:2b:3c:4f:56}
+c_mac[1]=${c_mac[1]:-00:1a:2b:3c:4f:57}
+c_mac[2]=${c_mac[2]:-00:1a:2b:3c:4f:58}
+c_mac[3]=${c_mac[3]:-00:1a:2b:3c:4f:59}
 
 # compute node BMC addresses
 c_bmc[0]=${c_bmc[0]:-10.16.1.1}


### PR DESCRIPTION
Things corrected:

- `slurm_node_config` in input.local was broken by default, since it referred to variables that hadn't necessarily been set
- some compute node attributes in input.local would accept existing environment variables, others wouldn't. Now they all do.
-  by default, there were duplicate MAC addresses for compute nodes in input.local -- granted, sites should change those values regardless, but there's no reason to throw an error by default
- more consistent use of curly braces for `compute_prefix` and `num_computes`