### PR TITLE
docs: add internal_network variable validation in Warewulf4 intro

### DIFF
--- a/docs/recipes/install/common/install_provisioning_warewulf4_intro.tex
+++ b/docs/recipes/install/common/install_provisioning_warewulf4_intro.tex
@@ -14,6 +14,7 @@ Warewulf configuration files are edited to reflect the environment.
 \begin{lstlisting}[language=bash,keywords={}]
 # Make sure required variables are set
 [sms](*\#*) : ${sms_eth_internal:?ERROR: sms_eth_internal not set}
+[sms](*\#*) : ${internal_network:?ERROR: internal_network not set}
 
 # Install base packages
 [sms](*\#*) (*\install*) epel-release


### PR DESCRIPTION
Add early validation check for the internal_network variable before Warewulf package installation to prevent setup failures due to missing required network configuration. This follows the same pattern as the existing sms_eth_internal variable check.

🤖 Generated with [Claude Code](https://claude.ai/code)