### PR TITLE
Fix OpenHPC version and other documentation fixes

### DIFF
--- a/docs/recipes/install/common/ohpc-doc.sty
+++ b/docs/recipes/install/common/ohpc-doc.sty
@@ -45,7 +45,7 @@
 % ----------- Variables to change per release -------------
 
 
-\newcommand{\OHPCVersion}{3.2}
+\newcommand{\OHPCVersion}{3.4}
 \newcommand{\OHPCVerTree}{3}
 %\newcommand{\OHPCReleaseCand}{RC1}
 

--- a/docs/recipes/install/common/warewulf4_add_to_compute_chroot_slurm.tex
+++ b/docs/recipes/install/common/warewulf4_add_to_compute_chroot_slurm.tex
@@ -1,6 +1,6 @@
 % begin_ohpc_run
 % ohpc_validation_comment Add SLURM and other components to compute instance
-\begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true,literate={BOSVER}{\baseos{}}1]
+\begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true,keepspaces,literate={BOSVER}{\baseos{}}1]
   [sms](*\#*) wwctl image exec --build=false BOSVER /bin/bash <<- EOF
     # Add Slurm client support meta-package and enable munge and slurmd
     dnf -y install ohpc-slurm-client


### PR DESCRIPTION
* Bump documentation version displayed to ~3.3~ 3.4 from 3.2 
* Add missing space in rendered PDF

Fixes: #2144