### PR TITLE
Update steps for forwarding system logs to use new syntax in rsyslog.conf

### DIFF
--- a/docs/recipes/install/common/syslog.tex
+++ b/docs/recipes/install/common/syslog.tex
@@ -14,8 +14,8 @@ forward their logs to the SMS, and to allow the SMS to accept these log requests
 [sms](*\#*) systemctl restart rsyslog
 
 # Define compute node forwarding destination
-[sms](*\#*) echo "*.* @${sms_ip}:514" >> $CHROOT/etc/rsyslog.conf
-[sms](*\#*) echo "Target=\"${sms_ip}\" Protocol=\"udp\"" >> $CHROOT/etc/rsyslog.conf
+[sms](*\#*) echo "*.* action(type=\"omfwd\" Target=\"${sms_ip}\" Port=\"514\" "\
+   "Protocol=\"udp\")">> $CHROOT/etc/rsyslog.conf
 
 # Disable most local logging on computes. Emergency and boot logs will remain on the compute nodes
 [sms](*\#*) perl -pi -e "s/^\*\.info/\\#\*\.info/" $CHROOT/etc/rsyslog.conf


### PR DESCRIPTION
Updated steps for forwarding of system logs to use new rsyslog syntax. 

Without this, rsyslogd would report `error during parsing file /etc/rsyslog.conf`

Ref: https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/6/html/deployment_guide/sec-using_the_new_syntax_for_rsyslog_queues#sec-Using_the_New_Syntax_for_rsyslog_queues