### PR TITLE
Reformat modification of /etc/hosts.ww

### DIFF
--- a/docs/recipes/install/common/warewulf4_setup_centos.tex
+++ b/docs/recipes/install/common/warewulf4_setup_centos.tex
@@ -28,7 +28,9 @@
 [sms](*\#*) wwctl profile set -y nodes --netdev=default --nettagadd=DNS=${dns_servers}
 
 # Update /etc/hosts template to have ${hostname}.localdomain as the first host entry
-[sms](*\#*) wwctl overlay cat host /etc/hosts.ww  | sed -e 's_\({{$node.Id}}{{end}}\)_{{$node.Id}}.localdomain \1_g' | EDITOR=tee wwctl overlay edit host /etc//hosts.ww
+[sms](*\#*) wwctl overlay cat host /etc/hosts.ww | \
+  sed -e 's_\({{$node.Id}}{{end}}\)_{{$node.Id}}.localdomain \1_g' | \
+  EDITOR=tee wwctl overlay edit host /etc/hosts.ww
 
 # Configuring Warewulf will restart/enable relevant services to support provisioning
 [sms](*\#*) systemctl enable --now warewulfd


### PR DESCRIPTION
Reformat (word-wrap) modification of /etc/hosts.ww in the host overlay that modifies /etc/hosts on the SMS.

I don't believe this is strictly needed except in the CI/test clusters, perhaps it could be only run during CI? 
