### PR TITLE
tau: filter out SUNWprivate RPM dependencies from binaries

### DIFF
--- a/components/perf-tools/tau/SPECS/tau.spec
+++ b/components/perf-tools/tau/SPECS/tau.spec
@@ -49,11 +49,11 @@ BuildRequires: postgresql-devel binutils-devel
 BuildRequires: zlib-devel python3-devel
 BuildRequires: pdtoolkit-%{compiler_family}%{PROJ_DELIM}
 
-# Exclude libCg*.so that breaks install
+# Exclude requires that breaks install
 %if "0%{?__requires_exclude}" == "0"
-%global __requires_exclude ^libCg.*$
+%global __requires_exclude ^libCg.*$|.*SUNWprivate.*
 %else
-%global __requires_exclude %{__requires_exclude}|^libCg.*$
+%global __requires_exclude %{__requires_exclude}|^libCg.*$|.*SUNWprivate.*
 %endif
 
 Requires: lmod%{PROJ_DELIM} >= 7.6.1


### PR DESCRIPTION
Some TAU binaries include libjawt.so which introduces RPM dependency to "libjawt.so(SUNWprivate_1.1)(64bit)" that needs to be filtered out to avoid packaging issues.

🤖 Generated with [Claude Code](https://claude.ai/code)