### PR TITLE
Different cosmetic changes for containers subdirectories

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -46,6 +46,7 @@ jobs:
         globs: |
           README.md
           CONTRIBUTING.md
+          containers/README.md
 
   lint:
     strategy:

--- a/containers/README.md
+++ b/containers/README.md
@@ -1,57 +1,78 @@
 # OpenHPC 3.x with Slurm running Rocky9 in a container
 
-This is a simple single-user container environment for learning and testing Slurm on OpenHPC 3.x with Rocky9.
+This is a simple single-user container environment for learning and testing
+Slurm on OpenHPC 3.x with Rocky9.
 
-The cluster contains a head node, login node, and 8 compute nodes as separate containers with a shared docker network and shared docker storage.  The containers are named `openhpc-head`, `openhpc-login` and `openhpc-node-[0-7]` respectively and will overwrite/delete any local containers with those names.  Shared storage is in /project and /scratch in volumes `openhpc-container-project` and `openhpc-container-scratch` respectively.  The /home directory is not shared.
+The cluster contains a head node, login node, and 8 compute nodes as separate
+containers with a shared docker network and shared docker storage.  The
+containers are named `openhpc-head`, `openhpc-login` and `openhpc-node-[0-7]`
+respectively and will overwrite/delete any local containers with those names.
+Shared storage is in /project and /scratch in volumes
+`openhpc-container-project` and `openhpc-container-scratch` respectively.  The
+/home directory is not shared.
 
 ## Run the cluster
 
-If you want to use podman or another container system with the same syntax as Docker, set the `CONTAINER` environment variable as follows:
+If you want to use podman or another container system with the same syntax as
+Docker, set the `CONTAINER` environment variable as follows:
 
 ```bash
 export CONTAINER=podman
 ```
 
 Build and Run the cluster with the following:
+
 ```bash
 ./run.sh
 ```
 
-This will create a Docker network and shared storage and start the cluster with 8 nodes and connect to the login node.  Exiting the shell will shutdown the cluster cleanly.
+This will create a Docker network and shared storage and start the cluster with
+8 nodes and connect to the login node.  Exiting the shell will shutdown the
+cluster cleanly.
 
-To connect to the cluster as if you were using `ssh login` use the following in a new terminal:
+To connect to the cluster as if you were using `ssh login` use the following in
+a new terminal:
+
 ```bash
 ./ssh.sh
 ```
 
-To login to the head node as root run the following in a separate terminal (everything will be lost when exiting from `./run.sh`):
+To login to the head node as root run the following in a separate terminal
+(everything will be lost when exiting from `./run.sh`):
+
 ```bash
 USER=root ./ssh.sh
 ```
 
 When you are done run the following:
+
 ```bash
 ./delete.sh
 ```
 
-This will remove the container cluster network, storage, and container images.  You may want to prune the container images as well.
+This will remove the container cluster network, storage, and container images.
+You may want to prune the container images as well.
 
 ## Examples
 
 Copy examples to project folder
 
-If you have rsync installed locally (look at ./rsync.sh for details), run in a new local terminal:
+If you have rsync installed locally (look at ./rsync.sh for details), run in a
+new local terminal:
+
 ```bash
 ./rsync.sh -av ./examples openhpc-login:/project/$USER/
 ```
 
 If you don't have rsync
+
 ```bash
 docker cp examples openhpc-login:/project/$USER/
 docker exec -i openhpc-login chown -R $USER:$USER /project/$USER
 ```
 
 And run the MPI example
+
 ```bash
 cd /project/$USER/examples/mpi
 bash run.sh

--- a/containers/README.md
+++ b/containers/README.md
@@ -2,7 +2,7 @@
 
 This is a simple single-user container environment for learning and testing Slurm on OpenHPC 3.x with Rocky9.
 
-The cluster contains a head node, login node, and 8 compute nodes as separate containers with a shared docker network and shared docker storage.  The containers are named `openhpc-head`, `openhpc-login` and `openhpc-node-[0-7]` respectively and will overwrite/delete any local containers with those names.  Shared storage is in /project and /scratch in volumes `openhpc-container-project` and `openhpc-container-scratch` respectively.  The /home directory is not shared. 
+The cluster contains a head node, login node, and 8 compute nodes as separate containers with a shared docker network and shared docker storage.  The containers are named `openhpc-head`, `openhpc-login` and `openhpc-node-[0-7]` respectively and will overwrite/delete any local containers with those names.  Shared storage is in /project and /scratch in volumes `openhpc-container-project` and `openhpc-container-scratch` respectively.  The /home directory is not shared.
 
 ## Run the cluster
 

--- a/containers/build.sh
+++ b/containers/build.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 
 container=${CONTAINER:-docker}
-user=${USER:-$USER}
+user=${USER:-${USER}}
 arch=$(uname -m)
 
-echo "=== setup $container"
-$container volume create openhpc-container-project
-$container network create openhpc-container-network
+echo "=== setup ${container}"
+"${container}" volume create openhpc-container-project
+"${container}" network create openhpc-container-network
 
 set -e
 echo '=== build openhpc'
-$container build -t openhpc/openhpc:3 -f openhpc/Containerfile openhpc \
-  --build-arg USER=$user \
-  --build-arg ARCH=${arch/arm64/aarch64}
+"${container}" build -t openhpc/openhpc:3 -f openhpc/Containerfile openhpc \
+	--build-arg USER="${user}" \
+	--build-arg ARCH="${arch/arm64/aarch64}"
 
-for I in container head node ; do
-  echo "=== build $I"
-  $container build -t openhpc/$I -f $I/Containerfile --build-arg USER=$user $I
+for I in container head node; do
+	echo "=== build ${I}"
+	"${container}" build -t openhpc/"${I}" -f "${I}"/Containerfile --build-arg USER="${user}" "${I}"
 done

--- a/containers/container/Containerfile
+++ b/containers/container/Containerfile
@@ -31,7 +31,7 @@ RUN dnf install -y ohpc-base-compute lmod-ohpc \
     git patch file zstd bzip2 xz \
     python3 python3-pip \
     gcc-c++ gcc-gfortran \
-    ohpc-gnu13-runtimes gnu13-compilers-ohpc \ 
+    ohpc-gnu13-runtimes gnu13-compilers-ohpc \
     openmpi5-pmix-gnu13-ohpc openblas-gnu13-ohpc netcdf-gnu13-openmpi5-ohpc
 
 ## Compilers, runtimes, and libraries.

--- a/containers/container/Containerfile
+++ b/containers/container/Containerfile
@@ -44,6 +44,9 @@ RUN dnf install -y spack-ohpc ohpc-gnu13-openmpi5-parallel-libs \
 RUN passwd -d $USER && \
   echo "$USER ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers.d/20-$USER
 
+RUN dnf clean all && \
+    rm -rf /var/cache/dnf /var/log/dnf.librepo.log /var/log/dnf.rpm.log /var/log/hawkey.log
+
 ## User entry point
 WORKDIR /home/$USER
 USER $USER:$USER

--- a/containers/container/Containerfile
+++ b/containers/container/Containerfile
@@ -31,12 +31,12 @@ RUN dnf install -y ohpc-base-compute lmod-ohpc \
     git patch file zstd bzip2 xz \
     python3 python3-pip \
     gcc-c++ gcc-gfortran \
-    ohpc-gnu13-runtimes gnu13-compilers-ohpc \
-    openmpi5-pmix-gnu13-ohpc openblas-gnu13-ohpc netcdf-gnu13-openmpi5-ohpc
+    ohpc-gnu14-runtimes gnu14-compilers-ohpc \
+    openmpi5-pmix-gnu14-ohpc openblas-gnu14-ohpc netcdf-gnu14-openmpi5-ohpc
 
 ## Compilers, runtimes, and libraries.
-RUN dnf install -y spack-ohpc ohpc-gnu13-openmpi5-parallel-libs \
-    ohpc-gnu13-python-libs ohpc-gnu13-runtimes
+RUN dnf install -y spack-ohpc ohpc-gnu14-openmpi5-parallel-libs \
+    ohpc-gnu14-python-libs ohpc-gnu14-runtimes
 
 ### Container configuration (unique to this container)
 

--- a/containers/delete.sh
+++ b/containers/delete.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 container=${CONTAINER:-docker}
-echo "=== delete.sh $container"
+echo "=== delete.sh ${container}"
 
-$container kill openhpc-login
-for I in {0..7} ; do
-  $container kill openhpc-node-$I
+"${container}" kill openhpc-login
+for I in {0..7}; do
+	"${container}" kill openhpc-node-"${I}"
 done
-$container kill openhpc-head
+"${container}" kill openhpc-head
 
-$container volume rm openhpc-container-project
-$container network rm openhpc-container-network
-$container image rm openhpc/node:latest openhpc/head:latest openhpc/openhpc:3
+"${container}" volume rm openhpc-container-project
+"${container}" network rm openhpc-container-network
+"${container}" image rm openhpc/node:latest openhpc/head:latest openhpc/openhpc:3

--- a/containers/examples/mpi/mpi.c
+++ b/containers/examples/mpi/mpi.c
@@ -3,27 +3,28 @@
 
 // mpicc mpi.c -o mpi
 
-int main(int argc, char** argv) {
-    // Initialize the MPI environment
-    MPI_Init(NULL, NULL);
+int main(int argc, char **argv)
+{
+	// Initialize the MPI environment
+	MPI_Init(NULL, NULL);
 
-    // Get the number of processes
-    int world_size;
-    MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+	// Get the number of processes
+	int world_size;
+	MPI_Comm_size(MPI_COMM_WORLD, &world_size);
 
-    // Get the rank of the process
-    int world_rank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+	// Get the rank of the process
+	int world_rank;
+	MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
 
-    // Get the name of the processor
-    char processor_name[MPI_MAX_PROCESSOR_NAME];
-    int name_len;
-    MPI_Get_processor_name(processor_name, &name_len);
+	// Get the name of the processor
+	char processor_name[MPI_MAX_PROCESSOR_NAME];
+	int name_len;
+	MPI_Get_processor_name(processor_name, &name_len);
 
-    // Print off a hello world message
-    printf("Hello world from processor %s, rank %d out of %d processors\n",
-           processor_name, world_rank, world_size);
+	// Print off a hello world message
+	printf("Hello world from processor %s, rank %d out of %d processors\n",
+	       processor_name, world_rank, world_size);
 
-    // Finalize the MPI environment.
-    MPI_Finalize();
+	// Finalize the MPI environment.
+	MPI_Finalize();
 }

--- a/containers/node/Containerfile
+++ b/containers/node/Containerfile
@@ -16,4 +16,7 @@ RUN dnf install -y ohpc-slurm-client
 RUN dnf install -y spack-ohpc ohpc-gnu13-openmpi5-parallel-libs \
     ohpc-gnu13-python-libs ohpc-gnu13-runtimes
 
+RUN dnf clean all && \
+    rm -rf /var/cache/dnf /var/log/dnf.librepo.log /var/log/dnf.rpm.log /var/log/hawkey.log
+
 CMD ["/bin/bash", "-c", "sudo -u munge /usr/sbin/munged -f && while ! /usr/sbin/slurmd -D -s --conf-server head ; do sleep 2 ; done"]

--- a/containers/node/Containerfile
+++ b/containers/node/Containerfile
@@ -6,7 +6,7 @@ RUN dnf install -y ohpc-base-compute lmod-ohpc \
     git patch file zstd bzip2 xz \
     python3 python3-pip \
     gcc-c++ gcc-gfortran \
-    ohpc-gnu13-runtimes gnu13-compilers-ohpc \ 
+    ohpc-gnu13-runtimes gnu13-compilers-ohpc \
     openmpi5-pmix-gnu13-ohpc openblas-gnu13-ohpc netcdf-gnu13-openmpi5-ohpc
 
 ## Scheduler

--- a/containers/node/Containerfile
+++ b/containers/node/Containerfile
@@ -6,15 +6,15 @@ RUN dnf install -y ohpc-base-compute lmod-ohpc \
     git patch file zstd bzip2 xz \
     python3 python3-pip \
     gcc-c++ gcc-gfortran \
-    ohpc-gnu13-runtimes gnu13-compilers-ohpc \
-    openmpi5-pmix-gnu13-ohpc openblas-gnu13-ohpc netcdf-gnu13-openmpi5-ohpc
+    ohpc-gnu14-runtimes gnu14-compilers-ohpc \
+    openmpi5-pmix-gnu14-ohpc openblas-gnu14-ohpc netcdf-gnu14-openmpi5-ohpc
 
 ## Scheduler
 RUN dnf install -y ohpc-slurm-client
 
 ## Compilers, runtimes, and libraries.
-RUN dnf install -y spack-ohpc ohpc-gnu13-openmpi5-parallel-libs \
-    ohpc-gnu13-python-libs ohpc-gnu13-runtimes
+RUN dnf install -y spack-ohpc ohpc-gnu14-openmpi5-parallel-libs \
+    ohpc-gnu14-python-libs ohpc-gnu14-runtimes
 
 RUN dnf clean all && \
     rm -rf /var/cache/dnf /var/log/dnf.librepo.log /var/log/dnf.rpm.log /var/log/hawkey.log

--- a/containers/rsync.sh
+++ b/containers/rsync.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 container=${CONTAINER:-docker}
-exec rsync -e "$container exec -i --user $USER:$USER" $*
+# shellcheck disable=SC2048,SC2086
+exec rsync -e "${container} exec -i --user ${USER}:${USER}" $*

--- a/containers/run.sh
+++ b/containers/run.sh
@@ -1,23 +1,23 @@
 #!/bin/bash
 
 container=${CONTAINER:-docker}
-CONTAINER=$container ./build.sh
+CONTAINER="${container}" ./build.sh
 network=--network=openhpc-container-network
 volume=--volume=openhpc-container-project:/project
 
-echo "=== Start cluster $container"
-$container run -d --rm $network $volume --name=openhpc-head --hostname=head openhpc/head
-$container run -d --rm $network $volume --name=openhpc-login --hostname=login openhpc/node
-for I in {0..7} ; do
-  $container run -d --rm $network $volume --name=openhpc-node-$I --hostname=node-$I openhpc/node
+echo "=== Start cluster ${container}"
+"${container}" run -d --rm "${network}" "${volume}" --name=openhpc-head --hostname=head openhpc/head
+"${container}" run -d --rm "${network}" "${volume}" --name=openhpc-login --hostname=login openhpc/node
+for I in {0..7}; do
+	"${container}" run -d --rm "${network}" "${volume}" --name=openhpc-node-"${I}" --hostname=node-"${I}" openhpc/node
 done
 
 echo '=== Login Node (exit to shutdown cluster)'
 ./ssh.sh
 
 echo '=== Stop cluster'
-for I in {0..7} ; do
-  $container kill openhpc-node-$I
+for I in {0..7}; do
+	"${container}" kill openhpc-node-"${I}"
 done
-$container kill openhpc-login
-$container kill openhpc-head
+"${container}" kill openhpc-login
+"${container}" kill openhpc-head

--- a/containers/ssh.sh
+++ b/containers/ssh.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 container=${CONTAINER:-docker}
-exec $container exec -it openhpc-login sudo -u $USER -i $*
+# shellcheck disable=SC2048,SC2086
+exec "${container}" exec -it openhpc-login sudo -u "${USER}" -i $*

--- a/tests/ci/Makefile
+++ b/tests/ci/Makefile
@@ -5,6 +5,7 @@ codespell-lint:
 	cd ../..; codespell $$(find components -name "*.spec") \
 		README.md \
 		CONTRIBUTING.md \
+		containers/README \
 		../../tests/ci/check_spec.py \
 		../../tests/ci/run_build.py \
 		../../misc/build_order.py \

--- a/tests/ci/Makefile
+++ b/tests/ci/Makefile
@@ -95,6 +95,7 @@ whitespace-lint:
 		tests/libs/ptscotch/tests/test_module \
 		tests/libs/boost-mpi/tests/mpi/test/rm_execution \
 		tests/libs/plasma/tests/* \
+		containers/* \
 		\*.tex
 
 shellcheck-lint:
@@ -119,7 +120,9 @@ shellcheck-lint:
 		../../tests/libs/netcdf/ohpc-tests/netcdf_all_test_mpi_families \
 		../../tests/libs/hdf5/ohpc-tests/test_compiler_families \
 		../../tests/libs/phdf5/ohpc-tests/test_mpi_families \
-		../../tests/libs/netcdf/ohpc-tests/test_mpi_families
+		../../tests/libs/netcdf/ohpc-tests/test_mpi_families \
+		../../containers/*.sh \
+		../../containers/examples/mpi/*.sh
 	shellcheck --exclude=SC2239,SC1091 \
 		../../tests/apps/hpcg/run \
 		../../tests/dev-tools/cuda/cuda \
@@ -203,7 +206,9 @@ shfmt-lint:
 		../../tests/libs/phdf5/ohpc-tests/test_mpi_families \
 		../../components/compiler-families/intel-compilers-devel/SOURCES/ohpc-update-modules-intel \
 		../../components/mpi-families/impi-devel/SOURCES/ohpc-update-modules-impi \
-		../../components/rms/slurm/SOURCES/slurm.epilog.clean
+		../../components/rms/slurm/SOURCES/slurm.epilog.clean \
+		../../containers/*.sh \
+		../../containers/examples/mpi/*.sh
 
 clang-format-lint:
 	@echo "Running 'clang-format' on selected source code files"
@@ -219,4 +224,5 @@ clang-format-lint:
 		../libs/phdf5/tests/C_mpi_test.c \
 		../dev-tools/cuda/add.cu \
 		../../tests/libs/plasma/tests/*.c \
-		../../tests/libs/plasma/tests/*.h
+		../../tests/libs/plasma/tests/*.h \
+		../../containers/examples/mpi/mpi.c


### PR DESCRIPTION
* This renames the ReadMe.md file to README.md as this is what we already use in the main directory.
* Apply our linting rules to shell scripts and C code
* Run README.md through the markdown checker
* cleanup temporary dnf files in the containers (decreases size by at least 120MB)
* switch to gnu14

@middelkoopt I made a couple of changes to the containers subdirectory. Please take a look if this all still makes sense to you? Let me know if you prefer some things to be changed back again.