### PR TITLE
ci: re-enable TAU builds and restore meta-package requirements

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -97,7 +97,6 @@ jobs:
           export SKIP_CI_SPECS="${SKIP_CI_SPECS} components/serial-libs/openblas/SPECS/openblas.spec"
           export SKIP_CI_SPECS="${SKIP_CI_SPECS} components/dev-tools/scipy/SPECS/python-scipy.spec"
           export SKIP_CI_SPECS="${SKIP_CI_SPECS} components/serial-libs/R/SPECS/R.spec"
-          export SKIP_CI_SPECS="${SKIP_CI_SPECS} components/perf-tools/tau/SPECS/tau.spec"
           export SKIP_CI_SPECS="${SKIP_CI_SPECS} components/parallel-libs/opencoarrays/SPECS/opencoarrays.spec"
         fi
         if [ "${{ matrix.os }}" == "ubuntu-24.04-arm" ]; then
@@ -164,7 +163,6 @@ jobs:
           export SKIP_CI_SPECS="${SKIP_CI_SPECS} components/dev-tools/spack/SPECS/spack.spec"
           export SKIP_CI_SPECS="${SKIP_CI_SPECS} components/dev-tools/cmake/SPECS/cmake.spec"
           export SKIP_CI_SPECS="${SKIP_CI_SPECS} components/serial-libs/R/SPECS/R.spec"
-          export SKIP_CI_SPECS="${SKIP_CI_SPECS} components/perf-tools/tau/SPECS/tau.spec"
           export SKIP_CI_SPECS="${SKIP_CI_SPECS} components/parallel-libs/opencoarrays/SPECS/opencoarrays.spec"
         fi
         if [ "${{ matrix.os }}" == "ubuntu-24.04-arm" ]; then

--- a/components/admin/meta-packages/SPECS/meta-packages.spec
+++ b/components/admin/meta-packages/SPECS/meta-packages.spec
@@ -631,6 +631,10 @@ Requires:  omb-intel-mvapich2%{PROJ_DELIM}
 Requires:  omb-intel-%{mpi_family}%{PROJ_DELIM}
 Requires:  papi%{PROJ_DELIM}
 Requires:  tau-%{compiler_family}-impi%{PROJ_DELIM}
+Requires:  tau-intel-impi%{PROJ_DELIM}
+Requires:  tau-intel-mpich%{PROJ_DELIM}
+Requires:  tau-intel-mvapich2%{PROJ_DELIM}
+Requires:  tau-intel-%{mpi_family}%{PROJ_DELIM}
 Requires:  scalasca-%{compiler_family}-impi%{PROJ_DELIM}
 Requires:  scalasca-intel-impi%{PROJ_DELIM}
 Requires:  scalasca-intel-mpich%{PROJ_DELIM}
@@ -649,6 +653,7 @@ Summary:   OpenHPC performance tools for Intel(R) oneAPI Toolkit and Intel(R) MP
 Requires:  imb-intel-impi%{PROJ_DELIM}
 Requires:  likwid-intel%{PROJ_DELIM}
 Requires:  omb-intel-impi%{PROJ_DELIM}
+Requires:  tau-intel-impi%{PROJ_DELIM}
 Requires:  scalasca-intel-impi%{PROJ_DELIM}
 Requires:  scorep-intel-impi%{PROJ_DELIM}
 Requires:  papi%{PROJ_DELIM}
@@ -660,6 +665,7 @@ Summary:   OpenHPC performance tools for Intel(R) oneAPI Toolkit and MPICH
 Requires:  imb-intel-mpich%{PROJ_DELIM}
 Requires:  likwid-intel%{PROJ_DELIM}
 Requires:  omb-intel-mpich%{PROJ_DELIM}
+Requires:  tau-intel-mpich%{PROJ_DELIM}
 Requires:  scalasca-intel-mpich%{PROJ_DELIM}
 Requires:  scorep-intel-mpich%{PROJ_DELIM}
 Requires:  papi%{PROJ_DELIM}
@@ -671,6 +677,7 @@ Summary:   OpenHPC performance tools for Intel(R) oneAPI Toolkit and MVAPICH2
 Requires:  imb-intel-mvapich2%{PROJ_DELIM}
 Requires:  likwid-intel%{PROJ_DELIM}
 Requires:  omb-intel-mvapich2%{PROJ_DELIM}
+Requires:  tau-intel-mvapich2%{PROJ_DELIM}
 Requires:  scalasca-intel-mvapich2%{PROJ_DELIM}
 Requires:  scorep-intel-mvapich2%{PROJ_DELIM}
 Requires:  papi%{PROJ_DELIM}
@@ -682,6 +689,7 @@ Summary:   OpenHPC performance tools for Intel(R) oneAPI Toolkit and OpenMPI
 Requires:  imb-intel-%{mpi_family}%{PROJ_DELIM}
 Requires:  likwid-intel%{PROJ_DELIM}
 Requires:  omb-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  tau-intel-%{mpi_family}%{PROJ_DELIM}
 Requires:  scalasca-intel-%{mpi_family}%{PROJ_DELIM}
 Requires:  scorep-intel-%{mpi_family}%{PROJ_DELIM}
 Requires:  papi%{PROJ_DELIM}


### PR DESCRIPTION
- Remove tau.spec from CI skip list to re-enable TAU builds
- Restore tau-intel-* requirements in meta-packages that were removed

🤖 Generated with [Claude Code](https://claude.ai/code)