### PR TITLE
intel-compilers: handle new Intel module files

### DIFF
--- a/components/compiler-families/intel-compilers-devel/SPECS/intel-compilers-devel.spec
+++ b/components/compiler-families/intel-compilers-devel/SPECS/intel-compilers-devel.spec
@@ -157,6 +157,9 @@ if { ![info exists ::env(ACL_SKIP_BSP_CONF)] } {
     setenv          ACL_SKIP_BSP_CONF   1
 }
 
+module load "oclfpga"
+module load "tbb"
+module load "compiler-rt"
 module load "compiler/\$version"
 module load "$mklver"
 


### PR DESCRIPTION
The Intel module files are not working with Lmod correctly.

Preloading certain dependencies helps to work around this problem:

  module load "oclfpga"
  module load "tbb"
  module load "compiler-rt"

Tries to fix #1912 (again)