### PR TITLE
Revert static UID/GID for Munge not needed with updated AlmaLinux image

### DIFF
--- a/docs/recipes/install/common/install_slurm.tex
+++ b/docs/recipes/install/common/install_slurm.tex
@@ -3,17 +3,6 @@ The following command adds the \SLURM{} workload manager server components to th
 chosen {\em master} host. Note that client-side components will be added to
 the corresponding compute image in a subsequent step.
 
-\iftoggleverb{isWarewulf4}
-% begin_ohpc_run
-% ohpc_comment_header Allocate static UID/GID for Munge (120:120) \ref{sec:add_rm}
-\begin{lstlisting}[language=bash,keywords={}]
-# Allocate static UID/GID for munge (120:120)
-[sms](*\#*) groupadd --system -g 120 munge
-[sms](*\#*) useradd --system -u 120 -g 120 -d /run/munge -s /sbin/nologin -c "Runs Uid N Gid Emporium" munge
-\end{lstlisting}
-% end_ohpc_run
-\fi
-
 % begin_ohpc_run
 % ohpc_comment_header Add resource management services on master node \ref{sec:add_rm}
 \begin{lstlisting}[language=bash,keywords={}]

--- a/docs/recipes/install/common/warewulf4_add_to_compute_chroot_slurm.tex
+++ b/docs/recipes/install/common/warewulf4_add_to_compute_chroot_slurm.tex
@@ -2,10 +2,6 @@
 % ohpc_validation_comment Add SLURM and other components to compute instance
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true,literate={BOSVER}{\baseos{}}1]
   [sms](*\#*) wwctl image exec --build=false BOSVER /bin/bash <<- EOF
-    # Allocate static UID/GID for munge (120:120)
-    groupadd --system -g 120 munge
-    useradd --system -u 120 -g 120 -d /run/munge -s /sbin/nologin -c "Runs Uid N Gid Emporium" munge
-
     # Add Slurm client support meta-package and enable munge and slurmd
     dnf -y install ohpc-slurm-client
     systemctl enable munge


### PR DESCRIPTION
Reverts the static Munge ID.  Until published by Warewulf use 
```
wwctl image import docker://ghcr.io/middelkoopt/warewulf-almalinux:9 almalinux-9 --syncuser
```
for the node image (note the different user `middelkoopt` - my development repo)
