### PR TITLE
update meta-packages: bump version to 4.0 and add libyaml-cpp dependency

### DIFF
--- a/components/admin/meta-packages/SPECS/meta-packages.spec
+++ b/components/admin/meta-packages/SPECS/meta-packages.spec
@@ -17,7 +17,7 @@
 
 Summary: Meta-packages to ease installation
 Name:    meta-packages
-Version: 3.3
+Version: 4.0
 Release: 1
 License: Apache-2.0
 Group:   %{PROJ_NAME}/meta-package
@@ -91,6 +91,7 @@ Requires:  numactl
 Requires:  python3
 Requires:  %{python_prefix}
 %if 0%{?rhel} || 0%{?openEuler}
+Requires:  libyaml-cpp
 Requires:  cairo-devel
 Requires:  libpciaccess
 Requires:  libseccomp


### PR DESCRIPTION
Update meta-packages version from 3.3 to 4.0 to reflect the new major release series. Add libyaml-cpp as a required package for RHEL and openEuler distributions in the -base-compute meta package to support adios2 which depends on YAML configuration parsing.

🤖 Generated with [Claude Code](https://claude.ai/code)