### PR TITLE
chore(hwloc): update version to 2.12.1

### DIFF
--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -64,6 +64,12 @@ BuildRequires: ohpc-buildroot
 %{!?mpi_family: %global mpi_family openmpi5}
 %{!?python_family: %global python_family python3}
 
+# Disable warning during build concerning source_date_epoch_from_changelog
+%if 0%{?rhel} >= 10
+%undefine source_date_epoch_from_changelog
+%global __brp_check_rpaths %{nil}
+%endif
+
 # Compiler dependencies
 %if 0%{?ohpc_compiler_dependent} == 1
 
@@ -115,12 +121,6 @@ Requires:      llvm-compilers%{PROJ_DELIM} >= 9.0.0
 %if 0%{?rhel} >= 8
 %undefine _annotated_build
 %endif
-
-# Disable warning during build concerning source_date_epoch_from_changelog
-%if 0%{?rhel} >= 10
-%undefine source_date_epoch_from_changelog
-%endif
-
 %endif
 
 # Disable generation of .build-id links

--- a/components/dev-tools/hwloc/SPECS/hwloc.spec
+++ b/components/dev-tools/hwloc/SPECS/hwloc.spec
@@ -13,7 +13,7 @@
 %define pname hwloc
 
 Name:           %{pname}%{PROJ_DELIM}
-Version:        2.12.0
+Version:        2.12.1
 Release:        %{?dist}.1
 Summary:        Portable Hardware Locality
 License:        BSD-3-Clause
@@ -29,8 +29,6 @@ BuildRequires:  libtool
 BuildRequires:  cairo-devel
 BuildRequires:  libxml2-devel
 BuildRequires:  ncurses-devel
-BuildRequires:  ncurses-devel
-BuildRequires:  transfig
 %if 0%{?sle_version}
 BuildRequires:  libnuma-devel
 %else


### PR DESCRIPTION
Update hwloc package version from 2.12.0 to 2.12.1 in the spec file. Also remove duplicate BuildRequires and transfig.

Assisted-by: Gemini 2.5 Flash