### PR TITLE
Add dnsmasq support to Warewulf

### DIFF
--- a/components/provisioning/warewulf/SOURCES/dnsmasq.patch
+++ b/components/provisioning/warewulf/SOURCES/dnsmasq.patch
@@ -1,0 +1,13 @@
+diff --git a/overlays/host/rootfs/etc/dnsmasq.d/ww4-hosts.conf.ww b/overlays/host/rootfs/etc/dnsmasq.d/ww4-hosts.conf.ww
+index 93295daf..5b6715ae 100644
+--- a/overlays/host/rootfs/etc/dnsmasq.d/ww4-hosts.conf.ww
++++ b/overlays/host/rootfs/etc/dnsmasq.d/ww4-hosts.conf.ww
+@@ -19,7 +19,7 @@ dhcp-boot=tag:x86PC,"warewulf/shim.efi"
+ dhcp-boot=tag:x86PC,"/warewulf/{{ index $.Tftp.IpxeBinaries "00:07" }}"
+ {{- end }}
+ {{- with (index $.Tftp.IpxeBinaries "00:0B" ) }}
+-dhcp-boot=tag:aarch64,"/warewulf/{{ index $.Tftp.IpxeBinaries "00:0B" }}"
++dhcp-boot=tag:aarch64,"/warewulf/{{ index $.Tftp.IpxeBinaries "00:0B" | basename }}"
+ {{- end }}
+ {{- end }}
+ # iPXE binary will get the following configuration file

--- a/components/provisioning/warewulf/SPECS/warewulf.spec
+++ b/components/provisioning/warewulf/SPECS/warewulf.spec
@@ -46,6 +46,7 @@ URL:     https://github.com/warewulf/warewulf
 Source0: https://github.com/warewulf/warewulf/releases/download/v%{version}/warewulf-%{version}.tar.gz
 # OpenHPC modifications to the warewulf template files
 Patch0:  hosts.ww.patch
+Patch1:  dnsmasq.patch
 
 ExclusiveOS: linux
 
@@ -74,7 +75,9 @@ Requires: ipxe-bootimgs
 BuildRequires: systemd
 BuildRequires: golang > 1.20
 BuildRequires: firewalld-filesystem
+%if ! (0%{?rhel} >= 10)
 Requires: tftp-server
+%endif
 Requires: nfs-utils
 %if 0%{?rhel} < 8
 Requires: ipxe-bootimgs
@@ -84,13 +87,13 @@ Requires: ipxe-bootimgs-aarch64
 %endif
 %endif
 
-%if 0%{?rhel} >= 10 || 0%{?suse_version} || 0%{?fedora}
+%if 0%{?rhel} >= 10
 Requires: dnsmasq
 %else
-%if 0%{?rhel} >= 8
+%if 0%{?rhel} >= 8 || 0%{?suse_version} || 0%{?fedora}
 Requires: dhcp-server
 %else
-# rhel < 8
+# rhel < 8 and others
 Requires: dhcp
 %endif
 %endif
@@ -112,6 +115,7 @@ system for large clusters of bare metal and/or virtual systems.
 %prep
 %setup -q -n %{pname}-%{version} -b0
 %patch -P 0 -p1
+%patch -P 1 -p1
 
 
 %build
@@ -151,6 +155,14 @@ make install \
 ln -s %{_sharedstatedir}/tftpboot %{buildroot}%{tftpdir}
 %endif
 ## END OHPC
+
+%if 0%{?rhel} >= 10
+sed -i '
+  s/systemd name: dhcpd/systemd name: dnsmasq/
+  s/systemd name: tftp/systemd name: dnsmasq/
+  /- dsa/d' \
+  -i %{buildroot}%{_sysconfdir}/warewulf/warewulf.conf
+%endif
 
 %if 0%{?suse_version} || 0%{?sle_version}
 yq e '


### PR DESCRIPTION
Based on upstream changes pending for Warewulf 4.6.4.  https://github.com/warewulf/warewulf/pull/1974

* Make dnsmasq default and fix overlay bug on aarch64
* Fix rpm SPEC file dependencies. 

Will remove overlay patch once 4.6.4 goes live.
