### PR TITLE
Fix the use of netname and set netdev for Warewulf4

### DIFF
--- a/docs/recipes/install/common/add_ww4_hosts_finalize.tex
+++ b/docs/recipes/install/common/add_ww4_hosts_finalize.tex
@@ -6,7 +6,7 @@
 \begin{lstlisting}[language=bash,keywords={},upquote=true,basicstyle=\footnotesize\ttfamily]
 # Optionally define IPoIB network settings (required if planning to mount Lustre/BeeGFS over IB)
 [sms](*\#*) for ((i=0; i<$num_computes; i++)) ; do
-  wwctl node set --yes ${c_name[$i]} --netdev=ib0 --ipaddr=${c_ipoib[$i]} --netmask=${ipoib_netmask}
+  wwctl node set --yes ${c_name[$i]} --netname=ib --netdev=ib0 --ipaddr=${c_ipoib[$i]} --netmask=${ipoib_netmask}
 done
 \end{lstlisting}
 % ohpc_indent 0

--- a/docs/recipes/install/common/warewulf4_setup_centos.tex
+++ b/docs/recipes/install/common/warewulf4_setup_centos.tex
@@ -23,9 +23,10 @@
 [sms](*\#*) wwctl profile set --yes nodes --system-overlays nodeconfig --runtime-overlays syncuser
 
 # Set default network configuration
-[sms](*\#*) wwctl profile set -y nodes --netdev=default --netmask=${internal_netmask}
-[sms](*\#*) wwctl profile set -y nodes --netdev=default --gateway=${ipv4_gateway}
-[sms](*\#*) wwctl profile set -y nodes --netdev=default --nettagadd=DNS=${dns_servers}
+[sms](*\#*) wwctl profile set -y nodes --netname=default --netdev=${eth_provision}
+[sms](*\#*) wwctl profile set -y nodes --netname=default --netmask=${internal_netmask}
+[sms](*\#*) wwctl profile set -y nodes --netname=default --gateway=${ipv4_gateway}
+[sms](*\#*) wwctl profile set -y nodes --netname=default --nettagadd=DNS=${dns_servers}
 
 # Update /etc/hosts template to have ${hostname}.localdomain as the first host entry
 [sms](*\#*) wwctl overlay cat host /etc/hosts.ww | \


### PR DESCRIPTION
* Fix the incorrect use of `--netname` when setting the network in a profile.  
* Specify the network device (`--netdev`) for a compute node  in the nodes profile.
* Fix setting the network information for IB interfaces
