### PR TITLE
Fix the build of `gnu-compiler` package on openEuler 24.03 LTS SP2

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -185,7 +185,6 @@ jobs:
         path: tests/**/*.log.xml
 
   build_on_openEuler:
-    if: ${{ false }}  # disable for now
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
@@ -203,7 +202,7 @@ jobs:
       run: dnf -y install git
     - uses: actions/checkout@v4
     - name: Setup
-      run: tests/ci/prepare-ci-environment.sh
+      run: tests/ci/prepare-ci-environment.sh --pre-release ${{ matrix.compiler }}
     - id: files
       uses: Ana06/get-changed-files@v2.3.0
     - name: Validate Build
@@ -251,7 +250,7 @@ jobs:
       run: dnf -y install git
     - uses: actions/checkout@v4
     - name: Setup
-      run: tests/ci/prepare-ci-environment.sh
+      run: tests/ci/prepare-ci-environment.sh --pre-release ${{ matrix.compiler }}
     - id: files
       uses: Ana06/get-changed-files@v2.3.0
     - uses: actions/download-artifact@v4

--- a/components/compiler-families/gnu-compilers/SPECS/gnu-compilers.spec
+++ b/components/compiler-families/gnu-compilers/SPECS/gnu-compilers.spec
@@ -82,12 +82,8 @@ Group:     %{PROJ_NAME}/compiler-families
 URL:       http://gcc.gnu.org/
 
 # Requirements from https://gcc.gnu.org/install/prerequisites.htmlzypper
-%if 0%{?openEuler}
-BuildRequires:  gcc-toolset-12-gcc-c++
-BuildRequires:  gcc-toolset-12-libstdc++-devel
-%else
+
 BuildRequires:  gcc-c++
-%endif
 BuildRequires:  binutils >= 2.30
 BuildRequires:  make >= 3.80
 BuildRequires:  gettext-devel >= 0.14.5
@@ -144,11 +140,6 @@ ln -s mpfr-%{gnu15_mpfr_version} mpfr
 %endif
 
 %build
-
-%if 0%{?openEuler}
-export PATH=/opt/openEuler/gcc-toolset-12/root/usr/bin:$PATH
-export LD_LIBRARY_PATH=/opt/openEuler/gcc-toolset-12/root/usr/lib64:$LD_LIBRARY_PATH
-%endif
 
 mkdir obj
 cd obj


### PR DESCRIPTION
GCC version 12 is now the default.
Removed conditional checks and manual configuration for `gcc-toolset-12-gcc-c++` and `gcc-toolset-12-libstdc++-devel` in `BuildRequires`.