### PR TITLE
Fix the build of `mpich-gnu15` package on openEuler 24.03 LTS SP2

### DIFF
--- a/components/mpi-families/mpich/SPECS/mpich.spec
+++ b/components/mpi-families/mpich/SPECS/mpich.spec
@@ -40,6 +40,11 @@ Requires: ucx-ib%{PROJ_DELIM}
 %define with_ofi 1
 BuildRequires: libfabric-devel
 BuildRequires: rdma-core-devel
+%ifarch x86_64
+%if 0%{?openEuler}
+BuildRequires: libpsm2-devel
+%endif
+%endif
 Requires: libfabric
 %define FABRIC_DELIM -ofi
 %endif


### PR DESCRIPTION
Following the upgrade to OpenHPC 4.x, the `BuildRequires` for `libpsm2-devel` was removed, but it is still a required dependency on openEuler 24.03 LTS SP2.

