### PR TITLE
fix(openmpi): add explicit libfabric requirement

### DIFF
--- a/components/mpi-families/openmpi/SPECS/openmpi.spec
+++ b/components/mpi-families/openmpi/SPECS/openmpi.spec
@@ -59,6 +59,9 @@ BuildRequires:  pmix%{PROJ_DELIM}
 %endif
 %if 0%{with_ofi}
 BuildRequires:  libfabric-devel
+# OBS is not clever enough to always pull in the right
+# libfabric.so.1()(64bit) provider
+Requires: libfabric
 %if 0%{?rhel} || 0%{?openEuler}
 BuildRequires:  libibverbs-devel
 %endif


### PR DESCRIPTION
OBS doesn't always pull the correct libfabric provider. This adds an explicit requirement to ensure the correct library is used.