### PR TITLE
Fixup #1983: Please rpmlint and add missing dependencies

### DIFF
--- a/components/io-libs/cubew/SOURCES/rpmlintrc
+++ b/components/io-libs/cubew/SOURCES/rpmlintrc
@@ -1,0 +1,4 @@
+addFilter("devel-file-in-non-devel-package");
+addFilter("library-without-ldconfig-postin");
+addFilter("library-without-ldconfig-postun");
+

--- a/components/io-libs/cubew/SPECS/cubew.spec
+++ b/components/io-libs/cubew/SPECS/cubew.spec
@@ -25,8 +25,10 @@ Group:          %{PROJ_NAME}/io-libs
 URL:            http://www.scalasca.org/software/cube-4.x/download.html
 Source0:        http://apps.fz-juelich.de/scalasca/releases/cube/%shortv/dist/cubew-%{version}.tar.gz
 BuildRequires:  chrpath
+BuildRequires:  file
 BuildRequires:  gcc-c++
 BuildRequires:  make
+BuildRequires:  sed
 BuildRequires:  which
 BuildRequires:  zlib-devel
 Requires:       lmod%{PROJ_DELIM} >= 7.6.1

--- a/components/io-libs/otf2/SOURCES/rpmlintrc
+++ b/components/io-libs/otf2/SOURCES/rpmlintrc
@@ -1,0 +1,4 @@
+addFilter("devel-file-in-non-devel-package");
+addFilter("library-without-ldconfig-postin");
+addFilter("library-without-ldconfig-postun");
+

--- a/components/io-libs/otf2/SPECS/otf2.spec
+++ b/components/io-libs/otf2/SPECS/otf2.spec
@@ -24,8 +24,10 @@ License:        BSD-3-Clause
 Group:          %{PROJ_NAME}/io-libs
 URL:            http://score-p.org
 Source0:        http://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/%{pname}-%{version}/%{pname}-%{version}.tar.gz
+BuildRequires:  file
 BuildRequires:  gcc-c++
 BuildRequires:  make
+BuildRequires:  sed
 BuildRequires:  which
 BuildRequires:  chrpath dos2unix
 # Need a new py-compile for Python 3.12

--- a/components/serial-libs/cubelib/SOURCES/rpmlintrc
+++ b/components/serial-libs/cubelib/SOURCES/rpmlintrc
@@ -1,0 +1,4 @@
+addFilter("devel-file-in-non-devel-package");
+addFilter("library-without-ldconfig-postin");
+addFilter("library-without-ldconfig-postun");
+

--- a/components/serial-libs/cubelib/SPECS/cubelib.spec
+++ b/components/serial-libs/cubelib/SPECS/cubelib.spec
@@ -25,8 +25,10 @@ Group:          %{PROJ_NAME}/serial-libs
 URL:            http://www.scalasca.org/software/cube-4.x/download.html
 Source0:        http://apps.fz-juelich.de/scalasca/releases/cube/%shortwv/dist/cubelib-%{version}.tar.gz
 BuildRequires:  chrpath
+BuildRequires:  file
 BuildRequires:  gcc-c++
 BuildRequires:  make
+BuildRequires:  sed
 BuildRequires:  which
 BuildRequires:  zlib-devel
 Requires:       lmod%{PROJ_DELIM} >= 7.6.1

--- a/components/serial-libs/opari2/SOURCES/rpmlintrc
+++ b/components/serial-libs/opari2/SOURCES/rpmlintrc
@@ -1,0 +1,4 @@
+addFilter("devel-file-in-non-devel-package");
+addFilter("library-without-ldconfig-postin");
+addFilter("library-without-ldconfig-postun");
+

--- a/components/serial-libs/opari2/SPECS/opari2.spec
+++ b/components/serial-libs/opari2/SPECS/opari2.spec
@@ -23,8 +23,11 @@ License:        BSD-3-Clause
 Group:          %{PROJ_NAME}/serial-libs
 URL:            https://www.vi-hps.org/projects/score-p/
 Source0:        http://perftools.pages.jsc.fz-juelich.de/cicd/opari2/tags/%{pname}-%{version}/%{pname}-%{version}.tar.gz
+BuildRequires:  file
 BuildRequires:  make
 BuildRequires:  gcc-c++
+BuildRequires:  sed
+BuildRequires:  which
 Requires:       lmod%{PROJ_DELIM} >= 7.6.1
 
 # Default library install path


### PR DESCRIPTION
As described in #1983 after merging, there are a few issues while building the packages:

1. Building OPARI2 fails because the awk script doesn't contain a correct shebang. This is caused by packages missing. 
```
[   64s] + /usr/lib/rpm/redhat/brp-mangle-shebangs
[   64s] *** WARNING: ./opt/ohpc/pub/libs/gnu13/opari2/2.0.8/share/doc/opari2/example/lib/libpomp.la is executable but has no shebang, removing executable bit
[   64s] *** ERROR: ./opt/ohpc/pub/libs/gnu13/opari2/2.0.8/libexec/pomp2-parse-init-regions.awk has shebang which doesn't start with '/' (-f)
[   64s] error: Bad exit status from /var/tmp/rpm-tmp.aWrFUM (%install)
```
To fix this, I've added the missing dependencies not only to OPARI2, but also the other packages. This is just to make sure that nothing else breaks we haven't noticed yet. The added packages are used in the configure step. 

2. `rpmlint` had some errors, see https://github.com/openhpc/ohpc/pull/1983#issuecomment-2146917587
To fix this, I added the failing parts to the rpmlintrc of each package, as done with other OpenHPC packages. 