### PR TITLE
docs: update default compiler family from gnu14 to gnu15

### DIFF
--- a/docs/recipes/install/common/build_tables.pl
+++ b/docs/recipes/install/common/build_tables.pl
@@ -18,7 +18,7 @@ sub usage {
 
 my @ohpcCategories    = ("admin","compiler-families","dev-tools","distro-packages","io-libs","mpi-families",
                         "parallel-libs","serial-libs","perf-tools","provisioning","rms", "runtimes");
-my @compiler_familes = ("gnu","gnu7","intel","gnu8","gnu9","gnu12","gnu13","gnu14","arm1");
+my @compiler_familes = ("gnu","gnu7","intel","gnu8","gnu9","gnu12","gnu13","gnu14","gnu15","arm1");
 my @mpi_families     = ("mvapich2","openmpi","openmpi3","openmpi4","openmpi5","impi","mpich");
 
 my @single_package_exceptions = ();
@@ -77,11 +77,11 @@ $mpi_exceptions{"mkl-blacs"} = 1;
 my %page_breaks = ();
 if ( $ENV{'PWD'} =~ /\S+\/x86_64\// ) {
     $page_breaks{"mpiP-gnu-impi-ohpc"} = 2;
-    $page_breaks{"pdtoolkit-gnu14-ohpc"} = 2;
+    $page_breaks{"pdtoolkit-gnu15-ohpc"} = 2;
 #    $page_breaks{"pdtoolkit-gnu13-ohpc"} = 3;
-    $page_breaks{"pnetcdf-gnu14-impi-ohpc"} = 2;
-    $page_breaks{"mumps-gnu14-impi-ohpc"} = 2;
-    $page_breaks{"superlu_dist-gnu14-impi-ohpc"} = 3;
+    $page_breaks{"pnetcdf-gnu15-impi-ohpc"} = 2;
+    $page_breaks{"mumps-gnu15-impi-ohpc"} = 2;
+    $page_breaks{"superlu_dist-gnu15-impi-ohpc"} = 3;
 } elsif ( $ENV{'PWD'} =~ /\S+\/aarch64\// ) {
     $page_breaks{"scalapack-gnu9-mpich-ohpc"} = 2;
 }

--- a/docs/recipes/install/common/compilers.tex
+++ b/docs/recipes/install/common/compilers.tex
@@ -6,7 +6,7 @@ toolchain currently loaded.
 % begin_ohpc_run
 % ohpc_comment_header Install Compilers \ref{sec:install_compilers}
 \begin{lstlisting}[language=bash]
-[sms](*\#*) (*\install*) gnu14-compilers-ohpc
+[sms](*\#*) (*\install*) gnu15-compilers-ohpc
 \end{lstlisting}
 % end_ohpc_run
 

--- a/docs/recipes/install/common/component_list.pl
+++ b/docs/recipes/install/common/component_list.pl
@@ -36,7 +36,7 @@ my %ohpcCategoryHeadings = ('admin' => 'Administrative Tools',
 			    'serial-libs' => 'Serial / Threaded Libraries');
 			
 			 
-my @compiler_familes = ("gnu","gnu7","intel","gnu8","gnu9","gnu12","gnu13","gnu14","arm1");
+my @compiler_familes = ("gnu","gnu7","intel","gnu8","gnu9","gnu12","gnu13","gnu14","gnu15","arm1");
 my @mpi_families     = ("mvapich2","openmpi","openmpi3","openmpi4","impi","mpich");
 
 my @package_skip = ("ohpc-release","gnu-compilers","R_base","mvapich2-psm","openmpi-psm2","scotch",

--- a/docs/recipes/install/common/default_dev.tex
+++ b/docs/recipes/install/common/default_dev.tex
@@ -8,7 +8,7 @@ OpenMPI stack.
 
 % begin_ohpc_run
 \begin{lstlisting}[language=bash]
-[sms](*\#*) (*\install*) lmod-defaults-gnu14-openmpi5-ohpc
+[sms](*\#*) (*\install*) lmod-defaults-gnu15-openmpi5-ohpc
 \end{lstlisting}
 % end_ohpc_run
 
@@ -28,10 +28,10 @@ are as follows:
 \fi
 
 \begin{itemize*}
-\item lmod-defaults-gnu14-mpich-ofi-ohpc
-\item lmod-defaults-gnu14-mpich-ucx-ohpc
+\item lmod-defaults-gnu15-mpich-ofi-ohpc
+\item lmod-defaults-gnu15-mpich-ucx-ohpc
 \iftoggleverb{isx86}
-\item lmod-defaults-gnu14-mvapich2-ohpc
+\item lmod-defaults-gnu15-mvapich2-ohpc
 \fi
 \end{itemize*}
 \end{tcolorbox}

--- a/docs/recipes/install/common/mpi_aarch_openpbs.tex
+++ b/docs/recipes/install/common/mpi_aarch_openpbs.tex
@@ -7,7 +7,7 @@ fabrics.  These MPI stacks can be installed as follows:
 % ohpc_command if [[ ${enable_mpi_defaults} -eq 1 ]];then
 % ohpc_indent 5
 \begin{lstlisting}[language=bash]
-[sms](*\#*) (*\install*) openmpi5-gnu14-ohpc mpich-ofi-gnu14-ohpc
+[sms](*\#*) (*\install*) openmpi5-gnu15-ohpc mpich-ofi-gnu15-ohpc
 \end{lstlisting}
 % ohpc_indent 0
 % ohpc_command fi
@@ -30,7 +30,7 @@ instead as a drop-in MPICH replacement:
 % ohpc_command if [[ ${enable_mpich_ucx} -eq 1 ]];then
 % ohpc_indent 5
 \begin{lstlisting}[language=bash]
-[sms](*\#*) (*\install*) mpich-ucx-gnu14-ohpc
+[sms](*\#*) (*\install*) mpich-ucx-gnu15-ohpc
 \end{lstlisting}
 % ohpc_indent 0
 % ohpc_command fi
@@ -43,7 +43,7 @@ highlighted is below.
 \begin{lstlisting}[language=bash]
 [sms](*\#*) module avail mpich
 
--------------------- /opt/ohpc/pub/moduledeps/gnu14 ---------------------
+-------------------- /opt/ohpc/pub/moduledeps/gnu15 ---------------------
    mpich/3.4.3-ofi    mpich/3.4.3-ucx (D)
 \end{lstlisting}
 

--- a/docs/recipes/install/common/mpi_aarch_slurm.tex
+++ b/docs/recipes/install/common/mpi_aarch_slurm.tex
@@ -7,7 +7,7 @@ fabrics.  These MPI stacks can be installed as follows:
 % ohpc_command if [[ ${enable_mpi_defaults} -eq 1 ]];then
 % ohpc_indent 5
 \begin{lstlisting}[language=bash]
-[sms](*\#*) (*\install*) openmpi5-pmix-gnu14-ohpc mpich-ofi-gnu14-ohpc
+[sms](*\#*) (*\install*) openmpi5-pmix-gnu15-ohpc mpich-ofi-gnu15-ohpc
 \end{lstlisting}
 % ohpc_indent 0
 % ohpc_command fi
@@ -30,7 +30,7 @@ instead as a drop-in MPICH replacement:
 % ohpc_command if [[ ${enable_mpich_ucx} -eq 1 ]];then
 % ohpc_indent 5
 \begin{lstlisting}[language=bash]
-[sms](*\#*) (*\install*) mpich-ucx-gnu14-ohpc
+[sms](*\#*) (*\install*) mpich-ucx-gnu15-ohpc
 \end{lstlisting}
 % ohpc_indent 0
 % ohpc_command fi
@@ -43,7 +43,7 @@ highlighted is below.
 \begin{lstlisting}[language=bash]
 [sms](*\#*) module avail mpich
 
--------------------- /opt/ohpc/pub/moduledeps/gnu14 ---------------------
+-------------------- /opt/ohpc/pub/moduledeps/gnu15 ---------------------
    mpich/3.4.3-ofi    mpich/3.4.3-ucx (D)
 \end{lstlisting}
 

--- a/docs/recipes/install/common/mpi_openpbs.tex
+++ b/docs/recipes/install/common/mpi_openpbs.tex
@@ -42,7 +42,7 @@ MVAPICH2 (psm2) &                              &                                
 % ohpc_command if [[ ${enable_mpi_defaults} -eq 1 ]];then
 % ohpc_indent 5
 \begin{lstlisting}[language=bash]
-[sms](*\#*) (*\install*) openmpi5-gnu14-ohpc mpich-ofi-gnu14-ohpc
+[sms](*\#*) (*\install*) openmpi5-gnu15-ohpc mpich-ofi-gnu15-ohpc
 \end{lstlisting}
 % ohpc_indent 0
 % ohpc_command fi
@@ -62,7 +62,7 @@ semantics. Alternatively, a site can choose to install the {\texttt ucx} variant
 instead as a drop-in MPICH replacement:
 
 \begin{lstlisting}[language=bash]
-[sms](*\#*) (*\install*) mpich-ucx-gnu14-ohpc
+[sms](*\#*) (*\install*) mpich-ucx-gnu15-ohpc
 \end{lstlisting}
 
 In the case where both MPICH variants are installed, two modules will be
@@ -72,7 +72,7 @@ highlighted is below.
 \begin{lstlisting}[language=bash]
 [sms](*\#*) module avail mpich
 
--------------------- /opt/ohpc/pub/moduledeps/gnu14---------------------
+-------------------- /opt/ohpc/pub/moduledeps/gnu15---------------------
    mpich/3.4.3-ofi    mpich/3.4.3-ucx (D)
 \end{lstlisting}
 
@@ -85,7 +85,7 @@ MVAPICH2 family is available for use:
 % ohpc_command if [[ ${enable_ib} -eq 1 ]];then
 % ohpc_indent 5
 \begin{lstlisting}[language=bash]
-[sms](*\#*) (*\install*) mvapich2-gnu14-ohpc
+[sms](*\#*) (*\install*) mvapich2-gnu15-ohpc
 \end{lstlisting}
 % ohpc_indent 0
 % ohpc_command fi
@@ -98,7 +98,7 @@ variant of MVAPICH2 instead:
 % ohpc_command if [[ ${enable_opa} -eq 1 ]];then
 % ohpc_indent 5
 \begin{lstlisting}[language=bash]
-[sms](*\#*) (*\install*) mvapich2-psm2-gnu14-ohpc
+[sms](*\#*) (*\install*) mvapich2-psm2-gnu15-ohpc
 \end{lstlisting}
 % ohpc_indent 0
 % ohpc_command fi

--- a/docs/recipes/install/common/mpi_slurm.tex
+++ b/docs/recipes/install/common/mpi_slurm.tex
@@ -41,7 +41,7 @@ MVAPICH2 (psm2) &                              &                                
 % ohpc_command if [[ ${enable_mpi_defaults} -eq 1 ]];then
 % ohpc_indent 5
 \begin{lstlisting}[language=bash]
-[sms](*\#*) (*\install*) openmpi5-pmix-gnu14-ohpc mpich-ofi-gnu14-ohpc
+[sms](*\#*) (*\install*) openmpi5-pmix-gnu15-ohpc mpich-ofi-gnu15-ohpc
 \end{lstlisting}
 % ohpc_indent 0
 % ohpc_command fi
@@ -61,7 +61,7 @@ semantics. Alternatively, a site can choose to install the {\texttt ucx} variant
 instead as a drop-in MPICH replacement:
 
 \begin{lstlisting}[language=bash]
-[sms](*\#*) (*\install*) mpich-ucx-gnu14-ohpc
+[sms](*\#*) (*\install*) mpich-ucx-gnu15-ohpc
 \end{lstlisting}
 
 In the case where both MPICH variants are installed, two modules will be
@@ -71,7 +71,7 @@ highlighted is below.
 \begin{lstlisting}[language=bash]
 [sms](*\#*) module avail mpich
 
--------------------- /opt/ohpc/pub/moduledeps/gnu14---------------------
+-------------------- /opt/ohpc/pub/moduledeps/gnu15---------------------
    mpich/3.4.3-ofi    mpich/3.4.3-ucx (D)
 \end{lstlisting}
 
@@ -84,7 +84,7 @@ MVAPICH2 family is available for use:
 % ohpc_command if [[ ${enable_ib} -eq 1 ]];then
 % ohpc_indent 5
 \begin{lstlisting}[language=bash]
-[sms](*\#*) (*\install*) mvapich2-gnu14-ohpc
+[sms](*\#*) (*\install*) mvapich2-gnu15-ohpc
 \end{lstlisting}
 % ohpc_indent 0
 % ohpc_command fi
@@ -97,7 +97,7 @@ variant of MVAPICH2 instead:
 % ohpc_command if [[ ${enable_opa} -eq 1 ]];then
 % ohpc_indent 5
 \begin{lstlisting}[language=bash]
-[sms](*\#*) (*\install*) mvapich2-psm2-gnu14-ohpc
+[sms](*\#*) (*\install*) mvapich2-psm2-gnu15-ohpc
 \end{lstlisting}
 % ohpc_indent 0
 % ohpc_command fi

--- a/docs/recipes/install/common/perf_tools.tex
+++ b/docs/recipes/install/common/perf_tools.tex
@@ -6,6 +6,6 @@ of available packages). This group of tools can be installed as follows:
 % ohpc_comment_header Install Performance Tools \ref{sec:install_perf_tools}
 \begin{lstlisting}[language=bash,keywords={},literate={-}{-}1]
 # Install perf-tools meta-package
-[sms](*\#*) (*\install*) ohpc-gnu14-perf-tools
+[sms](*\#*) (*\install*) ohpc-gnu15-perf-tools
 \end{lstlisting}
 % end_ohpc_run

--- a/docs/recipes/install/common/perf_tools_with_geopm.tex
+++ b/docs/recipes/install/common/perf_tools_with_geopm.tex
@@ -6,7 +6,7 @@ of available packages). This group of tools can be installed as follows:
 % ohpc_comment_header Install Performance Tools \ref{sec:install_perf_tools}
 \begin{lstlisting}[language=bash,keywords={},literate={-}{-}1]
 # Install perf-tools meta-package
-[sms](*\#*) (*\install*) ohpc-gnu14-perf-tools
+[sms](*\#*) (*\install*) ohpc-gnu15-perf-tools
 \end{lstlisting}
 % end_ohpc_run
 
@@ -21,7 +21,7 @@ kernel module as highlighted previously in \S\ref{sec:add_geopm}):
 % ohpc_indent 5
 \begin{lstlisting}[language=bash,keywords={},upquote=true]
 # Install GEOPM meta-package
-[sms](*\#*) (*\install*) ohpc-gnu14-geopm
+[sms](*\#*) (*\install*) ohpc-gnu15-geopm
 
 \end{lstlisting}
 % ohpc_indent 0

--- a/docs/recipes/install/common/third_party_libs.tex
+++ b/docs/recipes/install/common/third_party_libs.tex
@@ -27,10 +27,10 @@ following:
 % ohpc_comment_header Install 3rd Party Libraries and Tools \ref{sec:3rdparty}
 \begin{lstlisting}[language=bash,keywords={},upquote=true,keepspaces]
 # Install 3rd party libraries/tools meta-packages built with GNU toolchain
-[sms](*\#*) (*\install*) ohpc-gnu14-serial-libs
-[sms](*\#*) (*\install*) ohpc-gnu14-io-libs
-[sms](*\#*) (*\install*) ohpc-gnu14-python-libs
-[sms](*\#*) (*\install*) ohpc-gnu14-runtimes
+[sms](*\#*) (*\install*) ohpc-gnu15-serial-libs
+[sms](*\#*) (*\install*) ohpc-gnu15-io-libs
+[sms](*\#*) (*\install*) ohpc-gnu15-python-libs
+[sms](*\#*) (*\install*) ohpc-gnu15-runtimes
 \end{lstlisting}
 % end_ohpc_run
 

--- a/docs/recipes/install/common/third_party_libs_petsc_centos.tex
+++ b/docs/recipes/install/common/third_party_libs_petsc_centos.tex
@@ -1,24 +1,24 @@
 \iftoggleverb{isx86}
 \begin{lstlisting}[language=bash,keywords={}]
-[sms](*\#*) dnf search petsc-gnu14 ohpc
+[sms](*\#*) dnf search petsc-gnu15 ohpc
 Loaded plugins: fastestmirror
 Loading mirror speeds from cached hostfile
-=========================== N/S matched: petsc-gnu14, ohpc ===========================
-petsc-gnu14-impi-ohpc.x86_64 : Portable Extensible Toolkit for Scientific Computation
-petsc-gnu14-mpich-ohpc.x86_64 : Portable Extensible Toolkit for Scientific Computation
-petsc-gnu14-mvapich2-ohpc.x86_64 : Portable Extensible Toolkit for Scientific Computation
-petsc-gnu14-openmpi5-ohpc.x86_64 : Portable Extensible Toolkit for Scientific Computation
+=========================== N/S matched: petsc-gnu15, ohpc ===========================
+petsc-gnu15-impi-ohpc.x86_64 : Portable Extensible Toolkit for Scientific Computation
+petsc-gnu15-mpich-ohpc.x86_64 : Portable Extensible Toolkit for Scientific Computation
+petsc-gnu15-mvapich2-ohpc.x86_64 : Portable Extensible Toolkit for Scientific Computation
+petsc-gnu15-openmpi5-ohpc.x86_64 : Portable Extensible Toolkit for Scientific Computation
 \end{lstlisting}
 \fi
 
 \iftoggleverb{isaarch}
 \begin{lstlisting}[language=bash,keywords={}]
-[sms](*\#*) dnf search petsc-gnu14 ohpc
+[sms](*\#*) dnf search petsc-gnu15 ohpc
 Loaded plugins: fastestmirror
 Loading mirror speeds from cached hostfile
-=========================== N/S matched: petsc-gnu14, ohpc ===========================
-petsc-gnu14-mpich-ohpc.x86_64 : Portable Extensible Toolkit for Scientific Computation
-petsc-gnu14-openmpi5-ohpc.x86_64 : Portable Extensible Toolkit for Scientific Computation
+=========================== N/S matched: petsc-gnu15, ohpc ===========================
+petsc-gnu15-mpich-ohpc.x86_64 : Portable Extensible Toolkit for Scientific Computation
+petsc-gnu15-openmpi5-ohpc.x86_64 : Portable Extensible Toolkit for Scientific Computation
 \end{lstlisting}
 \fi
 

--- a/docs/recipes/install/common/third_party_libs_petsc_sles.tex
+++ b/docs/recipes/install/common/third_party_libs_petsc_sles.tex
@@ -1,28 +1,28 @@
 \iftoggleverb{isx86}
 \begin{lstlisting}[language=bash,keepspaces=true,keywords={}]
-[sms](*\#*) zypper search -t package petsc-gnu14-*-ohpc
+[sms](*\#*) zypper search -t package petsc-gnu15-*-ohpc
 Loading repository data...
 Reading installed packages...
 
 S | Name                    | Summary
 --+-------------------------+--------------------------------------------------------+--------
- | petsc-gnu14-impi-ohpc     | Portable Extensible Toolkit for Scientific Computation | package
- | petsc-gnu14-mpich-ohpc    | Portable Extensible Toolkit for Scientific Computation | package
- | petsc-gnu14-mvapich2-ohpc | Portable Extensible Toolkit for Scientific Computation | package
- | petsc-gnu14-openmpi5-ohpc | Portable Extensible Toolkit for Scientific Computation | package
+ | petsc-gnu15-impi-ohpc     | Portable Extensible Toolkit for Scientific Computation | package
+ | petsc-gnu15-mpich-ohpc    | Portable Extensible Toolkit for Scientific Computation | package
+ | petsc-gnu15-mvapich2-ohpc | Portable Extensible Toolkit for Scientific Computation | package
+ | petsc-gnu15-openmpi5-ohpc | Portable Extensible Toolkit for Scientific Computation | package
 \end{lstlisting}
 \fi
 
 \iftoggleverb{isaarch}
 \begin{lstlisting}[language=bash,keepspaces=true,keywords={}]
-[sms](*\#*) zypper search -t package petsc-gnu14-*-ohpc
+[sms](*\#*) zypper search -t package petsc-gnu15-*-ohpc
 Loading repository data...
 Reading installed packages...
 
 S | Name                    | Summary
 --+-------------------------+--------------------------------------------------------+--------
- | petsc-gnu14-mpich-ohpc    | Portable Extensible Toolkit for Scientific Computation | package
- | petsc-gnu14-openmpi5-ohpc | Portable Extensible Toolkit for Scientific Computation | package
+ | petsc-gnu15-mpich-ohpc    | Portable Extensible Toolkit for Scientific Computation | package
+ | petsc-gnu15-openmpi5-ohpc | Portable Extensible Toolkit for Scientific Computation | package
 \end{lstlisting}
 \fi
 

--- a/docs/recipes/install/common/third_party_mpi_libs_aarch.tex
+++ b/docs/recipes/install/common/third_party_mpi_libs_aarch.tex
@@ -5,8 +5,8 @@
 % ohpc_indent 5
 \begin{lstlisting}[language=bash,keywords={},upquote=true,keepspaces]
 # Install parallel lib meta-packages for all available MPI toolchains
-[sms](*\#*) (*\install*) ohpc-gnu14-mpich-parallel-libs
-[sms](*\#*) (*\install*) ohpc-gnu14-openmpi5-parallel-libs
+[sms](*\#*) (*\install*) ohpc-gnu15-mpich-parallel-libs
+[sms](*\#*) (*\install*) ohpc-gnu15-openmpi5-parallel-libs
 \end{lstlisting}
 % ohpc_indent 0
 % ohpc_command fi

--- a/docs/recipes/install/common/third_party_mpi_libs_x86.tex
+++ b/docs/recipes/install/common/third_party_mpi_libs_x86.tex
@@ -4,19 +4,19 @@
 % ohpc_indent 5
 \begin{lstlisting}[language=bash,keywords={},upquote=true,keepspaces]
 # Install parallel lib meta-packages for all available MPI toolchains
-[sms](*\#*) (*\install*) ohpc-gnu14-mpich-parallel-libs
-[sms](*\#*) (*\install*) ohpc-gnu14-openmpi5-parallel-libs
+[sms](*\#*) (*\install*) ohpc-gnu15-mpich-parallel-libs
+[sms](*\#*) (*\install*) ohpc-gnu15-openmpi5-parallel-libs
 \end{lstlisting}
 % ohpc_indent 0
 % ohpc_command fi
 % ohpc_command if [[ ${enable_ib} -eq 1 ]];then
 % ohpc_indent 5
-% ohpc_command (*\install*) ohpc-gnu14-mvapich2-parallel-libs
+% ohpc_command (*\install*) ohpc-gnu15-mvapich2-parallel-libs
 % ohpc_indent 0
 % ohpc_command fi
 % ohpc_command if [[ ${enable_opa} -eq 1 ]];then
 % ohpc_indent 5
-% ohpc_command (*\install*) ohpc-gnu14-mvapich2-parallel-libs
+% ohpc_command (*\install*) ohpc-gnu15-mvapich2-parallel-libs
 % ohpc_indent 0
 % ohpc_command fi
 % end_ohpc_run


### PR DESCRIPTION
Update documentation references throughout installation recipes to use gnu15 as the default compiler family instead of gnu14.

🤖 Generated with [Claude Code](https://claude.ai/code)