### PR TITLE
Score-P & Scalasca: Add minor fixes

### DIFF
--- a/components/perf-tools/scalasca/SOURCES/scalasca-2.6.1-nowarn-omp-pragmas.patch
+++ b/components/perf-tools/scalasca/SOURCES/scalasca-2.6.1-nowarn-omp-pragmas.patch
@@ -1,0 +1,39 @@
+This patch fixes a missing $ in configure, which causes following checks to
+fail if they produce any output to stdout or stderr.
+
+diff -Nrup scalasca-2.6.1.orig/build-config/m4/scalasca_nowarn_omp_pragmas.m4 scalasca-2.6.1/build-config/m4/scalasca_nowarn_omp_pragmas.m4
+--- scalasca-2.6.1.orig/build-config/m4/scalasca_nowarn_omp_pragmas.m4	2022-12-14 11:55:38.810618928 +0100
++++ scalasca-2.6.1/build-config/m4/scalasca_nowarn_omp_pragmas.m4	2023-09-27 09:47:31.155201804 +0200
+@@ -62,7 +62,7 @@ AS_CASE([$_scalasca_nowarn_omp_pragmas],
+ AC_SUBST([NOWARN_OMP_PRAGMAS_]_AC_LANG_PREFIX[FLAGS])
+ 
+ dnl Reset environment
+-ac_[]_AC_LANG_ABBREV[]_werror_flag=_scalasca_save_[]_AC_LANG_ABBREV[]_werror_flag
++ac_[]_AC_LANG_ABBREV[]_werror_flag=$_scalasca_save_[]_AC_LANG_ABBREV[]_werror_flag
+ ])
+ 
+ 
+diff -Nrup scalasca-2.6.1.orig/build-backend/configure scalasca-2.6.1/build-backend/configure
+--- scalasca-2.6.1.orig/build-backend/configure	2022-12-14 11:56:16.350709778 +0100
++++ scalasca-2.6.1/build-backend/configure	2023-09-27 09:49:35.847822426 +0200
+@@ -21128,7 +21128,7 @@ case $_scalasca_nowarn_omp_pragmas in #(
+ esac
+ 
+ 
+-ac_cxx_werror_flag=_scalasca_save_cxx_werror_flag
++ac_cxx_werror_flag=$_scalasca_save_cxx_werror_flag
+ 
+  if test "x${ac_cv_prog_cxx_openmp}" != "xunsupported" \
+                 && test "x${enable_openmp}" != "xno"; then
+diff -Nrup scalasca-2.6.1.orig/build-mpi/configure scalasca-2.6.1/build-mpi/configure
+--- scalasca-2.6.1.orig/build-mpi/configure	2022-12-14 11:56:33.574751469 +0100
++++ scalasca-2.6.1/build-mpi/configure	2023-09-27 09:49:06.135678364 +0200
+@@ -21878,7 +21878,7 @@ case $_scalasca_nowarn_omp_pragmas in #(
+ esac
+ 
+ 
+-ac_cxx_werror_flag=_scalasca_save_cxx_werror_flag
++ac_cxx_werror_flag=$_scalasca_save_cxx_werror_flag
+ 
+  if test "x${ac_cv_prog_cxx_openmp}" != "xunsupported" \
+                 && test "x${enable_openmp}" != "xno"; then

--- a/components/perf-tools/scalasca/SPECS/scalasca.spec
+++ b/components/perf-tools/scalasca/SPECS/scalasca.spec
@@ -33,6 +33,7 @@ Requires: cubew-%{compiler_family}%{PROJ_DELIM} >= 4.8
 Requires: cubelib-%{compiler_family}%{PROJ_DELIM} >= 4.4
 Requires: otf2-%{compiler_family}-%{mpi_family}%{PROJ_DELIM} >= 3.0
 Requires: scorep-%{compiler_family}-%{mpi_family}%{PROJ_DELIM} >= 1.2
+Patch1:   scalasca-2.6.1-nowarn-omp-pragmas.patch
 
 # Default library install path
 %define install_path %{OHPC_LIBS}/%{compiler_family}/%{mpi_family}/%{pname}/%version
@@ -56,6 +57,7 @@ This is the %{compiler_family}-%{mpi_family} version.
 %prep
 
 %setup -q -n %{pname}-%{version}
+%patch -P 1 -p1
 
 %build
 

--- a/components/perf-tools/scorep/SOURCES/scorep-8.4-gcc-update-fake-gmp-header.patch
+++ b/components/perf-tools/scorep/SOURCES/scorep-8.4-gcc-update-fake-gmp-header.patch
@@ -1,0 +1,42 @@
+This patch replaces the GMP header used by Score-P during configure. This header is used
+when checking for gcc-plugin.h, building the plug-in and linking it to work around issues
+with installations where GMP is not available since Score-P v1.4.1.
+The previous header did work up-to GCC 13, but changes in GCC 14 cause the header check to fail,
+which disables the GCC plug-in in Score-P. This resulted in a lack of functionality,
+namely compile-time filtering.
+
+With this patch, the configure check now passes correctly once again.
+
+---
+--- a/src/adapters/compiler/gcc-plugin/fake-gmp/gmp.h
++++ b/src/adapters/compiler/gcc-plugin/fake-gmp/gmp.h
+@@ -1,7 +1,7 @@
+ /*
+  * This file is part of the Score-P software (http://www.score-p.org)
+  *
+- * Copyright (c) 2015,
++ * Copyright (c) 2015, 2024,
+  * Technische Universitaet Dresden, Germany
+  *
+  * This software may be modified and distributed under the terms of
+@@ -13,6 +13,16 @@
+ #ifndef SCOREP_FAKE_GMP_H
+ #define SCOREP_FAKE_GMP_H
+
+-typedef void* mpz_t;
++struct __fake_mpz_struct
++{
++    int empty;
++};
++
++typedef struct __fake_mpz_struct  mpz_t[ 1 ];
++typedef struct __fake_mpz_struct* mpz_ptr;
++
++void mpz_init( mpz_ptr );
++
++void mpz_clear( mpz_ptr );
+
+ #endif /* SCOREP_FAKE_GMP_H */
+--
+
+

--- a/components/perf-tools/scorep/SPECS/scorep.spec
+++ b/components/perf-tools/scorep/SPECS/scorep.spec
@@ -30,6 +30,7 @@ Source0:   https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-%{v
 %if 0%{?suse_version}
 Patch1:    scorep-8.4-opensuse-libbfd-additional-libs.patch
 %endif
+Patch2:    scorep-8.4-gcc-update-fake-gmp-header.patch
 
 BuildRequires: automake
 BuildRequires: bison
@@ -76,6 +77,7 @@ This is the %{compiler_family}-%{mpi_family} version.
 %if 0%{?suse_version}
 %patch -P 1 -p1
 %endif
+%patch -P 2 -p1
 
 %build
 


### PR DESCRIPTION
Add two minor fixes to Score-P & Scalasca, which were partially already merged in other build systems.

**Score-P**:

GCC 14 has changed some things on GMP, which caused our GCC plug-in check to fail. We fixed this in the Score-P 9.0 development cycle by updating our "fake" header. This commit backports these changes to Score-P 8.4, so that the GCC plug-in continues to work. This patch is already merged in Fedora for example (see [here](https://src.fedoraproject.org/rpms/scorep/c/23c83219cbb94a65f67933c97832c3178500225d?branch=rawhide)).

**Scalasca**:

Add a small patch which fixes a typo in configure. This can cause tests to during configure to fail, as all tests after the OpenMP detection will be checked for any output on `stdout` and `stderr`. A PR for this fix exists for [Fedora](https://src.fedoraproject.org/rpms/scalasca/pull-request/3) & [EasyBuild](https://github.com/easybuilders/easybuild-easyconfigs/pull/21135), with our internal JSC EasyBuild having this patch for quite some while already.