### PR TITLE
Include f2py back into OHPC Numpy

### DIFF
--- a/components/dev-tools/numpy/SPECS/python-numpy.spec
+++ b/components/dev-tools/numpy/SPECS/python-numpy.spec
@@ -147,7 +147,6 @@ EOF
 %{__mkdir_p} ${RPM_BUILD_ROOT}/%{_docdir}
 
 %files
-%exclude %{install_path}/bin/f2py
 %{OHPC_PUB}
 %doc INSTALL.rst
 %doc README.md


### PR DESCRIPTION
This follows the discussion from the [OHPC mailing list](https://lists.openhpc.community/g/users/topic/no_f2py_with/110266952).

Commit 1ab2e9c9ec42a2b170a1a125e5359606090be9f3 in 2019 added a line in the .spec file to explicitly exclude f2py installation. This commit simply removes this line.