### PR TITLE
Revert "lmod: Update to 8.7.49"

### DIFF
--- a/components/admin/lmod/SPECS/lmod.spec
+++ b/components/admin/lmod/SPECS/lmod.spec
@@ -16,7 +16,7 @@
 
 Summary:   Lua based Modules (lmod)
 Name:      %{pname}%{PROJ_DELIM}
-Version:   8.7.49
+Version:   8.7.37
 Release:   %{?dist}.1
 License:   MIT
 Group:     %{PROJ_NAME}/admin


### PR DESCRIPTION
Reverts openhpc/ohpc#2034

Because of https://github.com/TACC/Lmod/issues/718#issuecomment-2343334206
For example: https://github.com/openhpc/ohpc/actions/runs/11139088691/job/30955137264