### PR TITLE
Update Warewulf to 4.5.5

### DIFF
--- a/components/provisioning/warewulf/SOURCES/warewulf-4.5.x-sle_ipxe.patch
+++ b/components/provisioning/warewulf/SOURCES/warewulf-4.5.x-sle_ipxe.patch
@@ -1,0 +1,16 @@
+--- a/etc/warewulf.conf	2024-05-13 20:43:03.000000000 -0700
++++ b/etc/warewulf.conf	2024-06-02 14:42:51.645090625 -0700
+@@ -18,10 +18,10 @@
+   enabled: true
+   systemd name: tftp
+   ipxe:
+-    00:09: ipxe-snponly-x86_64.efi
++    00:09: ipxe-x86_64.efi
+     00:00: undionly.kpxe
+-    00:0B: arm64-efi/snponly.efi
+-    00:07: ipxe-snponly-x86_64.efi
++    00:0B: snp-arm64.efi
++    00:07: ipxe-x86_64.efi
+ nfs:
+   enabled: true
+   export paths:


### PR DESCRIPTION
Updates to Warewulf 4.5.5 in OpenHPC 3.x.

Other changes:
Require Go 1.20 or later
Adds API
Add patchfile to update config for SUSE
Select offline build based on OHPC/OBS macro
Adds subpackage for dracut module (for compute nodes)