### PR TITLE
Fix setting MANPATH in csh

### DIFF
--- a/components/admin/lmod/SPECS/lmod.spec
+++ b/components/admin/lmod/SPECS/lmod.spec
@@ -21,7 +21,7 @@ Release:   %{?dist}.1
 License:   MIT
 Group:     %{PROJ_NAME}/admin
 Url:       https://github.com/TACC/Lmod
-Source0:   https://github.com/TACC/Lmod/archive/%{version}.tar.gz#$/%{pname}-%{version}.tar.gz
+Source0:   https://github.com/TACC/Lmod/archive/%{version}/%{pname}-%{version}.tar.gz
 
 BuildRequires: rsync
 BuildRequires: tcl-devel
@@ -86,7 +86,7 @@ make DESTDIR=$RPM_BUILD_ROOT install
 # Customize startup script to suit
 
 %{__mkdir_p} %{buildroot}/%{_sysconfdir}/profile.d
-%{__cat} << EOF > %{buildroot}/%{_sysconfdir}/profile.d/lmod.sh
+%{__cat} << 'EOF' > %{buildroot}/%{_sysconfdir}/profile.d/lmod.sh
 #!/bin/sh
 # -*- shell-script -*-
 ########################################################################
@@ -96,7 +96,7 @@ make DESTDIR=$RPM_BUILD_ROOT install
 ########################################################################
 
 # NOOP if running under known resource manager
-if [ ! -z "\$SLURM_NODELIST" ] || [ ! -z "\$PBS_NODEFILE" ]; then
+if [ ! -z "$SLURM_NODELIST" ] || [ ! -z "$PBS_NODEFILE" ]; then
      return
 fi
 
@@ -105,7 +105,7 @@ export LMOD_FULL_SETTARG_SUPPORT=no
 export LMOD_COLORIZE=no
 export LMOD_PREPEND_BLOCK=normal
 
-if [ \$EUID -eq 0 ]; then
+if [ $EUID -eq 0 ]; then
     export MODULEPATH=%{OHPC_ADMIN}/modulefiles:%{OHPC_MODULES}
 else
     export MODULEPATH=%{OHPC_MODULES}
@@ -113,9 +113,9 @@ fi
 
 # Add : to MANPATH to not drop default search paths, then safely append Lmod's
 # man directory using addto helper
-export MANPATH="\${MANPATH}:"
+export MANPATH="${MANPATH}:"
 
-export MANPATH=\$(%{OHPC_ADMIN}/lmod/lmod/libexec/addto MANPATH %{OHPC_ADMIN}/lmod/lmod/share/man)
+export MANPATH=$(%{OHPC_ADMIN}/lmod/lmod/libexec/addto MANPATH %{OHPC_ADMIN}/lmod/lmod/share/man)
 
 # Set BASH_ENV for environment
 export BASH_ENV=%{OHPC_ADMIN}/lmod/lmod/init/bash
@@ -128,7 +128,7 @@ module try-add ohpc
 
 EOF
 
-%{__cat} << EOF > %{buildroot}/%{_sysconfdir}/profile.d/lmod.csh
+%{__cat} << 'EOF' > %{buildroot}/%{_sysconfdir}/profile.d/lmod.csh
 #!/bin/csh
 # -*- shell-script -*-
 ########################################################################
@@ -137,11 +137,11 @@ EOF
 #
 ########################################################################
 
-if ( \$?SLURM_NODELIST ) then
+if ( $?SLURM_NODELIST ) then
     exit 0
 endif
 
-if ( \$?PBS_NODEFILE ) then
+if ( $?PBS_NODEFILE ) then
     exit 0
 endif
 
@@ -151,7 +151,7 @@ setenv LMOD_COLORIZE "no"
 setenv LMOD_PREPEND_BLOCK "normal"
 
 
-if ( \`id -u\` == "0" ) then
+if ( `id -u` == "0" ) then
    setenv MODULEPATH "%{OHPC_ADMIN}/modulefiles:%{OHPC_MODULES}"
 else
    setenv MODULEPATH "%{OHPC_MODULES}"
@@ -159,7 +159,11 @@ endif
 
 # Add : to MANPATH to not drop default search paths, then safely append Lmod's
 # man directory using addto helper
-setenv MANPATH "\${MANPATH}:"
+if ( $?MANPATH ) then
+    setenv MANPATH "${MANPATH}:"
+else
+    setenv MANPATH ":"
+endif
 setenv MANPATH `%{OHPC_ADMIN}/lmod/lmod/libexec/addto MANPATH %{OHPC_ADMIN}/lmod/lmod/share/man`
 
 # Initialize modules system


### PR DESCRIPTION
This fixes #2139 

Escaping everything needed is tricky, so switched to using `'EOF'`.   In the current version the backticks in the MANPATH command were not escaped and so evaluated to `` when building the RPM.

I don't think the `.tar.gz#$` is really needed, but I can re-add if the change breaks your workflow.  It's presence broke mine.

I still think it's not great to unconditionally append `:` to MANPATH - what if it was already present?