### PR TITLE
Upgrade Warewulf 4.6.0

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -161,6 +161,9 @@ jobs:
         path: tests/**/*.log.xml
 
   build_on_openEuler:
+    env:
+      JOB_SKIP_CI_SPECS: |
+        components/provisioning/warewulf/SPECS/warewulf.spec
     runs-on: ubuntu-latest
     name: Build on openEuler
     container:
@@ -177,6 +180,7 @@ jobs:
       uses: Ana06/get-changed-files@v2.3.0
     - name: Validate Build
       run: |
+        export SKIP_CI_SPECS="${{ env.JOB_SKIP_CI_SPECS }}"
         . /etc/profile.d/lmod.sh
         tests/ci/run_build.py ohpc ${{ steps.files.outputs.added_modified }}
         touch /tmp/empty
@@ -197,6 +201,7 @@ jobs:
       JOB_SKIP_CI_SPECS: |
         components/runtimes/charliecloud/SPECS/charliecloud.spec
         components/perf-tools/likwid/SPECS/likwid.spec
+        components/provisioning/warewulf/SPECS/warewulf.spec
     runs-on: ubuntu-latest
     name: Test on openEuler
     container:

--- a/components/provisioning/warewulf/SPECS/warewulf.spec
+++ b/components/provisioning/warewulf/SPECS/warewulf.spec
@@ -258,7 +258,3 @@ getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
 %files dracut
 %defattr(-, root, root)
 %{_prefix}/lib/dracut/modules.d/90wwinit
-
-%changelog
-* Mon Mar 03 2025 Timothy Middelkoop <tmiddelkoop@internet2.edu>
-- Merged/combined spec from 4.6.0

--- a/components/provisioning/warewulf/SPECS/warewulf.spec
+++ b/components/provisioning/warewulf/SPECS/warewulf.spec
@@ -8,15 +8,22 @@
 #
 #----------------------------------------------------------------------------eh-
 
+## Inserted by OHPC
 %include %{_sourcedir}/OHPC_macros
 
 %global debug_package %{nil}
+
+%global api 0
 
 # Base package name
 %global pname warewulf
 
 # Group for warewulfd and other WW operations
 %global wwgroup warewulf
+
+%if 0%{?fedora}
+%define _build_id_links none
+%endif
 
 # Service directories (change /var/lib/* default to match WW3 build)
 %global tftpdir /srv/tftpboot
@@ -25,13 +32,12 @@
 
 Name:    %{pname}%{PROJ_DELIM}
 Summary: A provisioning system for large clusters of bare metal and/or virtual systems
-Version: 4.5.5
+Version: 4.6.0
 Release: 1%{?dist}
 License: BSD-3-Clause
 Group:   %{PROJ_NAME}/provisioning
-URL:     https://github.com/hpcng/warewulf
-Source0: https://github.com/hpcng/warewulf/releases/download/v%{version}/warewulf-%{version}.tar.gz
-Patch0:  warewulf-4.5.x-sle_ipxe.patch
+URL:     https://github.com/warewulf/warewulf
+Source0: https://github.com/warewulf/warewulf/releases/download/v%{version}/warewulf-%{version}.tar.gz
 
 ExclusiveOS: linux
 
@@ -42,50 +48,81 @@ Conflicts: warewulf-vnfs
 Conflicts: warewulf-provision
 Conflicts: warewulf-ipmi
 
-BuildRequires: make
-BuildRequires: git
-BuildRequires: libassuan-devel
-BuildRequires: gpgme-devel
-BuildRequires: unzip
-Requires: dhcp-server
-
 %if 0%{?suse_version} || 0%{?sle_version}
+BuildRequires: distribution-release
 BuildRequires: systemd-rpm-macros
 BuildRequires: go > 1.20
 BuildRequires: firewall-macros
 BuildRequires: firewalld
 BuildRequires: tftp
+BuildRequires: yq
 Requires: tftp
 Requires: nfs-kernel-server
 Requires: firewalld
 Requires: ipxe-bootimgs
 %else
-# Assume Fedora-based OS (>= RHEL 9) if not SUSE-based
+# Assume Red Hat/Fedora build
+BuildRequires: system-release
 BuildRequires: systemd
-BuildRequires: gcc
 BuildRequires: golang > 1.20
 BuildRequires: firewalld-filesystem
 Requires: tftp-server
 Requires: nfs-utils
+%if 0%{?rhel} < 8
+Requires: ipxe-bootimgs
+%else
 Requires: ipxe-bootimgs-x86
 Requires: ipxe-bootimgs-aarch64
 %endif
-
-%description
-Warewulf is a stateless and diskless container operating system provisioning
-system for large clusters of bare metal and/or virtual systems.
-
-
-%prep
-%setup -q -n %{pname}-%{version}
-%if 0%{?suse_version} || 0%{?sle_version}
-%patch0 -p1
 %endif
 
+%if 0%{?rhel} >= 8 || 0%{?suse_version} || 0%{?fedora}
+Requires: dhcp-server
+%else
+# rhel < 8
+Requires: dhcp
+%endif
+
+BuildRequires: git
+BuildRequires: make
+BuildRequires: gpgme-devel
+%if %{api}
+BuildRequires: libassuan-devel
+%endif
+
+Recommends: logrotate
+Recommends: ipmitool
+
+%description
+Warewulf is a stateless and diskless provisioning
+system for large clusters of bare metal and/or virtual systems.
+
+%package dracut
+Summary: dracut module for loading a Warewulf image
+BuildArch: noarch
+
+Requires: dracut
+%if 0%{?suse_version}
+%else
+Requires: dracut-network
+%endif
+Requires: curl
+Requires: cpio
+Requires: dmidecode
+
+%description dracut
+Warewulf is a stateless and diskless provisioning
+system for large clusters of bare metal and/or virtual systems.
+
+This subpackage contains a dracut module that can be used to generate
+an initramfs that can fetch and boot a Warewulf node image from a
+Warewulf server.
+
+%prep
+%setup -q -n %{pname}-%{version} -b0 %if %{?with_offline:-a2}
 
 %build
 export OFFLINE_BUILD=1
-# Install to sharedstatedir by redirecting LOCALSTATEDIR
 make defaults \
     PREFIX=%{_prefix} \
     BINDIR=%{_bindir} \
@@ -101,26 +138,45 @@ make defaults \
     SYSTEMDDIR=%{_unitdir} \
     BASHCOMPDIR=/etc/bash_completion.d/ \
     FIREWALLDDIR=/usr/lib/firewalld/services \
-    WWCLIENTDIR=/warewulf
-    IPXESOURCE=/usr/share/ipxe
-make
+    WWCLIENTDIR=/warewulf \
+    IPXESOURCE=/usr/share/ipxe \
+    DRACUTMODDIR=/usr/lib/dracut/modules.d \
+    CACHEDIR=%{_localstatedir}/cache
+make build
+%if %{api}
 make api
+%endif
 
 
 %install
-export NO_BRP_STALE_LINK_ERROR=yes
 export OFFLINE_BUILD=1
-make install DESTDIR=%{buildroot}
-make installapi DESTDIR=%{buildroot}
+export NO_BRP_STALE_LINK_ERROR=yes
+make install \
+    DESTDIR=%{buildroot}
+%if %{api}
+make installapi \
+    DESTDIR=%{buildroot}
+%endif
 
+## Inserted by OHPC
 # For RH, tftpboot directory is hardcoded
 %if 0%{?rhel}
 ln -s %{_sharedstatedir}/tftpboot %{buildroot}%{tftpdir}
 %endif
 
+%if 0%{?suse_version} || 0%{?sle_version}
+yq e '
+  .tftp.ipxe."00:00" = "undionly.kpxe" |
+  .tftp.ipxe."00:07" = "ipxe-x86_64.efi" |
+  .tftp.ipxe."00:09" = "ipxe-x86_64.efi" |
+  .tftp.ipxe."00:0B" = "snp-arm64.efi" ' \
+  -i %{buildroot}%{_sysconfdir}/warewulf/warewulf.conf
+%endif
+
 
 %pre
 getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
+# use ipxe images from the distribution
 
 
 %post
@@ -138,65 +194,71 @@ getent group %{wwgroup} >/dev/null || groupadd -r %{wwgroup}
 
 
 %files
-%defattr(-, root, %{wwgroup})
+%defattr(-, root, root)
+
 %dir %{_sysconfdir}/warewulf
 %config(noreplace) %{_sysconfdir}/warewulf/warewulf.conf
-%dir %{_sysconfdir}/warewulf/examples
-%config(noreplace) %{_sysconfdir}/warewulf/examples/*.ww
-%dir %{_sysconfdir}/warewulf/ipxe
-%config(noreplace) %{_sysconfdir}/warewulf/ipxe/*.ipxe
-%dir %{_sysconfdir}/warewulf/grub
-%config(noreplace) %{_sysconfdir}/warewulf/grub/*.ww
-%config(noreplace) %attr(0640,-,-) %{_sysconfdir}/warewulf/nodes.conf
-%{_sysconfdir}/bash_completion.d/wwctl
+%config(noreplace) %attr(0640,-,%{wwgroup}) %{_sysconfdir}/warewulf/nodes.conf
+%config(noreplace) %{_sysconfdir}/warewulf/examples
+%config(noreplace) %{_sysconfdir}/warewulf/ipxe
+%config(noreplace) %{_sysconfdir}/warewulf/grub
+%{_sysconfdir}/bash_completion.d
+%config(noreplace) %{_sysconfdir}/logrotate.d
 
 %dir %{statedir}/warewulf
-%dir %{srvdir}/warewulf
-%{statedir}/warewulf/chroots
+%dir %{statedir}/warewulf/chroots
 %dir %{statedir}/warewulf/overlays
-%dir %{statedir}/warewulf/overlays/*
-%attr(-, root, root) %{statedir}/warewulf/overlays/*/rootfs
 
-%if 0%{?rhel}
-%{tftpdir}
-%endif
+%dir %{_datadir}/warewulf
+%{_datadir}/warewulf/bmc
+%dir %{_datadir}/warewulf/overlays
+%dir %{_datadir}/warewulf/overlays/*
+%dir %{_datadir}/warewulf/overlays/*/rootfs
+%{_datadir}/warewulf/overlays/NetworkManager/rootfs/*
+%{_datadir}/warewulf/overlays/debian.interfaces/rootfs/*
+%{_datadir}/warewulf/overlays/debug/rootfs/*
+%{_datadir}/warewulf/overlays/fstab/rootfs/*
+%{_datadir}/warewulf/overlays/host/rootfs/*
+%{_datadir}/warewulf/overlays/hostname/rootfs/*
+%{_datadir}/warewulf/overlays/hosts/rootfs/*
+%{_datadir}/warewulf/overlays/ifcfg/rootfs/*
+%{_datadir}/warewulf/overlays/ignition/rootfs/*
+%{_datadir}/warewulf/overlays/issue/rootfs/*
+%{_datadir}/warewulf/overlays/netplan/rootfs/*
+%{_datadir}/warewulf/overlays/resolv/rootfs/*
+%attr(700, -, -) %{_datadir}/warewulf/overlays/ssh.authorized_keys/rootfs/*
+%{_datadir}/warewulf/overlays/ssh.host_keys/rootfs/*
+%{_datadir}/warewulf/overlays/syncuser/rootfs/*
+%{_datadir}/warewulf/overlays/systemd.netname/rootfs/*
+%{_datadir}/warewulf/overlays/udev.netname/rootfs/*
+%{_datadir}/warewulf/overlays/wicked/rootfs/*
+%{_datadir}/warewulf/overlays/wwclient/rootfs/*
+%{_datadir}/warewulf/overlays/wwinit/rootfs/*
+%{_datadir}/warewulf/overlays/localtime/rootfs/*
 
-%attr(-, root, root) %{_bindir}/wwctl
-%attr(-, root, root) %{_prefix}/lib/firewalld/services/warewulf.xml
-%attr(-, root, root) %{_unitdir}/warewulfd.service
-%attr(-, root, root) %{_mandir}/man1/wwctl*
-%attr(-, root, root) %{_mandir}/man5/*.5*
-%attr(-, root, root) %{_datadir}/warewulf
+%{_bindir}/wwctl
+%{_prefix}/lib/firewalld/services/warewulf.xml
+%{_unitdir}/warewulfd.service
+%{_mandir}/man1/wwctl*
+%{_mandir}/man5/*.5*
 
 %dir %{_docdir}/warewulf
 %license %{_docdir}/warewulf/LICENSE.md
 
-%attr(-, root, root) %{_bindir}/wwapi*
+%if %{api}
+%{_bindir}/wwapi*
 %config(noreplace) %{_sysconfdir}/warewulf/wwapi*.conf
-
-# ===========================================================
-%define dracut_package %{pname}-dracut%{PROJ_DELIM}
-
-%package -n %{dracut_package}
-Summary: A dracut module for loading a Warewulf container image
-BuildArch: noarch
-
-Requires: dracut
-%if 0%{?suse_version} || 0%{?sle_version}
-%else
-Requires: dracut-network
 %endif
 
-%description -n %{dracut_package}
-Warewulf is a stateless and diskless container operating system provisioning
-system for large clusters of bare metal and/or virtual systems.
+## Inserted by OHPC
+%if 0%{?rhel}
+%{tftpdir}
+%endif
 
-This subpackage contains a dracut module that can be used to generate
-an initramfs that can fetch and boot a Warewulf container image from a
-Warewulf server.
-
-
-%files -n %{dracut_package}
+%files dracut
 %defattr(-, root, root)
-%dir %{_prefix}/lib/dracut/modules.d/90wwinit
-%{_prefix}/lib/dracut/modules.d/90wwinit/*.sh
+%{_prefix}/lib/dracut/modules.d/90wwinit
+
+%changelog
+* Mon Mar 03 2025 Timothy Middelkoop <tmiddelkoop@internet2.edu>
+- Merged/combined spec from 4.6.0

--- a/docs/recipes/install/common/add_ww4_hosts_intro.tex
+++ b/docs/recipes/install/common/add_ww4_hosts_intro.tex
@@ -3,7 +3,7 @@
 % ohpc_validation_comment Add hosts to cluster
 \begin{lstlisting}[language=bash,keywords={},upquote=true,basicstyle=\footnotesize\ttfamily,literate={BOSVER}{\baseos{}}1]
 [sms](*\#*) for ((i=0; i<$num_computes; i++)) ; do
-wwctl node add --container=rocky-9.4 \
+wwctl node add --image=rocky-9 --profile=nodes --netname=default \
     --ipaddr=${c_ip[$i]} --hwaddr=${c_mac[$i]} ${c_name[i]}
 done
 \end{lstlisting}

--- a/docs/recipes/install/common/finalize_warewulf4_provisioning.tex
+++ b/docs/recipes/install/common/finalize_warewulf4_provisioning.tex
@@ -4,16 +4,18 @@
 This section highlights creation of the node image and overlays, followed by the 
 registration of desired compute nodes.
 
-\subsubsection{Build container image and overlays}
+\subsubsection{Build image image and overlays}
 
 The bootstrap image includes the runtime kernel and associated modules, as well
-as some simple scripts to complete the provisioning process.
+as some simple scripts to complete the provisioning process.  We explicitly rebuild
+the image at the end because rebuilding the image is disabled in earlier steps.
+It is good practice to rebuild the overlays when after configuration changes.
 
 % begin_ohpc_run
 % ohpc_comment_header Assemble bootstrap image \ref{sec:assemble_bootstrap}
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true,literate={BOSVER}{\baseos{}}1]
 # Build image
-[sms](*\#*) wwctl container build BOSVER
+[sms](*\#*) wwctl image build BOSVER
 [sms](*\#*) wwctl overlay build
 \end{lstlisting}
 % end_ohpc_run

--- a/docs/recipes/install/common/import_ww4_files.tex
+++ b/docs/recipes/install/common/import_ww4_files.tex
@@ -2,16 +2,18 @@ The \Warewulf{} system includes functionality to import arbitrary files from
 the provisioning server for distribution to managed hosts through a system 
 called "overlays". Some files, like \texttt{/etc/passwd}, and \texttt{/etc/hosts}
 handled in this way by default.  Here we add directories and files to the 
-\texttt{generic} overlay that is applied to all nodes. 
+\texttt{nodesconfig} overlay that is applied to all nodes. 
 
 % begin_ohpc_run
 % ohpc_comment_header Import files \ref{sec:file_import}
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true]
 # Add the following to support unprivileged user namespaces for tools like Apptainer
-[sms](*\#*) wwctl overlay import generic /etc/subuid
-[sms](*\#*) wwctl overlay import generic /etc/subgid
+[sms](*\#*) wwctl overlay import --parents nodeconfig /etc/subuid
+[sms](*\#*) wwctl overlay import --parents nodeconfig /etc/subgid
 
-# Identify master host as local NTP server
-[sms](*\#*) echo "server ${sms_ip} iburst" | wwctl overlay import generic <(cat) /etc/chrony.conf
+# Identify master host as local NTP server, configure it with a template with a Tag
+[sms](*\#*) echo 'server {{.Tags.ntpserver}} iburst' | \
+  wwctl overlay import --parents nodeconfig <(cat) /etc/chrony.conf.ww
+[sms](*\#*) wwctl profile set --yes nodes --tagadd ntpserver=${sms_ip}
 \end{lstlisting}
 % \end_ohpc_run

--- a/docs/recipes/install/common/import_ww4_files_ib_centos.tex
+++ b/docs/recipes/install/common/import_ww4_files_ib_centos.tex
@@ -10,8 +10,8 @@ template file for \Warewulf{} that can optionally be imported and used later to 
 % ohpc_command if [[ ${enable_ipoib} -eq 1 ]];then
 % ohpc_indent 5
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true]
-[sms](*\#*) wwctl overlay mkdir generic /etc/sysconfig/network-scripts/
-[sms](*\#*) wwctl overlay import generic /opt/ohpc/pub/examples/network/centos/ifcfg-ib0.ww \
+# Import the template file for the ib interface
+[sms](*\#*) wwctl overlay import --parents nodeconfig /opt/ohpc/pub/examples/network/centos/ifcfg-ib0.ww \
  /etc/sysconfig/network-scripts/ifcfg-ib0.ww
 \end{lstlisting}
 % ohpc_indent 0

--- a/docs/recipes/install/common/import_ww4_files_slurm.tex
+++ b/docs/recipes/install/common/import_ww4_files_slurm.tex
@@ -4,14 +4,17 @@ on every host in the resource management pool, issue the following:
 
 % begin_ohpc_run
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true]
-# Configure Slurm server in the overlay (using "configless" option)
-[sms](*\#*) wwctl overlay mkdir generic /etc/sysconfig/
-[sms](*\#*) wwctl overlay import generic <(echo SLURMD_OPTIONS="--conf-server ${sms_ip}") /etc/sysconfig/slurmd
-  
+# Configure Slurm server in the overlay (using "configless" option) using a tag in a template file (slurmd.ww)
+[sms](*\#*) echo SLURMD_OPTIONS='--conf-server {{.Tags.slurmctld}}' | \
+  wwctl overlay import --parents nodeconfig <(cat) /etc/sysconfig/slurmd.ww
+
+# Set the value of the slurmctld tag to the $sms_ip for the nodes profile.
+[sms](*\#*) wwctl profile set --yes nodes --tagadd slurmctld=${sms_ip}
+
 # Configure munge
-[sms](*\#*) wwctl overlay mkdir generic --mode 0700 /etc/munge
-[sms](*\#*) wwctl overlay import generic /etc/munge/munge.key
-[sms](*\#*) wwctl overlay chown generic /etc/munge/munge.key $(id -u munge) $(id -g munge)
-[sms](*\#*) wwctl overlay chown generic /etc/munge $(id -u munge) $(id -g munge)
+[sms](*\#*) wwctl overlay import --parents nodeconfig /etc/munge/munge.key
+[sms](*\#*) wwctl overlay chown nodeconfig /etc/munge/munge.key $(id -u munge) $(id -g munge)
+[sms](*\#*) wwctl overlay chown nodeconfig /etc/munge $(id -u munge) $(id -g munge)
+[sms](*\#*) wwctl overlay chmod nodeconfig /etc/munge 0700
 \end{lstlisting}
 % \end_ohpc_run

--- a/docs/recipes/install/common/install_provisioning_warewulf4_intro.tex
+++ b/docs/recipes/install/common/install_provisioning_warewulf4_intro.tex
@@ -10,11 +10,12 @@ Warewulf configuration file is edited to reflect the environment.
 %\nottoggle{isCentOS}{\clearpage}
 
 % begin_ohpc_run
-% ohpc_comment_header Add baseline OpenHPC and provisioning services \ref{sec:add_provisioning}
+% ohpc_comment_header Add baseline OpenHPC\ref{sec:add_provisioning}
 \begin{lstlisting}[language=bash,keywords={}]
 # Install base packages
-[sms](*\#*) (*\install*) ohpc-base warewulf-ohpc hwloc-ohpc
+[sms](*\#*) (*\install*) ohpc-base
+
+# Install Warewulf
+[sms](*\#*) (*\install*) warewulf-ohpc hwloc-ohpc
 \end{lstlisting}
 % end_ohpc_run
-
-

--- a/docs/recipes/install/common/warewulf4_add_to_compute_chroot_intro.tex
+++ b/docs/recipes/install/common/warewulf4_add_to_compute_chroot_intro.tex
@@ -3,14 +3,21 @@ provide a minimal \baseOS{} configuration. Next, we add additional components
 to include resource management client services, NTP support, and
 other additional packages to support the default \OHPC{} environment. This
 process modifies the base provisioning image and will access the BOS and \OHPC{}
-repositories to resolve package install requests. We begin by installing a few
+repositories to resolve package install requests. 
+
+The instructions below are designed to be copied and pasted all at once into 
+a terminal.  Alternatively you can run `wwctl image shell rocky-9'
+to "run" the node image interactively and run the commands one at a time, this
+method is recommended.
+
+We begin by installing a few
 common base packages:
 
 % begin_ohpc_run
 % ohpc_comment_header Add OpenHPC base components to compute image \ref{sec:add_components}
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true,literate={BOSVER}{\baseos{}}1]
 # Install compute node base meta-package
-[sms](*\#*) wwctl container exec rocky-9.4 /bin/bash <<- EOF
+[sms](*\#*) wwctl image exec --build=false rocky-9 /bin/bash <<- EOF
   dnf -y install ohpc-base-compute
 EOF
 \end{lstlisting}
@@ -19,6 +26,6 @@ EOF
 \noindent Now, we can include additional required components to the compute
 instance including resource manager client, NTP, and development environment modules support.
 
-Adding packages can be done by entering the image with \texttt{wwctl container shell},
-\texttt{wwctl container exec}, or using a CHROOT.
+Adding packages can be done by entering the image with \texttt{wwctl image shell},
+\texttt{wwctl image exec}, or using a CHROOT.
 

--- a/docs/recipes/install/common/warewulf4_kargs_post.tex
+++ b/docs/recipes/install/common/warewulf4_kargs_post.tex
@@ -6,7 +6,7 @@ the following command is required to store the configuration in Warewulf:
 % ohpc_command if [[ ${enable_kargs} -eq 1 ]]; then
 \begin{lstlisting}[language=bash,keywords={},upquote=true,basicstyle=\footnotesize\ttfamily]
 # Set optional compute node kernel command line arguments.
-[sms](*\#*) wwctl node set --yes --kernelargs="${kargs}" "${compute_regex}"
+[sms](*\#*) wwctl profile set --yes nodes --kernelargs="${kargs}"
 \end{lstlisting}
 % ohpc_command fi
 % end_ohpc_run

--- a/docs/recipes/install/common/warewulf4_mkchroot_rocky.tex
+++ b/docs/recipes/install/common/warewulf4_mkchroot_rocky.tex
@@ -3,32 +3,32 @@ customize a system image that can subsequently be used to provision one or more
 {\em compute} nodes. The following subsections highlight this process.
 
 \subsubsection{Build initial BOS image} \label{sec:assemble_bos}
-\Warewulf{} 4 supports using container images as the base file system for 
+\Warewulf{} 4 supports using image images as the base file system for 
 provisioning, and it can import these images directly from an OCI registry like
 Docker Hub. Container images must be created especially for use with \Warewulf{}
 since they need to include things like a kernel and an init system. In this 
 example we will import our base image from a set maintained by the \Warewulf{}
 community on the GitHub container registry.
 
-The \texttt{wwctl container exec} command runs the commands below it, these commands 
-also be run interactively one a time with the command \texttt{wwctl container 
+The \texttt{wwctl image exec} command runs the commands below it, these commands 
+also be run interactively one a time with the command \texttt{wwctl image 
 shell \baseos{}}. You can add \texttt{/bin/false} as the last command to prevent 
 the image from rebuilding (it will show an error) and rebuild later with the 
-`wwctl container build` command.
+`wwctl image build` command.
 
 % begin_ohpc_run
 % ohpc_comment_header Create compute image for Warewulf \ref{sec:assemble_bos}
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true,keepspaces,literate={BOSVER}{\baseos{}}1]
 # Import the base image from ghcr
-[sms](*\#*) wwctl container import docker://ghcr.io/warewulf/warewulf-rockylinux:9 BOSVER --syncuser
+[sms](*\#*) wwctl image import docker://ghcr.io/warewulf/warewulf-rockylinux:9 BOSVER --syncuser
 
-# Enable OpenHPC inside image and update container
-[sms](*\#*) wwctl container exec rocky-9.4 /bin/bash <<- EOF
+# Enable OpenHPC inside image and update image.  Disable autorebuild.
+[sms](*\#*) wwctl image exec --build=false rocky-9 /bin/bash <<- EOF
   dnf -y install http://repos.openhpc.community/OpenHPC/3/EL_9/x86_64/ohpc-release-3-1.el9.x86_64.rpm
   dnf -y update
 EOF
 
-# Define chroot location 
+# Define chroot location
 [sms](*\#*) export CHROOT=/srv/warewulf/chroots/BOSVER/rootfs
 \end{lstlisting}
 % end_ohpc_run

--- a/docs/recipes/install/common/warewulf4_setup_centos.tex
+++ b/docs/recipes/install/common/warewulf4_setup_centos.tex
@@ -12,19 +12,21 @@
 [sms](*\#*) perl -pi -e 's/template:.*/template: static/' /etc/warewulf/warewulf.conf
 [sms](*\#*) perl -pi -e "s/range start:.*/range start: ${c_ip[0]}/" /etc/warewulf/warewulf.conf
 [sms](*\#*) perl -pi -e "s/range end:.*/range end: ${c_ip[$((num_computes-1))]}/" /etc/warewulf/warewulf.conf
-[sms](*\#*) perl -pi -e "s/mount: false/mount: true/" /etc/warewulf/warewulf.conf
+
+# Edit the nodes.conf to mount /opt
+[sms](*\#*) perl -pi -e "s/defaults,noauto,nofail,ro/defaults,nofail,ro/" /etc/warewulf/nodes.conf
+
+# Create a new "nodes" profile and inherit the "default" profile
+[sms](*\#*) wwctl profile add nodes --profile default --comment "Nodes profile"
+
+# Create a new "nodeconfig" overlay to store node configuration files, set the profile to use it
+[sms](*\#*) wwctl overlay create nodeconfig 
+[sms](*\#*) wwctl profile set --yes nodes --system-overlays nodeconfig
 
 # Set default network configuration
-[sms](*\#*) wwctl profile set -y default --netmask=${internal_netmask}
-[sms](*\#*) wwctl profile set -y default --gateway=${ipv4_gateway}
-[sms](*\#*) wwctl profile set -y default --netdev=default --nettagadd=DNS=${dns_servers}
-
-# Configure /etc/hostname on master and compute nodes
-[sms](*\#*) perl -pi -e "s/warewulf/${sms_name}/" /srv/warewulf/overlays/host/rootfs/etc/hosts.ww
-[sms](*\#*) perl -pi -e "s/warewulf/${sms_name}/" /srv/warewulf/overlays/generic/rootfs/etc/hosts.ww
-
-# Bugfix: dhcpd.template does not set next-server
-[sms](*\#*) echo "next-server ${sms_ip};" >> /srv/warewulf/overlays/host/rootfs/etc/dhcpd.conf.ww
+[sms](*\#*) wwctl profile set -y nodes --netdev=default --netmask=${internal_netmask}
+[sms](*\#*) wwctl profile set -y nodes --netdev=default --gateway=${ipv4_gateway}
+[sms](*\#*) wwctl profile set -y nodes --netdev=default --nettagadd=DNS=${dns_servers}
 
 # Configuring Warewulf will restart/enable relevant services to support provisioning
 [sms](*\#*) systemctl enable --now warewulfd
@@ -33,10 +35,4 @@
 # Generate ssh keys (usually generated on login)
 [sms](*\#*) bash /etc/profile.d/ssh_setup.sh
 \end{lstlisting}
-% end_ohpc_run
-
-% begin_ohpc_run
-% ohpc_validation_newline
-% ohpc_validation_comment Update /etc/hosts template to have ${hostname}.localdomain as the first host entry
-% ohpc_command sed -e 's_\({{$node.Id.Get}}{{end}}\)_{{$node.Id.Get}}.localdomain \1_g' -i /srv/warewulf/overlays/host/rootfs/etc/hosts.ww
 % end_ohpc_run

--- a/docs/recipes/install/rocky9/x86_64/warewulf4/slurm/steps.tex
+++ b/docs/recipes/install/rocky9/x86_64/warewulf4/slurm/steps.tex
@@ -7,11 +7,11 @@
 \input{vc.tex}
 
 % Define Base OS and other local macros
-\newcommand{\baseOS}{Rocky 9.4}
-\newcommand{\OSRepo}{Rocky\_9.4}
+\newcommand{\baseOS}{Rocky 9}
+\newcommand{\OSRepo}{Rocky\_9}
 \newcommand{\OSTree}{EL\_9}
 \newcommand{\OSTag}{el9}
-\newcommand{\baseos}{rocky-9.4}
+\newcommand{\baseos}{rocky-9}
 \newcommand{\baseosshort}{rocky9}
 \newcommand{\provisioner}{Warewulf4}
 \newcommand{\provheader}{\provisioner{}}
@@ -134,7 +134,7 @@
 % begin_ohpc_run
 % ohpc_validation_comment Add SLURM and other components to compute instance
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true,literate={BOSVER}{\baseos{}}1]
-[sms](*\#*) wwctl container exec rocky-9.4 /bin/bash <<- EOF 
+[sms](*\#*) wwctl image exec --build=false rocky-9 /bin/bash <<- EOF 
   # Add Slurm client support meta-package and enable munge and slurmd
   dnf -y install ohpc-slurm-client
   systemctl enable munge


### PR DESCRIPTION
Upgrade SPEC and docs to Warewulf 4.6.0.  https://warewulf.org/news/v4-6-0-released-2025-03-02/