### PR TITLE
Upgrade Warewulf to 4.6.3 and Prep for EL10/4.x

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,8 @@
 {
   "name": "OpenHPC Development",
-  "image": "registry.docker.com/library/rockylinux:9",
+  "image": "registry.docker.com/rockylinux/rockylinux:10",
   "remoteUser": "vscode",
-  "postCreateCommand": "sudo ./tests/ci/prepare-ci-environment.sh",
+  "postCreateCommand": "sudo ./tests/ci/prepare-ci-environment.sh --pre-release",
   "features": {
     "ghcr.io/devcontainers/features/common-utils:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/components/provisioning/warewulf/SPECS/warewulf.spec
+++ b/components/provisioning/warewulf/SPECS/warewulf.spec
@@ -38,7 +38,7 @@
 
 Name:    %{pname}%{PROJ_DELIM}
 Summary: A provisioning system for large clusters of bare metal and/or virtual systems
-Version: 4.6.2
+Version: 4.6.3
 Release: 1%{?dist}
 License: BSD-3-Clause
 Group:   %{PROJ_NAME}/provisioning
@@ -84,11 +84,15 @@ Requires: ipxe-bootimgs-aarch64
 %endif
 %endif
 
-%if 0%{?rhel} >= 8 || 0%{?suse_version} || 0%{?fedora}
+%if 0%{?rhel} >= 10 || 0%{?suse_version} || 0%{?fedora}
+Requires: dnsmasq
+%else
+%if 0%{?rhel} >= 8
 Requires: dhcp-server
 %else
 # rhel < 8
 Requires: dhcp
+%endif
 %endif
 
 BuildRequires: git
@@ -106,7 +110,7 @@ system for large clusters of bare metal and/or virtual systems.
 
 
 %prep
-%setup -q -n %{pname}-%{version} -b0 %if %{?with_offline:-a2}
+%setup -q -n %{pname}-%{version} -b0
 %patch -P 0 -p1
 
 

--- a/tests/ci/prepare-ci-environment.sh
+++ b/tests/ci/prepare-ci-environment.sh
@@ -140,12 +140,12 @@ if [ "${PRE_RELEASE}" != "yes" ]; then
 		# release RPM. As long as there is no release RPM only the OBS repository
 		# is used directly.
 		if [ "${ID}" = "openEuler" ]; then
-			OHPC_RELEASE="${REPOSITORY_URL}openEuler_22.03/${UNAME_M}/ohpc-release-3-1.oe2203.${UNAME_M}.rpm"
+			OHPC_RELEASE="${REPOSITORY_URL}openEuler_22.03/${UNAME_M}/ohpc-release-4-1.oe2203.${UNAME_M}.rpm"
 		else
-			OHPC_RELEASE="${REPOSITORY_URL}EL_10/${UNAME_M}/ohpc-release-3-1.el10.${UNAME_M}.rpm"
+			OHPC_RELEASE="${REPOSITORY_URL}EL_10/${UNAME_M}/ohpc-release-4-1.el10.${UNAME_M}.rpm"
 		fi
 	else
-		OHPC_RELEASE="${REPOSITORY_URL}Leap_15/${UNAME_M}/ohpc-release-3-1.leap15.${UNAME_M}.rpm"
+		OHPC_RELEASE="${REPOSITORY_URL}Leap_15/${UNAME_M}/ohpc-release-4-1.leap15.${UNAME_M}.rpm"
 	fi
 fi
 


### PR DESCRIPTION
* Upgrade to v4.6.3 of Warewulf and fix EL10 dep's (pending Warewulf PR)
* Includes a commit that increases the (yet to be) release(d) OpenHPC version to 4.x as well.
* Includes devcontainer upgrade to Rocky 10
 