### PR TITLE
HDF5: Fix the build with Intel compiler

### DIFF
--- a/components/io-libs/hdf5/SOURCES/fix-intel-compiler.patch
+++ b/components/io-libs/hdf5/SOURCES/fix-intel-compiler.patch
@@ -1,0 +1,21 @@
+--- a/config/cmake/HDF5UseFortran.cmake	2024-10-25 15:16:10.038600011 +0300
++++ b/config/cmake/HDF5UseFortran.cmake	2024-10-25 15:16:40.464403575 +0300
+@@ -218,10 +218,6 @@
+     string (REGEX REPLACE "," ";" VAR "${pac_validLogicalKinds}")
+ 
+     set(CMAKE_REQUIRED_QUIET TRUE)
+-    set(save_CMAKE_Fortran_FLAGS ${CMAKE_Fortran_FLAGS})
+-    if (CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+-       set(CMAKE_Fortran_FLAGS "-warn error")
+-    endif ()
+ 
+     foreach (KIND ${VAR})
+       unset(MPI_LOGICAL_KIND CACHE)
+@@ -248,7 +244,6 @@
+        message (FATAL_ERROR "Failed to determine LOGICAL KIND for MPI")
+     endif ()
+     set(CMAKE_REQUIRED_QUIET FALSE)
+-    set(CMAKE_Fortran_FLAGS ${save_CMAKE_Fortran_FLAGS})
+   endif()
+ endif()
+ 

--- a/components/io-libs/hdf5/SPECS/hdf5.spec
+++ b/components/io-libs/hdf5/SPECS/hdf5.spec
@@ -23,6 +23,7 @@ License:   Hierarchical Data Format (HDF) Software Library and Utilities License
 Group:     %{PROJ_NAME}/io-libs
 URL:       http://www.hdfgroup.org/HDF5
 Source0:   https://github.com/HDFGroup/%{pname}/archive/refs/tags/%{pname}_%{version}.tar.gz
+Patch1:    fix-intel-compiler.patch
 
 BuildRequires: zlib-devel make
 BuildRequires: perl(File::Compare)
@@ -49,6 +50,7 @@ grids. You can also mix and match them in HDF5 files according to your needs.
 
 %prep
 %setup -q -n %{pname}-%{pname}_%{version}
+%patch -P1 -p1
 
 %build
 


### PR DESCRIPTION
Uses a patch to revert https://github.com/HDFGroup/hdf5/commit/f6ae24103290215a92b981a205215e59a6ada5f3#diff-eff1bae8d512738be4c5337b594867ef4f22b5f8940b8fbdcc3e9a78e1419bb6R225

Also see https://github.com/HDFGroup/hdf5/issues/4637