### PR TITLE
fix(ci): allow empty specfiles list for run_build.py

### DIFF
--- a/tests/ci/run_build.py
+++ b/tests/ci/run_build.py
@@ -22,7 +22,7 @@ parser.add_argument(
 parser.add_argument(
     'specfiles',
     help='list of specfiles to check',
-    nargs='+',
+    nargs='*',
 )
 parser.add_argument(
     '--compiler-family',


### PR DESCRIPTION
The run_build.py script now accepts an empty list of specfiles as a valid argument. This prevents errors when no specfiles are provided.