### PR TITLE
meta-packages: remove scipy dependencies from python3-libs meta-package

### DIFF
--- a/components/admin/meta-packages/SPECS/meta-packages.spec
+++ b/components/admin/meta-packages/SPECS/meta-packages.spec
@@ -348,11 +348,8 @@ Summary:   OpenHPC python3 libraries for GNU
 Requires:  %{python_prefix}-mpi4py-%{compiler_family}-mpich%{PROJ_DELIM}
 Requires:  %{python_prefix}-mpi4py-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  %{python_prefix}-numpy-%{compiler_family}%{PROJ_DELIM}
-Requires:  %{python_prefix}-scipy-%{compiler_family}-mpich%{PROJ_DELIM}
-Requires:  %{python_prefix}-scipy-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 %ifnarch aarch64
 Requires:  %{python_prefix}-mpi4py-%{compiler_family}-mvapich2%{PROJ_DELIM}
-Requires:  %{python_prefix}-scipy-%{compiler_family}-mvapich2%{PROJ_DELIM}
 %endif
 %description -n %{PROJ_NAME}-%{compiler_family}-python3-libs
 Collection of python3 related library builds for use with GNU compiler toolchain


### PR DESCRIPTION
The scipy package dependencies are being removed from the GNU compiler python3-libs meta-package to reduce dependency complexity and avoid potential build conflicts.

🤖 Generated with [Claude Code](https://claude.ai/code)