### PR TITLE
Fix default network and DNS for compute nodes on Warewulf 4

### DIFF
--- a/docs/recipes/install/common/add_ww4_hosts_intro.tex
+++ b/docs/recipes/install/common/add_ww4_hosts_intro.tex
@@ -4,7 +4,7 @@
 \begin{lstlisting}[language=bash,keywords={},upquote=true,basicstyle=\footnotesize\ttfamily,literate={BOSVER}{\baseos{}}1]
 [sms](*\#*) for ((i=0; i<$num_computes; i++)) ; do
 wwctl node add --container=rocky-9.4 \
-    --ipaddr=${c_ip[$i]} --hwaddr=${c_mac[$i]} --netmask=${internal_netmask} ${c_name[i]}
+    --ipaddr=${c_ip[$i]} --hwaddr=${c_mac[$i]} ${c_name[i]}
 done
 \end{lstlisting}
 % end_ohpc_run

--- a/docs/recipes/install/common/inputs.tex
+++ b/docs/recipes/install/common/inputs.tex
@@ -22,6 +22,10 @@ node counts. \\
 \fi
 & \texttt{\$\{internal\_network\}} & {\small \# Subnet network address for internal network} \\
 & \texttt{\$\{internal\_netmask\}} & {\small \# Subnet netmask for internal network} \\
+\iftoggleverb{isWarewulf4}
+& \texttt{\$\{ipv4\_gateway\}} & {\small \# Default gateway for the internal network} \\
+& \texttt{\$\{dns\_servers\}} & {\small \# DNS resolver for the internal network} \\
+\fi
 & \texttt{\$\{ntp\_server\}} & {\small \# Local ntp server for time synchronization} \\
 & \texttt{\$\{bmc\_username\}} & {\small \# BMC username for use by IPMI} \\
 & \texttt{\$\{bmc\_password\}} & {\small \# BMC password for use by IPMI} \\

--- a/docs/recipes/install/common/install_provisioning_warewulf4_intro.tex
+++ b/docs/recipes/install/common/install_provisioning_warewulf4_intro.tex
@@ -13,7 +13,7 @@ Warewulf configuration file is edited to reflect the environment.
 % ohpc_comment_header Add baseline OpenHPC and provisioning services \ref{sec:add_provisioning}
 \begin{lstlisting}[language=bash,keywords={}]
 # Install base packages
-[sms](*\#*) (*\install*) ohpc-base warewulf-ohpc hwloc-ohpc netmask
+[sms](*\#*) (*\install*) ohpc-base warewulf-ohpc hwloc-ohpc
 \end{lstlisting}
 % end_ohpc_run
 

--- a/docs/recipes/install/common/warewulf4_setup_centos.tex
+++ b/docs/recipes/install/common/warewulf4_setup_centos.tex
@@ -5,10 +5,6 @@
 [sms](*\#*) ip link set dev ${sms_eth_internal} up
 [sms](*\#*) ip address add ${sms_ip}/${internal_netmask} broadcast + dev ${sms_eth_internal}
 
-# Compute the network address for the internal network
-[sms](*\#*) internal_cidr=$(netmask ${sms_ip}/${internal_netmask})
-[sms](*\#*) internal_network=${internal_cidr%/*}
-
 # Edit the warewulf.conf file to use appropriate interface and settings
 [sms](*\#*) perl -pi -e "s/ipaddr:.*/ipaddr: ${sms_ip}/" /etc/warewulf/warewulf.conf
 [sms](*\#*) perl -pi -e "s/netmask:.*/netmask: ${internal_netmask}/" /etc/warewulf/warewulf.conf
@@ -17,6 +13,11 @@
 [sms](*\#*) perl -pi -e "s/range start:.*/range start: ${c_ip[0]}/" /etc/warewulf/warewulf.conf
 [sms](*\#*) perl -pi -e "s/range end:.*/range end: ${c_ip[$((num_computes-1))]}/" /etc/warewulf/warewulf.conf
 [sms](*\#*) perl -pi -e "s/mount: false/mount: true/" /etc/warewulf/warewulf.conf
+
+# Set default network configuration
+[sms](*\#*) wwctl profile set -y default --netmask=${internal_netmask}
+[sms](*\#*) wwctl profile set -y default --gateway=${ipv4_gateway}
+[sms](*\#*) wwctl profile set -y default --netdev=default --nettagadd=DNS=${dns_servers}
 
 # Configure /etc/hostname on master and compute nodes
 [sms](*\#*) perl -pi -e "s/warewulf/${sms_name}/" /srv/warewulf/overlays/host/rootfs/etc/hosts.ww

--- a/docs/recipes/install/rocky9/input.local.template
+++ b/docs/recipes/install/rocky9/input.local.template
@@ -21,6 +21,9 @@ sms_eth_internal="${sms_eth_internal:-eth1}"
 # Subnet netmask for internal cluster network
 internal_netmask="${internal_netmask:-255.255.0.0}"
 
+# Subnet network for internal cluster network
+internal_network="${internal_network:-172.16.0.0}"
+
 # ipv4 gateway 
 ipv4_gateway="${ipv4_gateway:-172.16.0.2}"
 


### PR DESCRIPTION
Add default networking to node profiles   
    * Add netmask, gateway, and dns at the node profile level
    * Add internal_network, ipv4_gateway, dns_servers across
      input.local.template and inputs.tex