### PR TITLE
Add a test for parse_doc.pl

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -363,3 +363,15 @@ jobs:
         name: event-file
         retention-days: 1
         path: ${{ github.event_path }}
+
+  test_parse_doc:
+    name: Run bats tests
+    runs-on: ubuntu-latest
+    container:
+      image: registry.fedoraproject.org/fedora:latest
+    steps:
+    - name: Setup
+      run: dnf -y install bats
+    - uses: actions/checkout@v4
+    - name: Run bats tests
+      run: ./tests/ci/test_parse_doc.bats

--- a/tests/ci/Makefile
+++ b/tests/ci/Makefile
@@ -12,6 +12,7 @@ codespell-lint:
 		misc/build_order.py \
 		misc/obs/obs_config.py \
 		tests/ci/spec_to_test_mapping.py \
+		tests/ci/test_parse_doc.bats \
 		components/admin/prun/SOURCES/prun \
 		components/rms/slurm/SOURCES/slurm.epilog.clean \
 		tests/common/functions \
@@ -59,6 +60,7 @@ flake8-lint:
 whitespace-lint:
 	@echo "Checking spec files for trailing whitespaces"
 	cd ../../; ! git --no-pager grep -E '\s+$$' \*.spec \
+		tests/ci/test_parse_doc.bats \
 		components/admin/prun/SOURCES/prun \
 		components/compiler-families/intel-compilers-devel/SOURCES/ohpc-update-modules-intel \
 		components/mpi-families/impi-devel/SOURCES/ohpc-update-modules-impi \
@@ -110,6 +112,7 @@ shellcheck-lint:
 		../../misc/shell-functions \
 		../../tests/ci/prepare-ci-environment.sh \
 		../../tests/ci/setup_slurm_and_run_tests.sh \
+		../../tests/ci/test_parse_doc.bats \
 		../../tests/common/functions \
 		../../components/OHPC_setup_compiler \
 		../../components/OHPC_setup_mpi \
@@ -165,6 +168,7 @@ shfmt-lint:
 	@echo "Running 'shfmt' on selected shell scripts"
 	shfmt \
 		-w -d -ln bats \
+		../../tests/ci/test_parse_doc.bats \
 		../../tests/apps/hpcg/run \
 		../../tests/dev-tools/cuda/cuda \
 		../../tests/dev-tools/cmake/test_cmake \

--- a/tests/ci/test_parse_doc.bats
+++ b/tests/ci/test_parse_doc.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env -S bats --report-formatter junit
+
+setup() {
+	TMPDIR=$(mktemp -d)
+	TEST_TEX_FILE="${TMPDIR}/test.tex"
+	INCLUDED_FILE="${TMPDIR}/included.tex"
+	PARSE_DOC_SCRIPT="$(pwd)/docs/recipes/install/parse_doc.pl"
+}
+
+teardown() {
+	rm -rf "${TMPDIR}"
+}
+
+@test "Test input handling" {
+	cat >"${TEST_TEX_FILE}" <<EOF
+\\newcommand{\\install}{'install'}
+\\newcommand{\\chrootinstall}{'chrootinstall'}
+\\newcommand{\\groupinstall}{'groupinstall'}
+\\newcommand{\\groupchrootinstall}{'groupchrootinstall'}
+\\input{included.tex}
+% begin_ohpc_run
+[sms](*\\#*) echo "Main file command"
+% end_ohpc_run
+EOF
+
+	cat >"${INCLUDED_FILE}" <<EOF
+% begin_ohpc_run
+[sms](*\\#*) echo "Included file command"
+% end_ohpc_run
+EOF
+
+	run "${PARSE_DOC_SCRIPT}" "${TEST_TEX_FILE}"
+	[ "${status}" -eq 0 ]
+	echo "${output}" | grep -q 'echo "Main file command"'
+	echo "${output}" | grep -q 'echo "Included file command"'
+}
+
+@test "Test HERE document handling" {
+	echo -e "\\\\newcommand{\\\\install}{'install'}\n\\\\newcommand{\\\\chrootinstall}{'chrootinstall'}\n\\\\newcommand{\\\\groupinstall}{'groupinstall'}\n\\\\newcommand{\\\\groupchrootinstall}{'groupchrootinstall'}\n% begin_ohpc_run\n[sms](*\\\\#*) cat <<-EOF > /tmp/test.txt\nline 1\nline 2\nEOF\n% end_ohpc_run" >"${TEST_TEX_FILE}"
+
+	run "${PARSE_DOC_SCRIPT}" "${TEST_TEX_FILE}"
+	[ "${status}" -eq 0 ]
+	echo "${output}" | grep -Fq "cat <<-EOF > /tmp/test.txt"
+	echo "${output}" | grep -q "line 1"
+	echo "${output}" | grep -q "line 2"
+	echo "${output}" | grep -q "EOF"
+}
+
+@test "Test line continuation handling" {
+	cat >"${TEST_TEX_FILE}" <<EOF
+\\newcommand{\\install}{'install'}
+\\newcommand{\\chrootinstall}{'chrootinstall'}
+\\newcommand{\\groupinstall}{'groupinstall'}
+\\newcommand{\\groupchrootinstall}{'groupchrootinstall'}
+% begin_ohpc_run
+[sms](*\\#*) echo \\
+"Hello, \\
+World!"
+% end_ohpc_run
+EOF
+
+	run "${PARSE_DOC_SCRIPT}" "${TEST_TEX_FILE}"
+	[ "${status}" -eq 0 ]
+	echo "${output}" | grep -q "echo \"Hello, \\\\"
+}
+
+@test "Test ARCH handling" {
+	cat >"${TEST_TEX_FILE}" <<EOF
+\\newcommand{\\install}{'install'}
+\\newcommand{\\chrootinstall}{'chrootinstall'}
+\\newcommand{\\groupinstall}{'groupinstall'}
+\\newcommand{\\groupchrootinstall}{'groupchrootinstall'}
+\\newcommand{\\arch}{x86_64}
+% begin_ohpc_run
+[sms](*\\#*) echo "ARCH is ARCH"
+% end_ohpc_run
+EOF
+
+	run "${PARSE_DOC_SCRIPT}" "${TEST_TEX_FILE}"
+	[ "${status}" -eq 0 ]
+	echo "${output}" | grep -q 'echo "x86_64 is ARCH"'
+}


### PR DESCRIPTION
This commit adds bats tests to verify the functionality of the parse_doc.pl script, covering input handling, HERE document handling, line continuation, and ARCH substitution.