### PR TITLE
serial-libs/gsl: add pkgconfig env

### DIFF
--- a/components/serial-libs/gsl/SPECS/gsl.spec
+++ b/components/serial-libs/gsl/SPECS/gsl.spec
@@ -92,6 +92,7 @@ prepend-path    PATH                %{install_path}/bin
 prepend-path    MANPATH             %{install_path}/share/man
 prepend-path    INCLUDE             %{install_path}/include
 prepend-path    LD_LIBRARY_PATH     %{install_path}/lib
+prepend-path    PKG_CONFIG_PATH     %{install_path}/lib/pkgconfig
 
 setenv          %{PNAME}_DIR        %{install_path}
 setenv          %{PNAME}_LIB        %{install_path}/lib

--- a/tests/ci/spec_to_test_mapping.py
+++ b/tests/ci/spec_to_test_mapping.py
@@ -233,6 +233,11 @@ test_map = {
         '',
         ''
     ],
+    'components/serial-libs/gsl/SPECS/gsl.spec': [
+        'gsl',
+        '',
+        ''
+    ],
 }
 
 skip_ci_specs = []


### PR DESCRIPTION
```
[root@sirius ~]# module load gsl
[root@sirius ~]# pkg-config --libs gsl
Package gsl was not found in the pkg-config search path.
Perhaps you should add the directory containing `gsl.pc'
to the PKG_CONFIG_PATH environment variable
Package 'gsl', required by 'virtual:world', not found
```

So I wanna prepend env PKG_CONFIG_PATH for compatibility.