### PR TITLE
Fix the build of `docs` package on openEuler 24.03 LTS SP2

### DIFF
--- a/components/admin/docs/SPECS/docs.spec
+++ b/components/admin/docs/SPECS/docs.spec
@@ -55,7 +55,7 @@ BuildRequires:  tex
 %endif
 
 %if 0%{?openEuler}
-BuildRequires:  texlive-texconfig
+BuildRequires:  texlive-texlive-scripts-extra
 BuildRequires:  texlive-pdftex
 BuildRequires:  texlive-epstopdf
 BuildRequires:  texlive-collection-basic


### PR DESCRIPTION
The `texlive-texconfig` package has been integrated into `texlive-texlive-scripts-extra` from openEuler 24.03 LTS.