### PR TITLE
Warewulf 4 images no longer tigger firstboot

### DIFF
--- a/docs/recipes/install/common/warewulf4_add_to_compute_chroot_slurm.tex
+++ b/docs/recipes/install/common/warewulf4_add_to_compute_chroot_slurm.tex
@@ -6,8 +6,8 @@
     dnf -y install ohpc-slurm-client
 
     # Enable services to start on boot
-    echo "enable munge.service" > /etc/systemd/system-preset/90-munge.preset
-    echo "enable slurmd.service" > /etc/systemd/system-preset/90-slurmd.preset
+    systemctl enable munge.service
+    systemctl enable slurmd.service
 
     # Add Network Time Protocol (NTP) support
     dnf -y install chrony

--- a/docs/recipes/install/common/warewulf4_mkchroot.tex
+++ b/docs/recipes/install/common/warewulf4_mkchroot.tex
@@ -25,12 +25,6 @@ the image from rebuilding (it will show an error) and rebuild later with the
 # Define chroot location
 [sms](*\#*) export CHROOT=$(wwctl image show BOSVER)
 
-# FIXME: Enable wwclient on the compute nodes
-[sms](*\#*) wwctl image exec --build=false BOSVER -- /bin/bash -ex <<- EOF
-  install -dvp /etc/systemd/system-preset
-  echo "enable wwclient.service" > /etc/systemd/system-preset/90-wwclient.preset
-EOF
-
 # Enable OpenHPC inside image and update image.  Disable image build on exit, rebuild later.
 [sms](*\#*) wwctl image exec --build=false BOSVER -- /bin/bash -ex <<- EOF
 %% FIXME: Not yet released (remove this block released)


### PR DESCRIPTION
Nolonger required by upstream.  /etc/machine-id is set to zero bytes instead of removed.  This will regenerate a new machine-id but not a FirstBoot. https://www.freedesktop.org/software/systemd/man/latest/machine-id.html

Upstream change: https://github.com/warewulf/warewulf-node-images/pull/86
