### PR TITLE
feat(compiler): set optimization baseline to x86-64-v3 for RHEL 10

### DIFF
--- a/components/OHPC_setup_compiler
+++ b/components/OHPC_setup_compiler
@@ -120,8 +120,8 @@ if [ "${arch}" == "x86_64" ]; then
 		# shellcheck disable=SC1091
 		. /etc/os-release
 		if [ -n "${PLATFORM_ID}" ] && [ "${PLATFORM_ID}" == "platform:el9" ]; then
-			# Only RHEL 9 has switched to the optimization baseline 'x86-64-v2'
-			ARCH_OPTS="${ARCH_OPTS} -march=x86-64-v2"
+			# RHEL 10 has switched to the optimization baseline 'x86-64-v3'
+			ARCH_OPTS="${ARCH_OPTS} -march=x86-64-v3"
 		fi
 	fi
 fi


### PR DESCRIPTION
Update compiler optimization flags for RHEL 10 to utilize the 'x86-64-v3' architecture. This change aligns with the platform's optimization baseline.