### PR TITLE
Fix warewulf documentation typo's (4.x)

### DIFF
--- a/docs/recipes/install/common/warewulf4_mkchroot.tex
+++ b/docs/recipes/install/common/warewulf4_mkchroot.tex
@@ -3,8 +3,8 @@ customize a system image that can subsequently be used to provision one or more
 {\em compute} nodes. The following subsections highlight this process.
 
 \subsubsection{Build initial BOS image} \label{sec:assemble_bos}
-\Warewulf{} 4 supports using image images as the base file system for
-provisioning, and it can import these images directly from an OCI registry like
+\Warewulf{} 4 supports using container images as the base file system for
+provisioning, and it can import these directly from an OCI registry like
 Docker Hub. Container images must be created especially for use with \Warewulf{}
 since they need to include things like a kernel and an init system. In this
 example we will import our base image from a set maintained by the \Warewulf{}


### PR DESCRIPTION
Thanks to @anderbubble for the catch.
