### PR TITLE
warewulf-ipmi: require perl(sys/ioctl.ph) on RHEL

### DIFF
--- a/components/provisioning/warewulf-ipmi/SPECS/warewulf-ipmi.spec
+++ b/components/provisioning/warewulf-ipmi/SPECS/warewulf-ipmi.spec
@@ -39,6 +39,7 @@ Requires: ipmitool
 BuildRequires: which
 %if 0%{?rhel} >= 8
 BuildRequires: perl-generators
+Requires: perl(sys/ioctl.ph)
 %endif
 %define CONF_FLAGS "--with-local-ipmitool=yes"
 %else


### PR DESCRIPTION
Without perl(sys/ioctl.ph) this package is broken.

Fixes: #1943