### PR TITLE
build(hpc-workspace): update hpcworkspace.spec file

### DIFF
--- a/components/admin/hpc-workspace/SPECS/hpcworkspace.spec
+++ b/components/admin/hpc-workspace/SPECS/hpcworkspace.spec
@@ -61,12 +61,13 @@ working filesystems in an HPC environment.
 
 %prep
 %setup -q -n %{pname}-%{version}
+sed -e 's,-Os",-Os -fPIE",g' -i CMakeLists.txt
 
 %build
 cmake \
   -DCMAKE_INSTALL_PREFIX=%{install_path} \
   .
-make
+make VERBOSE=1
 
 %install
 make DESTDIR=%{buildroot} install


### PR DESCRIPTION
Update hpcworkspace.spec to include necessary dependencies and adjustments for building and installing the HPC Workspace utility. This includes changes to CMakeLists.txt to add -fPIE flag and adjustments to the module file installation.