### PR TITLE
Regenerate modulefiles on update (fixes #1601)

### DIFF
--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -20,6 +20,7 @@
 %global OHPC_ADMIN      %{OHPC_HOME}/admin
 %global OHPC_PUB        %{OHPC_HOME}/pub
 %global OHPC_APPS       %{OHPC_PUB}/apps
+%global OHPC_BIN        %{OHPC_PUB}/bin
 %global OHPC_COMPILERS  %{OHPC_PUB}/compiler
 %global OHPC_LIBS       %{OHPC_PUB}/libs
 %global OHPC_MODULES    %{OHPC_PUB}/modulefiles

--- a/components/admin/ohpc-filesystem/SPECS/ohpc-filesystem.spec
+++ b/components/admin/ohpc-filesystem/SPECS/ohpc-filesystem.spec
@@ -16,7 +16,7 @@
 
 Name: ohpc-filesystem
 Version: %{version}
-Release: %{?dist}.1
+Release: %{?dist}.3
 Summary: Common top-level OpenHPC directories
 
 Group:   ohpc/admin
@@ -48,7 +48,7 @@ builds.
 
 %install
 # The ohpc-filesystems owns all the common directories
-mkdir -p $RPM_BUILD_ROOT/opt/ohpc/pub/{apps,doc,compiler,libs,moduledeps,modulefiles,mpi}
+mkdir -p $RPM_BUILD_ROOT/opt/ohpc/pub/{apps,bin,doc,compiler,libs,moduledeps,modulefiles,mpi}
 mkdir -p $RPM_BUILD_ROOT/opt/ohpc/admin/ohpc
 mkdir -p $RPM_BUILD_ROOT/usr/lib/rpm/fileattrs
 
@@ -83,6 +83,7 @@ EOF
 %dir /opt/ohpc/admin/
 %dir /opt/ohpc/pub/
 %dir /opt/ohpc/pub/apps/
+%dir /opt/ohpc/pub/bin/
 %dir /opt/ohpc/pub/doc/
 %dir /opt/ohpc/pub/compiler/
 %dir /opt/ohpc/pub/libs/

--- a/components/compiler-families/intel-compilers-devel/SOURCES/ohpc-update-modules-intel
+++ b/components/compiler-families/intel-compilers-devel/SOURCES/ohpc-update-modules-intel
@@ -1,0 +1,136 @@
+#!/bin/bash
+# Do not overwrite existing files
+# Write the new file as rpmnew
+testfile() {
+	if [ -e "$1" ]; then
+		echo "$1.rpmnew"
+	else
+		echo "$1"
+	fi
+}
+
+# Remove .rpmnew files if they are identical
+# otherwise record in manifest
+modprocess() {
+	if [ "${1/.rpmnew/}" != "$1" ]; then
+		if cmp "${1/.rpmnew/}" "$1"; then
+			rm "$1"
+			return
+		fi
+	fi
+	md5sum "${modname}" >>@@oneapi_manifest@@
+}
+
+rm -f @@oneapi_manifest@@
+
+# Regenerate the oneAPI modules directory
+echo "Generating new oneAPI modulefiles"
+/opt/intel/oneapi/modulefiles-setup.sh --ignore-latest --force --output-dir=@@OHPC_MODULEDEPS@@/oneapi/ >/dev/null
+if [ ! -d @@OHPC_MODULEDEPS@@/oneapi/compiler ]; then
+	echo "ERROR: Failed to create oneAPI module directory"
+	exit 1
+fi
+
+# Set system defaults for default OBS oneAPI modules
+# shellcheck disable=SC2043
+for tool in @@exact_deps@@; do
+	filename=@@OHPC_MODULEDEPS@@/oneapi/${tool%%/*}/.version
+	echo "#%Module1.0" >"${filename}"
+	echo "set ModulesVersion \"${tool##*/}\"" >>"${filename}"
+done
+
+# Create an OpenHPC module file for each version found in compilers
+echo "Creating OpenHPC-style modulefiles for local oneAPI compiler installation(s)."
+for compilers in @@OHPC_MODULEDEPS@@/oneapi/compiler/2*; do
+	ver=$(basename "${compilers}")
+	# Skip 2023.2.0 due to errors that can hang installer
+	if [ "${ver}" = "2023.2.0" ]; then
+		echo "--> Skipping version=2023.2.0 : environment module format error"
+		continue
+	fi
+	# For the default, also specify the MKL version
+	if [ "${ver}" = "@@exact_intel_ver@@" ]; then
+		mklver="mkl/@@exact_mkl_ver@@"
+	else
+		mklver="mkl"
+	fi
+	echo "--> Installing modulefile for version=${ver}"
+	# Do not overwrite existing files
+	# Write the new file as rpmnew
+	modname=$(testfile @@OHPC_MODULES@@/intel/"${ver}")
+
+	cat <<EOF >"${modname}"
+#%Module1.0#####################################################################
+
+set version "${ver}"
+
+proc ModulesHelp { } {
+global version
+puts stderr "\nThis module loads the oneAPI compiler environment.\n"
+puts stderr "\nSee the man pages for icc, icpc, and ifort for detailed information"
+puts stderr "on available compiler options and command-line syntax."
+puts stderr "\nVersion \$version\n"
+}
+
+module-whatis "Name: Intel(R) Compiler"
+module-whatis "Version: \$version"
+module-whatis "Category: compiler, runtime support"
+module-whatis "Description: Intel(R) Compiler Family (C/C++/Fortran for x86_64)"
+module-whatis "URL: http://software.intel.com/en-us/articles/intel-compilers/"
+
+# update module path hierarchy
+prepend-path    MODULEPATH          @@OHPC_MODULEDEPS@@/intel
+prepend-path    MODULEPATH          @@OHPC_MODULEDEPS@@/oneapi
+
+# Assume no PAC device; allow override on each node
+if { ![info exists ::env(ACL_SKIP_BSP_CONF)] } {
+    setenv          ACL_SKIP_BSP_CONF   1
+}
+
+module load "oclfpga"
+module load "tbb"
+module load "compiler-rt"
+module load "compiler/\$version"
+module load "${mklver}"
+
+family "compiler"
+EOF
+
+	modprocess "${modname}"
+
+	# Provide standalone module for use with GNU toolchain
+	modname=$(testfile @@OHPC_MODULEDEPS@@/gnu/mkl/"${ver}")
+
+	cat <<EOF >"${modname}"
+#%Module1.0#####################################################################
+
+set version "${ver}"
+
+proc ModulesHelp { } {
+global version
+puts stderr "\nConfigures oneAPI MKL environment\n"
+puts stderr "\$version\n"
+}
+
+module-whatis "Name: Intel(R) Math Kernel Library"
+module-whatis "Version: \$version"
+module-whatis "Category: library, runtime support"
+module-whatis "Description: Intel(R) Math Kernel Library for C/C++ and Fortran"
+module-whatis "URL: https://software.intel.com/en-us/en-us/intel-mkl"
+
+prepend-path  MODULEPATH       @@OHPC_MODULEDEPS@@/oneapi
+module load   "${mklver}"
+EOF
+
+	modprocess "${modname}"
+done
+
+# Set default version to match that used to build OpenHPC packages
+modname=$(testfile @@OHPC_MODULES@@/intel/.version)
+
+cat <<EOF >"${modname}"
+#%Module1.0#####################################################################
+set     ModulesVersion      "@@exact_intel_ver_module@@"
+EOF
+
+modprocess "${modname}"

--- a/components/compiler-families/intel-compilers-devel/SPECS/intel-compilers-devel.spec
+++ b/components/compiler-families/intel-compilers-devel/SPECS/intel-compilers-devel.spec
@@ -28,7 +28,7 @@
 Summary:   OpenHPC compatibility package for Intel(R) oneAPI HPC Toolkit
 Name:      %{pname}%{PROJ_DELIM}
 Version:   2024.0
-Release:   %{?dist}.1
+Release:   %{?dist}.3
 License:   Apache-2.0
 URL:       https://github.com/openhpc/ohpc
 Group:     %{PROJ_NAME}/compiler-families
@@ -36,6 +36,7 @@ BuildArch: x86_64
 AutoReq:   no
 Source1:   mod_generator.sh
 Source2:   oneAPI.repo
+Source3:   ohpc-update-modules-intel
 
 
 #!BuildIgnore: post-build-checks
@@ -70,11 +71,26 @@ install -D -m644 %{SOURCE2} -t %{buildroot}%{repodir}/
 # Mod generator for PSXE support
 install -D -m755 %{SOURCE1} %{buildroot}/%{OHPC_ADMIN}/compat/modulegen/mod_generator.sh
 
+# Mod generator for oneAPI support
+sed -e 's|@@oneapi_manifest@@|%{oneapi_manifes}|' \
+    -e 's|@@OHPC_MODULEDEPS@@|%{OHPC_MODULEDEPS}|' \
+    -e 's|@@OHPC_MODULES@@|%{OHPC_MODULES}|' \
+    -e 's|@@exact_deps@@|%{exact_deps}|' \
+    -e 's|@@exact_intel_ver@@|%{exact_intel_ver}|' \
+    -e 's|@@exact_intel_ver_module@@|%{exact_intel_ver_module}|' \
+    -e 's|@@exact_mkl_ver@@|%{exact_mkl_ver}|' %{SOURCE3} > ohpc-update-modules-intel
+install -D -m755 ohpc-update-modules-intel %{buildroot}/%{OHPC_BIN}/ohpc-update-modules-intel
+
 # Module directories
 mkdir -p %{buildroot}/%{OHPC_MODULEDEPS}/oneapi
 mkdir -p %{buildroot}/%{OHPC_MODULES}/intel
 mkdir -p %{buildroot}/%{OHPC_MODULEDEPS}/gnu/mkl
 mkdir -p %{buildroot}/%{OHPC_MODULEDEPS}/intel
+
+
+# Regenerate module files when components are added or removed
+%transfiletriggerin -- /opt/intel/oneapi
+%{OHPC_BIN}/ohpc-update-modules-intel
 
 
 %pre -p /bin/bash
@@ -87,157 +103,39 @@ fi
 
 
 %post -p /bin/bash
-# Do not overwrite existing files
-# Write the new file as rpmnew
-testfile () {
-    if [ -e $1 ]; then
-       echo "$1.rpmnew"
-    else
-       echo "$1"
-    fi
-}
-
-rm -f %{oneapi_manifest}
-
-# Regenerate the oneAPI modules directory
-echo "Generating new oneAPI modulefiles"
-/opt/intel/oneapi/modulefiles-setup.sh --ignore-latest --force --output-dir=%{OHPC_MODULEDEPS}/oneapi/ > /dev/null
-if [ ! -d %{OHPC_MODULEDEPS}/oneapi/compiler ]; then
-    echo "ERROR: Failed to create oneAPI module directory"
-    exit 1
-fi
-
-# Set system defaults for default OBS oneAPI modules
-for tool in %{exact_deps}; do
-  filename=%{OHPC_MODULEDEPS}/oneapi/${tool%%/*}/.version
-  echo "#%Module1.0" > ${filename}
-  echo "set  ModulesVersion  \"${tool##*/}\"" >> ${filename}
-done
-
-# Create an OpenHPC module file for each version found in compilers
-echo "Creating OpenHPC-style modulefiles for local oneAPI compiler installation(s)."
-for compilers in %{OHPC_MODULEDEPS}/oneapi/compiler/2*; do
-    ver=$(basename "$compilers")
-    # Skip 2023.2.0 due to errors that can hang installer
-    if [ "$ver" = "2023.2.0" ]; then
-        echo "--> Skipping version=2023.2.0 : environment module format error"
-        continue
-    fi
-    # For the default, also specify the MKL version
-    if [ "$ver" = "%{exact_intel_ver}" ]; then
-        mklver="mkl/%{exact_mkl_ver}"
-    else
-        mklver="mkl"
-    fi
-    echo "--> Installing modulefile for version=${ver}"
-    # Do not overwrite existing files
-    # Write the new file as rpmnew
-    modname=$(testfile %{OHPC_MODULES}/intel/$ver)
-
-    cat << EOF > ${modname}
-#%Module1.0#####################################################################
-
-set version "$ver"
-
-proc ModulesHelp { } {
-global version
-puts stderr "\nThis module loads the oneAPI compiler environment.\n"
-puts stderr "\nSee the man pages for icc, icpc, and ifort for detailed information"
-puts stderr "on available compiler options and command-line syntax."
-puts stderr "\nVersion \$version\n"
-}
-
-module-whatis "Name: Intel(R) Compiler"
-module-whatis "Version: \$version"
-module-whatis "Category: compiler, runtime support"
-module-whatis "Description: Intel(R) Compiler Family (C/C++/Fortran for x86_64)"
-module-whatis "URL: http://software.intel.com/en-us/articles/intel-compilers/"
-
-# update module path hierarchy
-prepend-path    MODULEPATH          %{OHPC_MODULEDEPS}/intel
-prepend-path    MODULEPATH          %{OHPC_MODULEDEPS}/oneapi
-
-# Assume no PAC device; allow override on each node
-if { ![info exists ::env(ACL_SKIP_BSP_CONF)] } {
-    setenv          ACL_SKIP_BSP_CONF   1
-}
-
-module load "oclfpga"
-module load "tbb"
-module load "compiler-rt"
-module load "compiler/\$version"
-module load "$mklver"
-
-family "compiler"
-EOF
-
-    md5sum ${modname} >> %{oneapi_manifest}
-
-    # Provide standalone module for use with GNU toolchain
-    modname=$(testfile  %{OHPC_MODULEDEPS}/gnu/mkl/$ver)
-
-    cat << EOF > ${modname}
-#%Module1.0#####################################################################
-
-set version "$ver"
-
-proc ModulesHelp { } {
-global version
-puts stderr "\nConfigures oneAPI MKL environment\n"
-puts stderr "\$version\n"
-}
-
-module-whatis "Name: Intel(R) Math Kernel Library"
-module-whatis "Version: \$version"
-module-whatis "Category: library, runtime support"
-module-whatis "Description: Intel(R) Math Kernel Library for C/C++ and Fortran"
-module-whatis "URL: https://software.intel.com/en-us/en-us/intel-mkl"
-
-prepend-path  MODULEPATH       %{OHPC_MODULEDEPS}/oneapi
-module load   "$mklver"
-EOF
-
-    md5sum ${modname} >> %{oneapi_manifest}
-done
-
-# Set default version to match that used to build OpenHPC packages
-modname=$(testfile %{OHPC_MODULES}/intel/.version)
-
-cat << EOF > ${modname}
-#%Module1.0#####################################################################
-set     ModulesVersion      "%{exact_intel_ver_module}"
-EOF
-
-md5sum ${modname} >> %{oneapi_manifest}
+%{OHPC_BIN}/ohpc-update-modules-intel
 
 
 %preun -p /bin/bash
-# Check current files against the manifest
-# Remove files that match and backup files that don't
-if [ -s %{oneapi_manifest} ]; then
-    echo "Removing module files"
-    while IFS= read -r line; do
-       f=${line%:*}
-       s=${line#*:}
-       if [ "${s: -2}" = "OK" ]; then
-           rm -f $f
-       elif [ -f $f ]; then
-           mv -T -f $f $f.rpmsave
-       fi
-    done <<< $(md5sum --check %{oneapi_manifest})
-else
-    # Don't touch any generated files if there's no manifest
-    # On upgrade, expect lots of modulefiles created as .rpmnew
-    echo "WARNING: Manifest not found. Previously generated"
-    echo "         modulefiles will not be removed or moved."
+if [ $1 -eq 0 ]; then
+    # Check current files against the manifest
+    # Remove files that match and backup files that don't
+    if [ -s %{oneapi_manifest} ]; then
+        echo "Removing module files"
+        while IFS= read -r line; do
+           f=${line%:*}
+           s=${line#*:}
+           if [ "${s: -2}" = "OK" ]; then
+               rm -f $f
+           elif [ -f $f ]; then
+               mv -T -f $f $f.rpmsave
+           fi
+        done <<< $(md5sum --check %{oneapi_manifest})
+    else
+        # Don't touch any generated files if there's no manifest
+        # On upgrade, expect lots of modulefiles created as .rpmnew
+        echo "WARNING: Manifest not found. Previously generated"
+        echo "         modulefiles will not be removed or moved."
+    fi
+    # Remove the generated oneAPI module links, remove directories if empty
+    echo "Removing oneAPI module directory"
+    find %{OHPC_MODULEDEPS}/oneapi -type l -delete || true
+    find %{OHPC_MODULEDEPS}/oneapi/* -empty -type d -delete || true
 fi
-# Remove the generated oneAPI module links, remove directories if empty
-echo "Removing oneAPI module directory"
-find %{OHPC_MODULEDEPS}/oneapi -type l -delete || true
-find %{OHPC_MODULEDEPS}/oneapi/* -empty -type d -delete || true
 
 
 %files
+%{OHPC_BIN}/ohpc-update-modules-intel
 %dir %{OHPC_MODULES}/intel
 %dir %{OHPC_MODULEDEPS}/oneapi
 %dir %{OHPC_MODULEDEPS}/intel

--- a/components/mpi-families/impi-devel/SOURCES/ohpc-update-modules-impi
+++ b/components/mpi-families/impi-devel/SOURCES/ohpc-update-modules-impi
@@ -1,0 +1,172 @@
+#!/bin/bash
+# Don't clobber/overwrite existing files
+# Write the new file .rpmnew
+testfile() {
+	if [ -e "$1" ]; then
+		echo "$1.rpmnew"
+	else
+		echo "$1"
+	fi
+}
+
+# Remove .rpmnew files if they are identical
+# otherwise record in manifest
+modprocess() {
+	if [ "${1/.rpmnew/}" != "$1" ]; then
+		if cmp "${1/.rpmnew/}" "$1"; then
+			rm "$1"
+			return
+		fi
+	fi
+	md5sum "${modname}" >>@@oneapi_manifest@@
+}
+
+# Create an OpenHPC module file for each version found in compilers
+rm -f @@oneapi_manifest@@
+
+# Regenerate the oneAPI modules directory (since MPI may have just been added)
+echo "Generating new oneAPI modulefiles"
+/opt/intel/oneapi/modulefiles-setup.sh --ignore-latest --force --output-dir=@@OHPC_MODULEDEPS@@/oneapi/ >/dev/null
+if [ ! -d @@OHPC_MODULEDEPS@@/oneapi/compiler ]; then
+	echo "ERROR: Failed to create oneAPI module directory"
+	exit 1
+fi
+
+# Set system defaults for default OBS oneAPI modules
+# shellcheck disable=SC2043
+for tool in @@exact_deps@@; do
+	filename="@@OHPC_MODULEDEPS@@/oneapi/${tool%%/*}/.version"
+	echo "#%Module1.0" >"${filename}"
+	echo "set ModulesVersion \"${tool##*/}\"" >>"${filename}"
+done
+
+# Create an OpenHPC module file for each MPI version found
+echo "Creating OpenHPC-style modulefiles for local oneAPI MPI installation(s)."
+for mpis in @@OHPC_MODULEDEPS@@/oneapi/mpi/2*; do
+	ver=$(basename "${mpis}")
+	echo "--> Installing modulefile for version=${ver}"
+	modname=$(testfile @@OHPC_MODULEDEPS@@/intel/impi/"${ver}")
+
+	# Get value for MPI_DIR
+	eval "$(@@OHPC_ADMIN@@/lmod/lmod/libexec/lmod --expert use @@OHPC_MODULEDEPS@@/oneapi)"
+	# shellcheck disable=SC2086
+	eval "$(@@OHPC_ADMIN@@/lmod/lmod/libexec/lmod --expert load mpi/"${ver}")"
+	MPIDIR=${I_MPI_ROOT}
+	# shellcheck disable=SC2086
+	eval "$(@@OHPC_ADMIN@@/lmod/lmod/libexec/lmod --expert unload mpi/"${ver}")"
+	eval "$(@@OHPC_ADMIN@@/lmod/lmod/libexec/lmod --expert unuse @@OHPC_MODULEDEPS@@/oneapi)"
+
+	cat <<EOF >"${modname}"
+#%Module1.0#####################################################################
+
+set version "${ver}"
+
+proc ModulesHelp { } {
+global version
+puts stderr "\nThis module loads the Intel MPI environment.\n"
+puts stderr "   mpiifort  (Fortran source)"
+puts stderr "   mpiicc    (C   source)"
+puts stderr "   mpiicpc   (C++ source)"
+puts stderr "\nVersion \$version\n"
+}
+
+module-whatis "Name: Intel MPI"
+module-whatis "Version: \$version"
+module-whatis "Category: library, runtime support"
+module-whatis "Description: Intel MPI Library (C/C++/Fortran for x86_64)"
+module-whatis "URL: http://software.intel.com/en-us/articles/intel-mpi-library"
+
+# For convenience, redirect standard mpicc/mpicxx/mpifort
+# to use oneAPI icc/icpc/ifort instead of gcc/g++/gfortran
+setenv I_MPI_CC   icx
+setenv I_MPI_CXX  icpx
+setenv I_MPI_FC   ifx
+setenv I_MPI_F77  ifx
+setenv I_MPI_F90  ifx
+
+setenv MPI_DIR    "${MPIDIR}"
+
+prepend-path      MODULEPATH       @@OHPC_MODULEDEPS@@/oneapi
+prepend-path      MODULEPATH       @@OHPC_MODULEDEPS@@/intel-impi
+
+module load "mpi/\$version"
+
+prepend-path    LIBRARY_PATH    "${MPIDIR}/libfabric/lib"
+prepend-path    LIBRARY_PATH    "${MPIDIR}/lib"
+
+family "MPI"
+EOF
+
+	modprocess "${modname}"
+
+	modname=$(testfile @@OHPC_MODULEDEPS@@/gnu/impi/"${ver}")
+
+	cat <<EOF >"${modname}"
+#%Module1.0#####################################################################
+
+set version "${ver}"
+
+proc ModulesHelp { } {
+global version
+puts stderr "\nThis module loads the Intel MPI environment for use with the GNU"
+puts stderr "compiler toolchain\n"
+puts stderr "mpif90       (Fortran source)"
+puts stderr "mpicc        (C   source)"
+puts stderr "mpicxx       (C++ source)"
+puts stderr "\nVersion \$version\n"
+}
+
+module-whatis "Name: Intel MPI"
+module-whatis "Version: \$version"
+module-whatis "Category: library, runtime support"
+module-whatis "Description: Intel MPI Library (C/C++/Fortran for x86_64)"
+module-whatis "URL: http://software.intel.com/en-us/articles/intel-mpi-library/"
+
+setenv MPI_DIR    "${MPIDIR}"
+
+prepend-path    MODULEPATH      @@OHPC_MODULEDEPS@@/oneapi
+prepend-path    MODULEPATH      @@OHPC_MODULEDEPS@@/gnu-impi
+
+module load "mpi/\$version"
+
+prepend-path    LIBRARY_PATH    "${MPIDIR}/libfabric/lib"
+prepend-path    LIBRARY_PATH    "${MPIDIR}/lib"
+
+family "MPI"
+EOF
+
+	modprocess "${modname}"
+
+	# support for gnu major version
+	orig_modname=${modname/.rpmnew/}
+	modname=$(testfile @@OHPC_MODULEDEPS@@/gnu@@gnu_major_ver@@/impi/"${ver}")
+	cp "${orig_modname}" "${modname}"
+	sed -i "s,@@OHPC_MODULEDEPS@@/gnu-impi,@@OHPC_MODULEDEPS@@/gnu@@gnu_major_ver@@-impi," "${modname}"
+	modprocess "${modname}"
+
+done
+
+# Default Intel(R) MPI Versions to match OpenHPC build version
+modname=$(testfile @@OHPC_MODULEDEPS@@/intel/impi/.version)
+
+cat <<EOF >"${modname}"
+#%Module1.0#####################################################################
+set     ModulesVersion      "@@exact_mpi_ver@@"
+EOF
+
+modprocess "${modname}"
+
+modname=$(testfile @@OHPC_MODULEDEPS@@/gnu/impi/.version)
+
+cat <<EOF >"${modname}"
+#%Module1.0#####################################################################
+set     ModulesVersion      "@@exact_mpi_ver@@"
+EOF
+
+modprocess "${modname}"
+
+# support for gnu major version
+orig_modname=${modname/.rpmnew/}
+modname=$(testfile @@OHPC_MODULEDEPS@@/gnu@@gnu_major_ver@@/impi/.version)
+cp "${orig_modname}" "${modname}"
+modprocess "${modname}"

--- a/components/mpi-families/impi-devel/SPECS/intel-mpi.spec
+++ b/components/mpi-families/impi-devel/SPECS/intel-mpi.spec
@@ -26,7 +26,7 @@
 Summary:   OpenHPC compatibility package for Intel(R) oneAPI MPI Library
 Name:      %{pname}%{PROJ_DELIM}
 Version:   2024.0
-Release:   %{?dist}.1
+Release:   %{?dist}.3
 License:   Apache-2.0
 URL:       https://github.com/openhpc/ohpc
 Group:     %{PROJ_NAME}/mpi-families
@@ -34,6 +34,7 @@ BuildArch: x86_64
 AutoReq:   no
 
 Source1:   mod_generator_impi.sh
+Source2:   ohpc-update-modules-impi
 
 #!BuildIgnore: post-build-checks
 
@@ -57,10 +58,26 @@ MPI Library.
 # Mod generator for PSXE support
 install -D -m755 %{SOURCE1}  %{buildroot}/%{OHPC_ADMIN}/compat/modulegen/mod_generator_impi.sh
 
+# Mod generator for oneAPI support
+sed -e 's|@@oneapi_manifest@@|%{oneapi_manifest}|' \
+    -e 's|@@OHPC_ADMIN@@|%{OHPC_ADMIN}|' \
+    -e 's|@@OHPC_MODULEDEPS@@|%{OHPC_MODULEDEPS}|' \
+    -e 's|@@OHPC_MODULES@@|%{OHPC_MODULES}|' \
+    -e 's|@@exact_deps@@|%{exact_deps}|' \
+    -e 's|@@exact_mpi_ver@@|%{exact_mpi_ver}|' \
+    -e 's|@@gnu_major_ver@@|%{gnu_major_ver}|' %{SOURCE2} > ohpc-update-modules-impi
+install -D -m755 ohpc-update-modules-impi %{buildroot}/%{OHPC_BIN}/ohpc-update-modules-impi
+
 # Module directories
 mkdir -p %{buildroot}/%{OHPC_MODULEDEPS}/intel/impi
 mkdir -p %{buildroot}/%{OHPC_MODULEDEPS}/gnu/impi
 mkdir -p %{buildroot}/%{OHPC_MODULEDEPS}/gnu%{gnu_major_ver}/impi
+
+
+# Regenerate module files when components are added or removed
+%transfiletriggerin -- /opt/intel/oneapi/mpi
+%{OHPC_BIN}/ohpc-update-modules-impi
+
 
 %pre
 if ! [ -d /opt/intel/oneapi/mpi/%{exact_mpi_ver}/etc/modulefiles ]; then
@@ -72,162 +89,7 @@ fi
 
 
 %post
-# Don't clobber/overwrite existing files
-# Write the new file .rpmnew
-testfile () {
-    if [ -e $1 ]; then
-       echo "$1.rpmnew"
-    else
-       echo "$1"
-    fi
-}
-
-# Create an OpenHPC module file for each version found in compilers
-rm -f %{oneapi_manifest}
-
-# Regenerate the oneAPI modules directory  (since MPI may have just been added)
-echo "Generating new oneAPI modulefiles"
-/opt/intel/oneapi/modulefiles-setup.sh --ignore-latest --force --output-dir=%{OHPC_MODULEDEPS}/oneapi/ > /dev/null
-if [ ! -d %{OHPC_MODULEDEPS}/oneapi/compiler ]; then
-    echo "ERROR: Failed to create oneAPI module directory"
-    exit 1
-fi
-
-# Set system defaults for default OBS oneAPI modules
-for tool in %{exact_deps}; do
-  filename=%{OHPC_MODULEDEPS}/oneapi/${tool%%/*}/.version
-  echo "#%Module1.0" > ${filename}
-  echo "set  ModulesVersion  \"${tool##*/}\"" >> ${filename}
-done
-
-# Create an OpenHPC module file for each MPI version found
-echo "Creating OpenHPC-style modulefiles for local oneAPI MPI installation(s)."
-for mpis in %{OHPC_MODULEDEPS}/oneapi/mpi/2*; do
-    ver=$(basename "$mpis")
-    echo "--> Installing modulefile for version=${ver}"
-    modname=$(testfile %{OHPC_MODULEDEPS}/intel/impi/$ver)
-
-    # Get value for MPI_DIR
-    eval $(%{OHPC_ADMIN}/lmod/lmod/libexec/lmod --expert use %{OHPC_MODULEDEPS}/oneapi)
-    eval $(%{OHPC_ADMIN}/lmod/lmod/libexec/lmod --expert load mpi/$ver)
-    MPIDIR=$I_MPI_ROOT
-    eval $(%{OHPC_ADMIN}/lmod/lmod/libexec/lmod --expert unload mpi/$ver)
-    eval $(%{OHPC_ADMIN}/lmod/lmod/libexec/lmod --expert unuse %{OHPC_MODULEDEPS}/oneapi)
-
-    cat << EOF > ${modname}
-#%Module1.0#####################################################################
-
-set version "$ver"
-
-proc ModulesHelp { } {
-global version
-puts stderr "\nThis module loads the Intel MPI environment.\n"
-puts stderr "   mpiifort  (Fortran source)"
-puts stderr "   mpiicc    (C   source)"
-puts stderr "   mpiicpc   (C++ source)"
-puts stderr "\nVersion \$version\n"
-}
-
-module-whatis "Name: Intel MPI"
-module-whatis "Version: \$version"
-module-whatis "Category: library, runtime support"
-module-whatis "Description: Intel MPI Library (C/C++/Fortran for x86_64)"
-module-whatis "URL: http://software.intel.com/en-us/articles/intel-mpi-library"
-
-# For convenience, redirect standard mpicc/mpicxx/mpifort
-# to use oneAPI icc/icpc/ifort instead of gcc/g++/gfortran
-setenv I_MPI_CC   icx
-setenv I_MPI_CXX  icpx
-setenv I_MPI_FC   ifx
-setenv I_MPI_F77  ifx
-setenv I_MPI_F90  ifx
-
-setenv MPI_DIR    "${MPIDIR}"
-
-prepend-path      MODULEPATH       %{OHPC_MODULEDEPS}/oneapi
-prepend-path      MODULEPATH       %{OHPC_MODULEDEPS}/intel-impi
-
-module load "mpi/\$version"
-
-prepend-path    LIBRARY_PATH    "${MPIDIR}/libfabric/lib"
-prepend-path    LIBRARY_PATH    "${MPIDIR}/lib"
-
-family "MPI"
-EOF
-
-    md5sum ${modname} >> %{oneapi_manifest}
-
-    modname=$(testfile %{OHPC_MODULEDEPS}/gnu/impi/$ver)
-
-    cat << EOF > ${modname}
-#%Module1.0#####################################################################
-
-set version "$ver"
-
-proc ModulesHelp { } {
-global version
-puts stderr "\nThis module loads the Intel MPI environment for use with the GNU"
-puts stderr "compiler toolchain\n"
-puts stderr "mpif90       (Fortran source)"
-puts stderr "mpicc        (C   source)"
-puts stderr "mpicxx       (C++ source)"
-puts stderr "\nVersion \$version\n"
-}
-
-module-whatis "Name: Intel MPI"
-module-whatis "Version: \$version"
-module-whatis "Category: library, runtime support"
-module-whatis "Description: Intel MPI Library (C/C++/Fortran for x86_64)"
-module-whatis "URL: http://software.intel.com/en-us/articles/intel-mpi-library/"
-
-setenv MPI_DIR    "${MPIDIR}"
-
-prepend-path    MODULEPATH      %{OHPC_MODULEDEPS}/oneapi
-prepend-path    MODULEPATH      %{OHPC_MODULEDEPS}/gnu-impi
-
-module load "mpi/\$version"
-
-prepend-path    LIBRARY_PATH    "${MPIDIR}/libfabric/lib"
-prepend-path    LIBRARY_PATH    "${MPIDIR}/lib"
-
-family "MPI"
-EOF
-
-    md5sum ${modname} >> %{oneapi_manifest}
-
-    # support for gnu major version
-    orig_modname=$modname
-    modname=$(testfile  %{OHPC_MODULEDEPS}/gnu%{gnu_major_ver}/impi/$ver)
-    cp ${orig_modname} ${modname}
-    sed -i "s,%{OHPC_MODULEDEPS}/gnu-impi,%{OHPC_MODULEDEPS}/gnu%{gnu_major_ver}-impi," ${modname}
-    md5sum ${modname} >> %{oneapi_manifest}
-
-done
-
-# Default Intel(R) MPI Versions to match OpenHPC build version
-modname=$(testfile %{OHPC_MODULEDEPS}/intel/impi/.version)
-
-cat << EOF > ${modname}
-#%Module1.0#####################################################################
-set     ModulesVersion      "%{exact_mpi_ver}"
-EOF
-
-md5sum ${modname} >> %{oneapi_manifest}
-
-modname=$(testfile %{OHPC_MODULEDEPS}/gnu/impi/.version)
-
-cat << EOF > ${modname}
-#%Module1.0#####################################################################
-set     ModulesVersion      "%{exact_mpi_ver}"
-EOF
-
-md5sum ${modname} >> %{oneapi_manifest}
-
-# support for gnu major version
-orig_modname=$modname
-modname=$(testfile  %{OHPC_MODULEDEPS}/gnu%{gnu_major_ver}/impi/.version)
-cp ${orig_modname} ${modname}
-md5sum ${modname} >> %{oneapi_manifest}
+%{OHPC_BIN}/ohpc-update-modules-impi
 
 %preun -p /bin/bash
 # Check current files against the manifest
@@ -251,6 +113,7 @@ fi
 
 
 %files
+%{OHPC_BIN}/ohpc-update-modules-impi
 %dir %{OHPC_MODULEDEPS}/intel/impi
 %dir %{OHPC_MODULEDEPS}/gnu/impi
 %dir %{OHPC_MODULEDEPS}/gnu%{gnu_major_ver}/impi

--- a/tests/ci/Makefile
+++ b/tests/ci/Makefile
@@ -58,6 +58,8 @@ whitespace-lint:
 	@echo "Checking spec files for trailing whitespaces"
 	cd ../../; ! git --no-pager grep -E '\s+$$' \*.spec \
 		components/admin/prun/SOURCES/prun \
+		components/compiler-families/intel-compilers-devel/SOURCES/ohpc-update-modules-intel \
+		components/mpi-families/impi-devel/SOURCES/ohpc-update-modules-impi \
 		components/rms/slurm/SOURCES/slurm.epilog.clean \
 		tests/user-env/mem_limits \
 		tests/common/functions \
@@ -111,6 +113,8 @@ shellcheck-lint:
 		../../components/admin/prun/SOURCES/prun \
 		../../components/admin/docs/SOURCES/get_source.sh \
 		../../components/admin/test-suite/SOURCES/get_source.sh \
+		../../components/compiler-families/intel-compilers-devel/SOURCES/ohpc-update-modules-intel \
+		../../components/mpi-families/impi-devel/SOURCES/ohpc-update-modules-impi \
 		../../components/rms/slurm/SOURCES/slurm.epilog.clean \
 		../../tests/libs/netcdf/ohpc-tests/netcdf_all_test_mpi_families \
 		../../tests/libs/hdf5/ohpc-tests/test_compiler_families \
@@ -197,6 +201,8 @@ shfmt-lint:
 		../../tests/common/functions \
 		../../tests/libs/hdf5/ohpc-tests/test_compiler_families \
 		../../tests/libs/phdf5/ohpc-tests/test_mpi_families \
+		../../components/compiler-families/intel-compilers-devel/SOURCES/ohpc-update-modules-intel \
+		../../components/mpi-families/impi-devel/SOURCES/ohpc-update-modules-impi \
 		../../components/rms/slurm/SOURCES/slurm.epilog.clean
 
 clang-format-lint:


### PR DESCRIPTION
This is as yet completely untested.  But the idea is:

* Split out the module generation into a separate script into a new bin directory.  I think admins may want to run this at times as well
* Update the script to only generate .rpmnew files if the files are different than the currently installed ones
* Run that script whenever the /opt/intel/oneapi directory is updated by another rpm
* Only run the %postun script when the package is completely removed, not on updates

Does the CI generate rpms that can be tested?