### PR TITLE
Enable slurmd for Rocky/Warewulf/Slurm/3.x

### DIFF
--- a/docs/recipes/install/almalinux9/aarch64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/almalinux9/aarch64/warewulf/slurm/steps.tex
@@ -132,9 +132,10 @@
 # provisioning system.
 [sms](*\#*) cp /etc/passwd /etc/group  $CHROOT/etc
 
-# Add Slurm client support meta-package and enable munge
+# Add Slurm client support meta-package and enable munge and slurmd
 [sms](*\#*) (*\chrootinstall*) ohpc-slurm-client
 [sms](*\#*) chroot $CHROOT systemctl enable munge
+[sms](*\#*) chroot $CHROOT systemctl enable slurmd
 
 # Register Slurm server with computes (using "configless" option)
 [sms](*\#*) echo SLURMD_OPTIONS="--conf-server ${sms_ip}" > $CHROOT/etc/sysconfig/slurmd

--- a/docs/recipes/install/almalinux9/x86_64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/almalinux9/x86_64/warewulf/slurm/steps.tex
@@ -139,9 +139,10 @@
 # install. Note that these will be synchronized with future updates via the provisioning system.
 [sms](*\#*) cp /etc/passwd /etc/group  $CHROOT/etc
 
-# Add Slurm client support meta-package and enable munge
+# Add Slurm client support meta-package and enable munge and slurmd
 [sms](*\#*) (*\chrootinstall*) ohpc-slurm-client
 [sms](*\#*) chroot $CHROOT systemctl enable munge
+[sms](*\#*) chroot $CHROOT systemctl enable slurmd
 
 # Register Slurm server with computes (using "configless" option)
 [sms](*\#*) echo SLURMD_OPTIONS="--conf-server ${sms_ip}" > $CHROOT/etc/sysconfig/slurmd

--- a/docs/recipes/install/centos8/x86_64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/centos8/x86_64/warewulf/slurm/steps.tex
@@ -139,9 +139,10 @@
 # install. Note that these will be synchronized with future updates via the provisioning system.
 [sms](*\#*) cp /etc/passwd /etc/group  $CHROOT/etc
 
-# Add Slurm client support meta-package and enable munge
+# Add Slurm client support meta-package and enable munge and slurmd
 [sms](*\#*) (*\chrootinstall*) ohpc-slurm-client
 [sms](*\#*) chroot $CHROOT systemctl enable munge
+[sms](*\#*) chroot $CHROOT systemctl enable slurmd
 
 # Register Slurm server with computes (using "configless" option)
 [sms](*\#*) echo SLURMD_OPTIONS="--conf-server ${sms_ip}" > $CHROOT/etc/sysconfig/slurmd

--- a/docs/recipes/install/leap15/aarch64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/leap15/aarch64/warewulf/slurm/steps.tex
@@ -130,9 +130,10 @@
 # Add OpenHPC base components
 [sms](*\#*) (*\chrootinstall*) ohpc-base-compute
 
-# Add SLURM client support meta-package and enable munge
+# Add SLURM client support meta-package and enable munge and slurm
 [sms](*\#*) (*\chrootinstall*) ohpc-slurm-client
 [sms](*\#*) chroot $CHROOT systemctl enable munge
+[sms](*\#*) chroot $CHROOT systemctl enable slurmd
 
 # Register Slurm server with computes (using "configless" option)
 [sms](*\#*) echo SLURMD_OPTIONS="--conf-server ${sms_ip}" > $CHROOT/etc/sysconfig/slurmd

--- a/docs/recipes/install/leap15/x86_64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/leap15/x86_64/warewulf/slurm/steps.tex
@@ -130,9 +130,10 @@
 # Add OpenHPC base components
 [sms](*\#*) (*\chrootinstall*) ohpc-base-compute
 
-# Add SLURM client support meta-package and enable munge
+# Add SLURM client support meta-package and enable munge and slurm
 [sms](*\#*) (*\chrootinstall*) ohpc-slurm-client
 [sms](*\#*) chroot $CHROOT systemctl enable munge
+[sms](*\#*) chroot $CHROOT systemctl enable slurmd
 
 # Register Slurm server with computes (using "configless" option)
 [sms](*\#*) echo SLURMD_OPTIONS="--conf-server ${sms_ip}" > $CHROOT/etc/sysconfig/slurmd

--- a/docs/recipes/install/openeuler22.03/aarch64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/openeuler22.03/aarch64/warewulf/slurm/steps.tex
@@ -132,9 +132,10 @@
 # provisioning system.
 [sms](*\#*) cp /etc/passwd /etc/group  $CHROOT/etc
 
-# Add Slurm client support meta-package and enable munge
+# Add Slurm client support meta-package and enable munge and slurmd
 [sms](*\#*) (*\chrootinstall*) ohpc-slurm-client
 [sms](*\#*) chroot $CHROOT systemctl enable munge
+[sms](*\#*) chroot $CHROOT systemctl enable slurmd
 
 # Register Slurm server with computes (using "configless" option)
 [sms](*\#*) echo SLURMD_OPTIONS="--conf-server ${sms_ip}" > $CHROOT/etc/sysconfig/slurmd

--- a/docs/recipes/install/openeuler22.03/x86_64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/openeuler22.03/x86_64/warewulf/slurm/steps.tex
@@ -139,9 +139,10 @@
 # install. Note that these will be synchronized with future updates via the provisioning system.
 [sms](*\#*) cp /etc/passwd /etc/group  $CHROOT/etc
 
-# Add Slurm client support meta-package and enable munge
+# Add Slurm client support meta-package and enable munge and slurmd
 [sms](*\#*) (*\chrootinstall*) ohpc-slurm-client
 [sms](*\#*) chroot $CHROOT systemctl enable munge
+[sms](*\#*) chroot $CHROOT systemctl enable slurmd
 
 # Register Slurm server with computes (using "configless" option)
 [sms](*\#*) echo SLURMD_OPTIONS="--conf-server ${sms_ip}" > $CHROOT/etc/sysconfig/slurmd

--- a/docs/recipes/install/rocky9/aarch64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/rocky9/aarch64/warewulf/slurm/steps.tex
@@ -132,9 +132,10 @@
 # provisioning system.
 [sms](*\#*) cp /etc/passwd /etc/group  $CHROOT/etc
 
-# Add Slurm client support meta-package and enable munge
+# Add Slurm client support meta-package and enable munge and slurmd
 [sms](*\#*) (*\chrootinstall*) ohpc-slurm-client
 [sms](*\#*) chroot $CHROOT systemctl enable munge
+[sms](*\#*) chroot $CHROOT systemctl enable slurmd
 
 # Register Slurm server with computes (using "configless" option)
 [sms](*\#*) echo SLURMD_OPTIONS="--conf-server ${sms_ip}" > $CHROOT/etc/sysconfig/slurmd

--- a/docs/recipes/install/rocky9/x86_64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/rocky9/x86_64/warewulf/slurm/steps.tex
@@ -139,9 +139,10 @@
 # install. Note that these will be synchronized with future updates via the provisioning system.
 [sms](*\#*) cp /etc/passwd /etc/group  $CHROOT/etc
 
-# Add Slurm client support meta-package and enable munge
+# Add Slurm client support meta-package and enable munge and slurmd
 [sms](*\#*) (*\chrootinstall*) ohpc-slurm-client
 [sms](*\#*) chroot $CHROOT systemctl enable munge
+[sms](*\#*) chroot $CHROOT systemctl enable slurmd
 
 # Register Slurm server with computes (using "configless" option)
 [sms](*\#*) echo SLURMD_OPTIONS="--conf-server ${sms_ip}" > $CHROOT/etc/sysconfig/slurmd


### PR DESCRIPTION
Patch applied against all arch/OS combo's as requested.  Tested that it was still needed on Rocky9/WW4/slurm/x86_64 and aarch64  Issue #1821
