### PR TITLE
tests: Fix the spec URL value

### DIFF
--- a/components/admin/docs/SOURCES/get_source.sh
+++ b/components/admin/docs/SOURCES/get_source.sh
@@ -1,33 +1,34 @@
 #!/usr/bin/env bash
 
-set -x
+set -xe
 
 # Note: The current working directory is the component's SPEC folder
 OHPC_ROOT_FOLDER="../../../.."
 
 # The folder that will contain the .git/ and docs/ folders
-DOCS_OHPC_FOLDER=docs-ohpc
+DOCS_OHPC_FOLDER="docs-ohpc"
 
 cleanup() {
-    rm -rf ${DOCS_OHPC_FOLDER}
-    find ${OHPC_ROOT_FOLDER}/docs/recipes/install/ -name "vc.tex" -delete
+    rm -rf "${DOCS_OHPC_FOLDER}"
+    find "${OHPC_ROOT_FOLDER}/docs/recipes/install/" -name "vc.tex" -delete
 }
 trap cleanup EXIT
 
 # 1. Prepare
 cleanup
-mkdir -p ${DOCS_OHPC_FOLDER}
+mkdir -p "${DOCS_OHPC_FOLDER}"
 
 # 2. Copy the Git metadata
-cp -r ${OHPC_ROOT_FOLDER}/.git ${DOCS_OHPC_FOLDER}
+cp -r "${OHPC_ROOT_FOLDER}/.git" "${DOCS_OHPC_FOLDER}"
 
 # 3. Copy the local docs/
-cp -r ${OHPC_ROOT_FOLDER}/docs ${DOCS_OHPC_FOLDER}
+cp -r "${OHPC_ROOT_FOLDER}/docs" "${DOCS_OHPC_FOLDER}"
 
 # 4. Add dummy vc.tex to the docs
-for makefile in `find ${DOCS_OHPC_FOLDER}/docs/recipes/install/ -name "Makefile"`; do
-    folder=$(dirname ${makefile})
-    cat <<'EOF' > ${folder}/vc.tex
+find "${DOCS_OHPC_FOLDER}"/docs/recipes/install/ -name "Makefile" -print0 | while IFS= read -r -d '' makefile
+do
+    folder=$(dirname "${makefile}")
+    cat <<'EOF' > "${folder}"/vc.tex
 %%% Define Git specific macros.
 \gdef\GITHash{5ffbf3e2ed0ed558c1ae5672f7e5023298b7c2a9}%
 \gdef\GITAbrHash{5ffbf3e}%
@@ -55,4 +56,4 @@ EOF
 done
 
 # 5. Create docs-ohpc.tar
-tar cf ../SOURCES/docs-ohpc.tar ${DOCS_OHPC_FOLDER}
+tar cf ../SOURCES/docs-ohpc.tar "${DOCS_OHPC_FOLDER}"

--- a/components/admin/test-suite/SOURCES/get_source.sh
+++ b/components/admin/test-suite/SOURCES/get_source.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -xe
+
+# Note: The current working directory is the component's SPEC folder
+OHPC_ROOT_FOLDER="../../../.."
+
+# The folder that will contain the .git/ and docs/ folders
+TESTS_OHPC_FOLDER=tests-ohpc
+
+cleanup() {
+    rm -rf ${TESTS_OHPC_FOLDER}
+}
+trap cleanup EXIT
+
+# 1. Prepare
+cleanup
+mkdir -p ${TESTS_OHPC_FOLDER}
+
+# 2. Copy the local docs/
+cp -r ${OHPC_ROOT_FOLDER}/tests ${TESTS_OHPC_FOLDER}
+
+# 3. Create tests-ohpc.tar
+tar cf ../SOURCES/tests-ohpc.tar ${TESTS_OHPC_FOLDER}

--- a/components/admin/test-suite/SOURCES/get_source.sh
+++ b/components/admin/test-suite/SOURCES/get_source.sh
@@ -9,16 +9,16 @@ OHPC_ROOT_FOLDER="../../../.."
 TESTS_OHPC_FOLDER=tests-ohpc
 
 cleanup() {
-    rm -rf ${TESTS_OHPC_FOLDER}
+    rm -rf "${TESTS_OHPC_FOLDER}"
 }
 trap cleanup EXIT
 
 # 1. Prepare
 cleanup
-mkdir -p ${TESTS_OHPC_FOLDER}
+mkdir -p "${TESTS_OHPC_FOLDER}"
 
 # 2. Copy the local docs/
-cp -r ${OHPC_ROOT_FOLDER}/tests ${TESTS_OHPC_FOLDER}
+cp -r "${OHPC_ROOT_FOLDER}/tests" "${TESTS_OHPC_FOLDER}"
 
 # 3. Create tests-ohpc.tar
-tar cf ../SOURCES/tests-ohpc.tar ${TESTS_OHPC_FOLDER}
+tar cf ../SOURCES/tests-ohpc.tar "${TESTS_OHPC_FOLDER}"

--- a/components/admin/test-suite/SPECS/tests.spec
+++ b/components/admin/test-suite/SPECS/tests.spec
@@ -20,6 +20,8 @@ BuildArch: noarch
 URL:       https://github.com/openhpc/ohpc
 Source0:   tests-ohpc.tar
 
+BuildRequires:  perl(File::Copy)
+BuildRequires:  perl(File::Compare)
 BuildRequires:  autoconf%{PROJ_DELIM}
 BuildRequires:  automake%{PROJ_DELIM}
 

--- a/components/admin/test-suite/SPECS/tests.spec
+++ b/components/admin/test-suite/SPECS/tests.spec
@@ -17,7 +17,7 @@ Release:   1
 License:   Apache-2.0
 Group:     %{PROJ_NAME}/admin
 BuildArch: noarch
-URL:       https://github.com/openhpc/ohpc/tests
+URL:       https://github.com/openhpc/ohpc
 Source0:   tests-ohpc.tar
 
 BuildRequires:  autoconf%{PROJ_DELIM}

--- a/tests/ci/Makefile
+++ b/tests/ci/Makefile
@@ -70,6 +70,8 @@ shellcheck-lint:
 		../../components/OHPC_setup_compiler \
 		../../components/OHPC_setup_mpi \
 		../../components/admin/prun/SOURCES/prun \
+		../../components/admin/docs/SOURCES/get_source.sh \
+		../../components/admin/test-suite/SOURCES/get_source.sh \
 		../../components/rms/slurm/SOURCES/slurm.epilog.clean \
 		../../tests/libs/netcdf/ohpc-tests/netcdf_all_test_mpi_families \
 		../../tests/libs/netcdf/ohpc-tests/test_mpi_families


### PR DESCRIPTION
https://github.com/openhpc/ohpc/tests leads to 404. 
The correct one would be https://github.com/openhpc/ohpc/tree/3.x/tests but it is version specific