### PR TITLE
feat(warewulf): add templates and patches for warewulf

### DIFF
--- a/components/admin/examples/SOURCES/NetworkManager-wait-online.service.d.override.conf
+++ b/components/admin/examples/SOURCES/NetworkManager-wait-online.service.d.override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/bin/nm-online -q

--- a/components/admin/examples/SOURCES/chrony.conf.ww
+++ b/components/admin/examples/SOURCES/chrony.conf.ww
@@ -1,0 +1,1 @@
+server {{.Tags.ntpserver}} iburst

--- a/components/admin/examples/SOURCES/slurmd.ww
+++ b/components/admin/examples/SOURCES/slurmd.ww
@@ -1,0 +1,1 @@
+SLURMD_OPTIONS='--conf-server {{.Tags.slurmctld}}'

--- a/components/admin/examples/SPECS/examples.spec
+++ b/components/admin/examples/SPECS/examples.spec
@@ -30,7 +30,9 @@ Source9:  compute.cfg
 Source10: example.modulefile
 Source11: example-mpi-dependent.modulefile
 Source12: ifcfg-ib0.centos
-
+Source13: chrony.conf.ww
+Source14: NetworkManager-wait-online.service.d.override.conf
+Source15: slurmd.ww
 
 %description
 
@@ -40,8 +42,6 @@ OpenHPC development environment.
 %prep
 
 %{__cp} %SOURCE0 .
-
-%build
 
 %install
 
@@ -56,6 +56,9 @@ install -D -m 0644 %SOURCE7  %{buildroot}%{OHPC_HOME}/pub/examples/ganglia/gmond
 install -D -m 0644 %SOURCE8  %{buildroot}%{OHPC_HOME}/pub/examples/openpbs/job.mpi
 install -D -m 0644 %SOURCE10 %{buildroot}%{OHPC_HOME}/pub/examples/example.modulefile
 install -D -m 0644 %SOURCE11 %{buildroot}%{OHPC_HOME}/pub/examples/example-mpi-dependent.modulefile
+install -D -m 0644 %SOURCE13 %{buildroot}%{OHPC_HOME}/pub/examples/chrony.conf.ww
+install -D -m 0644 %SOURCE14 %{buildroot}%{OHPC_HOME}/pub/examples/network/NetworkManager-wait-online.service.d/override.conf
+install -D -m 0644 %SOURCE15  %{buildroot}%{OHPC_HOME}/pub/examples/slurm/slurmd.ww
 
 %{__mkdir_p} ${RPM_BUILD_ROOT}/%{_docdir}
 

--- a/components/provisioning/warewulf/SOURCES/hosts.ww.patch
+++ b/components/provisioning/warewulf/SOURCES/hosts.ww.patch
@@ -1,0 +1,11 @@
+--- a/overlays/host/rootfs/etc/hosts.ww.orig	2025-07-15 17:50:42.920000000 +0000
++++ b/overlays/host/rootfs/etc/hosts.ww	2025-07-15 17:51:17.214024833 +0000
+@@ -10,7 +10,7 @@
+ {{- range $devname, $netdev := $node.NetDevs}}{{/* for each network device on the node */}}
+ {{- if $netdev.Ipaddr}}{{/* if we have an ip address on this network device */}}
+ {{- /* emit the node name as hostname if this is the primary */}}
+-{{$netdev.Ipaddr}} {{if $netdev.Primary}}{{$node.Id}}{{end}} {{$node.Id}}-{{$devname}} {{if $netdev.Device}}{{$node.Id}}-{{$netdev.Device}}{{end}}
++{{$netdev.Ipaddr}} {{if $netdev.Primary}}{{$node.Id}}.localdomain {{$node.Id}}{{end}} {{$node.Id}}-{{$devname}} {{if $netdev.Device}}{{$node.Id}}-{{$netdev.Device}}{{end}}
+ {{- end }}{{/* if ip */}}
+ {{- end }}{{/* for each network device */}}
+ {{- end }}{{/* for each node */}}

--- a/components/provisioning/warewulf/SPECS/warewulf.spec
+++ b/components/provisioning/warewulf/SPECS/warewulf.spec
@@ -44,6 +44,8 @@ License: BSD-3-Clause
 Group:   %{PROJ_NAME}/provisioning
 URL:     https://github.com/warewulf/warewulf
 Source0: https://github.com/warewulf/warewulf/releases/download/v%{version}/warewulf-%{version}.tar.gz
+# OpenHPC modifications to the warewulf template files
+Patch0:  hosts.ww.patch
 
 ExclusiveOS: linux
 
@@ -105,6 +107,7 @@ system for large clusters of bare metal and/or virtual systems.
 
 %prep
 %setup -q -n %{pname}-%{version} -b0 %if %{?with_offline:-a2}
+%patch -P 0 -p1
 
 
 %build

--- a/docs/recipes/install/common/import_ww4_files.tex
+++ b/docs/recipes/install/common/import_ww4_files.tex
@@ -12,16 +12,13 @@ handled in this way by default.  Here we add directories and files to the
 [sms](*\#*) wwctl overlay import --parents nodeconfig /etc/subgid
 
 # Identify master host as local NTP server, configure it with a template with a Tag
-[sms](*\#*) echo 'server {{.Tags.ntpserver}} iburst' | \
-  wwctl overlay import --parents nodeconfig <(cat) /etc/chrony.conf.ww
+[sms](*\#*) wwctl overlay import --parents nodeconfig \
+ /opt/ohpc/pub/examples/chrony.conf.ww /etc/chrony.conf.ww
 [sms](*\#*) wwctl profile set --yes nodes --tagadd ntpserver=${sms_ip}
 
 # Configure systemd and NetworkManger to wait for the network to be fully up.
-[sms](*\#*) cat <<- EOF | wwctl overlay import --parents nodeconfig <(cat) \
-  /etc/systemd/system/NetworkManager-wait-online.service.d/override.conf
-[Service]
-ExecStart=
-ExecStart=/usr/bin/nm-online -q
-EOF
+[sms](*\#*) wwctl overlay import --parents nodeconfig \
+ /opt/ohpc/pub/examples/network/NetworkManager-wait-online.service.d/override.conf \
+ /etc/systemd/system/NetworkManager-wait-online.service.d/override.conf
 \end{lstlisting}
 % \end_ohpc_run

--- a/docs/recipes/install/common/import_ww4_files_slurm.tex
+++ b/docs/recipes/install/common/import_ww4_files_slurm.tex
@@ -5,8 +5,8 @@ on every host in the resource management pool, issue the following:
 % begin_ohpc_run
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true]
 # Configure Slurm server in the overlay (using "configless" option) using a tag in a template file (slurmd.ww)
-[sms](*\#*) echo SLURMD_OPTIONS='--conf-server {{.Tags.slurmctld}}' | \
-  wwctl overlay import --parents nodeconfig <(cat) /etc/sysconfig/slurmd.ww
+[sms](*\#*) wwctl overlay import --parents nodeconfig \
+ /opt/ohpc/pub/examples/slurm/slurmd.ww /etc/sysconfig/slurmd.ww
 
 # Set the value of the slurmctld tag to the $sms_ip for the nodes profile.
 [sms](*\#*) wwctl profile set --yes nodes --tagadd slurmctld=${sms_ip}

--- a/docs/recipes/install/common/warewulf4_setup_centos.tex
+++ b/docs/recipes/install/common/warewulf4_setup_centos.tex
@@ -28,11 +28,6 @@
 [sms](*\#*) wwctl profile set -y nodes --netname=default --gateway=${ipv4_gateway}
 [sms](*\#*) wwctl profile set -y nodes --netname=default --nettagadd=DNS=${dns_servers}
 
-# Update /etc/hosts template to have ${hostname}.localdomain as the first host entry
-[sms](*\#*) wwctl overlay import -o host \
-  <(sed -e 's_\({{$node.Id}}{{end}}\)_{{$node.Id}}.localdomain \1_g' \
-  /usr/share/warewulf/overlays/host/rootfs/etc/hosts.ww) /etc/hosts.ww
-
 # Configuring Warewulf will restart/enable relevant services to support provisioning
 [sms](*\#*) systemctl enable --now warewulfd
 [sms](*\#*) wwctl configure --all


### PR DESCRIPTION
This commit adds templates for chrony, networkmanager, and slurmd to the examples directory. It also adds a patch for the hosts.ww template to include the localdomain.

The templates are used to configure the nodes in the warewulf cluster. The patch is used to update the /etc/hosts file on the nodes.

All changes are trying to reduce the complexity in the recipe by creating files as needed by OpenHPC

@middelkoopt How do you feel about this approach? I tried to simplify a couple of steps in the recipes by creating the necessary files in examples package. This is based on what I saw for the InfiniBand configuration. I think the main advantage is reduced complexity in the commands provided in the recipe.