### PR TITLE
meta-packages: remove libpsm2 dependency for RHEL10 compatibility

### DIFF
--- a/components/admin/meta-packages/SPECS/meta-packages.spec
+++ b/components/admin/meta-packages/SPECS/meta-packages.spec
@@ -97,9 +97,6 @@ Requires:  librdmacm
 Requires:  NetworkManager
 Requires:  perl-interpreter
 Recommends: (singularity-ce or singularity or apptainer)
-%ifarch x86_64
-Requires:  libpsm2
-%endif
 %endif
 %if 0%{?openEuler}
 # For valgrind on openEuler we need to glibc-debuginfo on the compute nodes


### PR DESCRIPTION
libpsm2 has been removed from RHEL10, making this dependency unavailable for future OpenHPC releases targeting RHEL10-based distributions.

🤖 Generated with [Claude Code](https://claude.ai/code)