### PR TITLE
Align MANPATH handling in lmod.spec to preserve system man pages (#2070)

### DIFF
--- a/components/admin/lmod/SPECS/lmod.spec
+++ b/components/admin/lmod/SPECS/lmod.spec
@@ -162,7 +162,7 @@ if ( ! $?MANPATH ) then
     setenv MANPATH ":"
 endif
 # Initialize MANPATH if unset, then safely append Lmod's man directory using addto helper
-setenv MANPATH ` ${OHPC_ADMIN}/lmod/lmod/libexec/addto MANPATH ${OHPC_ADMIN}/lmod/lmod/share/man `
+setenv MANPATH `${OHPC_ADMIN}/lmod/lmod/libexec/addto MANPATH ${OHPC_ADMIN}/lmod/lmod/share/man`
 
 # Initialize modules system
 source %{OHPC_ADMIN}/lmod/lmod/init/csh >/dev/null

--- a/components/admin/lmod/SPECS/lmod.spec
+++ b/components/admin/lmod/SPECS/lmod.spec
@@ -112,6 +112,13 @@ else
     export MODULEPATH=%{OHPC_MODULES}
 fi
 
+if [ -z "\${MANPATH:-}" ]; then
+    export MANPATH=":"
+fi
+# Initialize MANPATH if unset, then safely append Lmod's man directory using addto helper
+export MANPATH=\$(${OHPC_ADMIN}/lmod/lmod/libexec/addto MANPATH ${OHPC_ADMIN}/lmod/lmod/share/man)
+
+# Set BASH_ENV for environment
 export BASH_ENV=%{OHPC_ADMIN}/lmod/lmod/init/bash
 
 # Initialize modules system
@@ -150,6 +157,12 @@ if ( \`id -u\` == "0" ) then
 else
    setenv MODULEPATH "%{OHPC_MODULES}"
 endif
+
+if ( ! $?MANPATH ) then
+    setenv MANPATH ":"
+endif
+# Initialize MANPATH if unset, then safely append Lmod's man directory using addto helper
+setenv MANPATH ` ${OHPC_ADMIN}/lmod/lmod/libexec/addto MANPATH ${OHPC_ADMIN}/lmod/lmod/share/man `
 
 # Initialize modules system
 source %{OHPC_ADMIN}/lmod/lmod/init/csh >/dev/null


### PR DESCRIPTION
### Summary

This PR updates the `lmod.spec` file to align MANPATH handling

### Changes

- Initialize MANPATH if unset to system defaults
- Use Lmod's 'addto' helper script to append Lmod man pages
- Applied changes in both bash (`lmod.sh`) and csh (`lmod.csh`) profile scripts
- Prevents module MANPATH overrides that hide system man pages (fixes #2070)

### Related Issue

Fixes: #2070

### Signed-off-by

Suresh Panneerselvam <sureshcbt@gmail.com>
