### PR TITLE
Add Warewulf two-stage boot using Dracut (tmpfs and provision-to-disk)

### DIFF
--- a/docs/recipes/install/almalinux10/input.local.template
+++ b/docs/recipes/install/almalinux10/input.local.template
@@ -63,6 +63,9 @@ epel_repo_dir="${epel_repo_dir:-/install/epel}"
 # Provisioning interface used by compute hosts (Warewulf recipe only)
 eth_provision="${eth_provision:-eth0}"
 
+# Compute disk config (Warewulf recipe only, set enable_todisk=1)
+node_disk=${node_disk:=/dev/sda}
+
 # Flags for optional installation/configuration
 enable_ib="${enable_ib:-0}"
 enable_opa="${enable_opa:-0}"
@@ -70,6 +73,7 @@ enable_opafm="${enable_opafm:-0}"
 enable_mpi_defaults="${enable_mpi_defaults:-1}"
 enable_mpich_ucx="${enable_mpich_ucx:-1}"
 enable_ipoib="${enable_ipoib:-0}"
+enable_todisk="${enable_todisk:-0}"
 
 enable_clustershell="${enable_clustershell:-0}"
 enable_ipmisol="${enable_ipmisol:-0}"

--- a/docs/recipes/install/common/finalize_warewulf4_provisioning.tex
+++ b/docs/recipes/install/common/finalize_warewulf4_provisioning.tex
@@ -4,6 +4,60 @@
 This section highlights creation of the node image and overlays, followed by the
 registration of desired compute nodes.
 
+\subsubsection{Two-Stage Provisioning (optional)}
+
+\Warewulf{} optionally supports two-stage provisioning to ramfs or disk on the
+compute nodes. The nodes are still stateless, but the image is copied to disk
+during the provisioning process and is reprovisioned on every boot.  This can be
+useful for cases when the compute node images are large, for example GPU
+drivers, or the compute nodes have limited memory.
+
+To configure two-stage provisioning, install Dracut and ignition (ignition can
+also be used to provision swap and local storage (see \Warewulf{} documentation
+for details) on the compute node.  The example below provisions to ramfs, which
+is the default.  To provision to disk, see the next section.  To aid in
+debugging, it is helpful to add \texttt{rd.shell} to the kernel arguments in
+Section~\ref{sec:optional_kargs} to aid in debugging.
+
+
+% begin_ohpc_run
+% ohpc_comment_header Two-Stage provision to ramfs
+\begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true,literate={BOSVER}{\baseos{}}1]
+## Install Dracut in the image
+[sms](*\#*) wwctl image exec --build=false BOSVER -- /usr/bin/dnf install -y warewulf-ohpc-dracut ignition gdisk
+
+## Configure Dracut.  Note the leading and trailing spaces in the quotes in "add_dracutmodules"
+[sms](*\#*) echo 'hostonly="no"' > $CHROOT/etc/dracut.conf.d/wwinit.conf
+[sms](*\#*) echo 'add_dracutmodules+=" wwinit ignition "' >> $CHROOT/etc/dracut.conf.d/wwinit.conf
+
+## Build the Dracut initramfs
+[sms](*\#*) wwctl image exec --build=false BOSVER -- /usr/bin/dracut --force --regenerate-all
+
+## Enable Dracut boot for compute nodes that use the "nodes" profile
+[sms](*\#*) wwctl profile set --yes nodes --tagadd IPXEMenuEntry=dracut
+\end{lstlisting}
+% end_ohpc_run
+
+Optionally, configure the compute node to provision to disk.  Two stage
+provisioning (previous step) must also be enabled.  The compute node will use,
+\textbf{and erase}, the disk specified by \texttt{node\_disk}.
+
+% begin_ohpc_run
+% ohpc_command if [[ ${enable_todisk} -eq 1 ]];then
+% ohpc_comment_header Configure two-stage provision-to-disk
+\begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true,literate={BOSVER}{\baseos{}}1]
+## Create the target "rootfs" partition and filesystem
+[sms](*\#*) wwctl profile set --yes nodes \
+  --diskname ${node_disk} --diskwipe \
+  --partname rootfs --partcreate --partnumber 1 \
+  --fsname rootfs --fswipe --fsformat ext4 --fspath /
+
+## Enable provision-to-disk for compute nodes that use the "nodes" profile
+[sms](*\#*) wwctl profile set nodes --yes --root=/dev/disk/by-partlabel/rootfs
+\end{lstlisting}
+% ohpc_command fi
+% end_ohpc_run
+
 \subsubsection{Build image image and overlays}
 
 The bootstrap image includes the runtime kernel and associated modules, as well

--- a/docs/recipes/install/common/inputs.tex
+++ b/docs/recipes/install/common/inputs.tex
@@ -46,6 +46,9 @@ node counts. \\
 & \texttt{\$\{epel\_repo\_dir\}} & {\small \# Directory location of local EPEL repository
 mirror} \\
 \fi
+\iftoggleverb{isWarewulf4}
+& \texttt{\$\{node\_disk\}} & {\small \# Device path for disk to be used for provision-to-disk} \\
+\fi
 \end{tabular}
 
 \vspace*{0.2cm}

--- a/docs/recipes/install/rocky10/input.local.template
+++ b/docs/recipes/install/rocky10/input.local.template
@@ -24,7 +24,7 @@ internal_netmask="${internal_netmask:-255.255.0.0}"
 # Subnet network for internal cluster network
 internal_network="${internal_network:-172.16.0.0}"
 
-# ipv4 gateway 
+# ipv4 gateway
 ipv4_gateway="${ipv4_gateway:-172.16.0.2}"
 
 # Local ntp server for time synchronization
@@ -50,7 +50,7 @@ deployment_protocols="${deployment_protocols:-firmware}"
 
 
 
-# Path to local repository web roots (Confluent reciRocky-9.4-x86_64-dvd.isope only)
+# Path to local repository web roots (Confluent recipe only)
 ohpc_repo_dir_confluent="${ohpc_repo_dir:-/var/lib/confluent/public/ohpc}"
 ohpc_repo_remote_dir="${ohpc_repo_remote_dir:-/confluent-public/ohpc}"
 epel_repo_dir_confluent="${epel_repo_dir:-/var/lib/confluent/public/epel}"
@@ -63,6 +63,9 @@ epel_repo_dir="${epel_repo_dir:-/install/epel}"
 # Provisioning interface used by compute hosts (Warewulf recipe only)
 eth_provision="${eth_provision:-eth0}"
 
+# Compute disk config (Warewulf recipe only, set enable_todisk=1)
+node_disk=${node_disk:=/dev/sda}
+
 # Flags for optional installation/configuration
 enable_ib="${enable_ib:-0}"
 enable_opa="${enable_opa:-0}"
@@ -70,6 +73,7 @@ enable_opafm="${enable_opafm:-0}"
 enable_mpi_defaults="${enable_mpi_defaults:-1}"
 enable_mpich_ucx="${enable_mpich_ucx:-1}"
 enable_ipoib="${enable_ipoib:-0}"
+enable_todisk="${enable_todisk:-0}"
 
 enable_clustershell="${enable_clustershell:-0}"
 enable_ipmisol="${enable_ipmisol:-0}"


### PR DESCRIPTION
Add Warewulf two-stage boot using Dracut (tmpfs and provision-to-disk)
* Always test two-stage/Dracut
* Disk device is set by ${node_disk} (optional)
* Testing of provision-to-disk is enabled by ${enable_todisk}
