### PR TITLE
Add amd gpu autodetect=rsmi support

### DIFF
--- a/components/rms/slurm/SPECS/slurm.spec
+++ b/components/rms/slurm/SPECS/slurm.spec
@@ -16,6 +16,7 @@
 %global _with_slurmrestd 1
 %global _with_multiple_slurmd 1
 %global _with_freeipmi 1
+%global _with_rsmi /opt/rocm/lib
 
 %if 0%{?rhel} || 0%{?openEuler}
 %global _with_yaml 1
@@ -77,7 +78,6 @@ Patch0: slurm.conf.example.patch
 # --with jwt		%_with_jwt 1		require jwt support
 # --with freeipmi	%_with_freeipmi 1	require freeipmi support
 # --with selinux	%_with_selinux 1	build with selinux support
-
 #  Options that are off by default (enable with --with <opt>)
 %bcond_with cray
 %bcond_with cray_network
@@ -94,6 +94,7 @@ Patch0: slurm.conf.example.patch
 %bcond_with lua
 %bcond_with numa
 %bcond_with pmix
+%bcond_with rsmi
 %bcond_with nvml
 %bcond_with jwt
 %bcond_with yaml
@@ -144,6 +145,9 @@ BuildRequires: mariadb-devel >= 5.0.0
 %endif
 %endif
 
+%if %{with rsmi}
+BuildRequires: rocm-smi-lib
+%endif
 %if %{with cray}
 BuildRequires: cray-libalpscomm_cn-devel
 BuildRequires: cray-libalpscomm_sn-devel
@@ -452,7 +456,6 @@ module load hwloc
 	%{?_with_nvml} \
 	--with-hwloc=%{OHPC_LIBS}/hwloc \
 	%{?_with_cflags} || { cat config.log && exit 1; }
-
 make %{?_smp_mflags}
 
 %install


### PR DESCRIPTION
This allows Autodetect=rsmi to be used in the slurm GRES.conf

technically no modification to the Spec file is needed but this is just a reminder that the rocm-smi-lib rpm needs to be installed as a build requirement on the OBS nodes

The rpm is included the AMD rocm repos which can be found here:
https://repo.radeon.com/rocm/el9/6.2.2/main

I have published a release in here with the rpms attached to verify that it works.
https://github.com/antonycleave/openhpc-slurm-with-rocm/releases



