### PR TITLE
Use GCC 12 to build GNU-13 compilers on openEuler

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,7 +30,7 @@ openeuler_task:
   name: openEuler on aarch64
   timeout_in: 120m
   arm_container:
-    image: docker.io/openeuler/openeuler:22.03-lts
+    image: docker.io/openeuler/openeuler:22.03-lts-sp3
     cpu: 4
     memory: 12G
   script: uname -a

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -136,7 +136,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build on openEuler
     container:
-      image: docker.io/openeuler/openeuler:22.03-lts
+      image: docker.io/openeuler/openeuler:22.03-lts-sp3
     steps:
     - name: Switch repo
       run: sed -i "s@repo.openeuler.org@repo.huaweicloud.com/openeuler@g" /etc/yum.repos.d/openEuler.repo
@@ -169,7 +169,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Test on openEuler
     container:
-      image: docker.io/openeuler/openeuler:22.03-lts
+      image: docker.io/openeuler/openeuler:22.03-lts-sp3
     needs: build_on_openEuler
     steps:
     - name: Switch repo

--- a/components/compiler-families/gnu-compilers/SPECS/gnu-compilers.spec
+++ b/components/compiler-families/gnu-compilers/SPECS/gnu-compilers.spec
@@ -50,7 +50,12 @@ Group:     %{PROJ_NAME}/compiler-families
 URL:       http://gcc.gnu.org/
 
 # Requirements from https://gcc.gnu.org/install/prerequisites.htmlzypper
+%if 0%{?openEuler}
+BuildRequires:  gcc-toolset-12-gcc-c++
+BuildRequires:  gcc-toolset-12-libstdc++-devel
+%else
 BuildRequires:  gcc-c++
+%endif
 BuildRequires:  binutils >= 2.30
 BuildRequires:  make >= 3.80
 BuildRequires:  gettext-devel >= 0.14.5
@@ -91,6 +96,12 @@ ln -s mpfr-%{gnu13_mpfr_version} mpfr
 %endif
 
 %build
+
+%if 0%{?openEuler}
+export PATH=/opt/openEuler/gcc-toolset-12/root/usr/bin:$PATH
+export LD_LIBRARY_PATH=/opt/openEuler/gcc-toolset-12/root/usr/lib64:$LD_LIBRARY_PATH
+%endif
+
 mkdir obj
 cd obj
 ../configure --disable-multilib \


### PR DESCRIPTION
By default openEuler 22.03 LTS (SP0-SP3) come with gcc/g++ 10.3.1 but it has some problems building gnu-compilers 13.2.0

```
[  379s] /home/abuild/rpmbuild/BUILD/gcc-13.2.0/obj/./gcc/xgcc -B/home/abuild/rpmbuild/BUILD/gcc-13.2.0/obj/./gcc/ -B/opt/ohpc/pub/compiler/gcc/13.2.0/x86_64-pc-linux-gnu/bin/ -B/opt/ohpc/pub/compiler/gcc/13.2.0/x86_64-pc-linux-gnu/lib/ -isystem /opt/ohpc/pub/compiler/gcc/13.2.0/x86_64-pc-linux-gnu/include -isystem /opt/ohpc/pub/compiler/gcc/13.2.0/x86_64-pc-linux-gnu/sys-include   -fno-checking -g -O2 -O2  -g -O2 -DIN_GCC    -W -Wall -Wno-narrowing -Wwrite-strings -Wcast-qual -Wno-format -Wstrict-prototypes -Wmissing-prototypes -Wold-style-definition  -isystem ./include  -fpic -mlong-double-80 -DUSE_ELF_SYMVER -fcf-protection -mshstk -g -DIN_LIBGCC2 -fbuilding-libgcc -fno-stack-protector  -fpic -mlong-double-80 -DUSE_ELF_SYMVER -fcf-protection -mshstk -I. -I. -I../.././gcc -I../../../libgcc -I../../../libgcc/. -I../../../libgcc/../gcc -I../../../libgcc/../include -I../../../libgcc/config/libbid -DENABLE_DECIMAL_BID_FORMAT -DHAVE_CC_TLS  -DUSE_TLS  -o _gcov_merge_time_profile.o -MT _gcov_merge_time_profile.o -MD -MP -MF _gcov_merge_time_profile.dep -DL_gcov_merge_time_profile -c ../../../libgcc/libgcov-merge.c
[  379s] In file included from /usr/include/time.h:39,
[  379s]                  from ../../../libgcc/../gcc/tsystem.h:108,
[  379s]                  from ../../../libgcc/generic-morestack-thread.c:27:
[  379s] /usr/include/bits/types/struct_tm.h:1: error: unterminated #ifndef
[  379s]     1 | #ifndef __struct_tm_defined
[  379s]       |
[  379s] /usr/include/bits/types/struct_tm.h:27:5: error: expected ';' before 'struct'
[  379s]    27 |
[  379s]       |     ^
[  379s]       |     ;
[  379s] In file included from /usr/include/time.h:39,
[  379s]                  from ../../../libgcc/../gcc/tsystem.h:108,
[  379s]                  from ../../../libgcc/libgcov.h:42,
[  379s]                  from ../../../libgcc/libgcov-merge.c:26:
[  379s] /usr/include/bits/types/struct_tm.h:31:1: error: expected '=', ',', ';', 'asm' or '__attribute__' before 'if'
[  379s] /usr/include/bits/types/struct_tm.h:1: error: unterminated #ifndef
[  379s]     1 | #ifndef __struct_tm_defined
[  379s]       |
[  379s] In file included from /usr/include/time.h:39,
[  379s]                  from ../../../libgcc/../gcc/tsystem.h:108,
[  379s]                  from ../../../libgcc/libgcov.h:42,
[  379s]                  from ../../../libgcc/libgcov-merge.c:26:
[  379s] /usr/include/bits/types/struct_tm.h:28:2: error: invalid preprocessing directive #e
[  379s]    28 | #endif
[  379s]       |  ^
[  379s] /usr/include/bits/types/struct_tm.h:1: error: unterminated #ifndef
[  379s]     1 | #ifndef __struct_tm_defined
[  379s]       |
[  379s] /usr/include/bits/types/struct_tm.h:29:3: error: expected ';' before 'struct'
[  379s] In file included from /usr/include/time.h:39,
[  379s]                  from ../../../libgcc/../gcc/tsystem.h:108,
[  379s]                  from ../../../libgcc/generic-morestack.c:32:
[  379s] /usr/include/bits/types/struct_tm.h:28:2: error: invalid preprocessing directive #e
[  379s]    28 | #endif
[  379s]       |  ^
[  379s] /usr/include/bits/types/struct_tm.h:1: error: unterminated #ifndef
[  379s]     1 | #ifndef __struct_tm_defined
[  379s]       |
[  379s] make[3]: *** [../../../libgcc/shared-object.mk:14: generic-morestack-thread.o] Error 1
[  379s] make[3]: *** Waiting for unfinished jobs....
[  379s] make[3]: *** [Makefile:924: _gcov_merge_add.o] Error 1
[  379s] make[3]: *** [Makefile:924: _gcov_merge_ior.o] Error 1
[  379s] make[3]: *** [../../../libgcc/shared-object.mk:14: generic-morestack.o] Error 1
[  379s] make[3]: Leaving directory '/home/abuild/rpmbuild/BUILD/gcc-13.2.0/obj/x86_64-pc-linux-gnu/libgcc'
[  379s] make[2]: *** [Makefile:23765: all-stage1-target-libgcc] Error 2
[  379s] make[2]: Leaving directory '/home/abuild/rpmbuild/BUILD/gcc-13.2.0/obj'
[  379s] make[1]: *** [Makefile:29278: stage1-bubble] Error 2
[  379s] make[1]: Leaving directory '/home/abuild/rpmbuild/BUILD/gcc-13.2.0/obj'
[  379s] make: *** [Makefile:1086: all] Error 2
[  379s] error: Bad exit status from /var/tmp/rpm-tmp.ulXejz (%build)
```