### PR TITLE
tests: add EL10 platform support and improve EL9/EL10 labels

### DIFF
--- a/tests/m4/distro_family.m4
+++ b/tests/m4/distro_family.m4
@@ -26,7 +26,10 @@ if test -r "/etc/os-release"; then
       AC_MSG_RESULT([RHEL])
       DISTRO_FAMILY=RHEL
    elif grep -q "platform:el9" /etc/os-release; then
-      AC_MSG_RESULT([CentOS9])
+      AC_MSG_RESULT([EL9])
+      DISTRO_FAMILY=CentOS
+   elif grep -q "platform:el10" /etc/os-release; then
+      AC_MSG_RESULT([EL10])
       DISTRO_FAMILY=CentOS
    elif grep -q "SLES" /etc/os-release; then
       AC_MSG_RESULT([SLES])


### PR DESCRIPTION
Add detection for platform:el10 in distro family detection and update AC_MSG_RESULT labels from CentOS9/CentOS10 to EL9/EL10 for clarity.

🤖 Generated with [Claude Code](https://claude.ai/code)