### PR TITLE
cuda: update nvhpc version and improve documentation

### DIFF
--- a/components/dev-tools/cuda-devel/SPECS/cuda-devel.spec
+++ b/components/dev-tools/cuda-devel/SPECS/cuda-devel.spec
@@ -11,7 +11,7 @@
 %include %{_sourcedir}/OHPC_macros
 
 %define pname cuda-devel
-%define nvhpc_version 25-1
+%define nvhpc_version 25-9
 %define dot_version %(tr "-" "." <<< %{nvhpc_version})
 
 Summary:   OpenHPC compatibility package for cuda
@@ -53,18 +53,17 @@ Installs and configures the online repository for the cuda toolkit
 
 install -D -m644 %{cuda_repofile} %{nvhpc_repofile} -t %{buildroot}%{repodir}
 
-mkdir -p %{buildroot}/%{OHPC_MODULES}/cuda
+mkdir -p %{buildroot}/%{OHPC_MODULES}
 
-%{__cat} << EOF > %{buildroot}/%{OHPC_MODULES}/cuda/%{dot_version}
+%{__cat} << EOF > %{buildroot}/%{OHPC_MODULES}/cuda
 #%Module1.0#####################################################################
 
-proc ModulesHelp { } { puts stderr "Activate cuda-toolkit %{dot_version} (nvhpc)" }
+proc ModulesHelp { } { puts stderr "Activate cuda-toolkit (nvhpc)" }
 
 module-whatis "Name: cuda-toolkit (nvhpc)"
-module-whatis "Version: %{dot_version}"
 
 # The default compiler from OpenHPC (currently gcc 15) is not supported
-# by nvhpc <= 25-1. We rely on the OS compiler for now.
+# by nvhpc <= 25-9. We rely on the OS compiler for now.
 setenv		NVCC_PREPEND_FLAGS	"-ccbin /usr/bin/gcc"
 # Make the nvidia hpc_sdk module files visible
 append-path	MODULEPATH		/opt/nvidia/hpc_sdk/modulefiles

--- a/docs/recipes/install/common/install_gpu_driver_nvidia_rhel_warewulf4.tex
+++ b/docs/recipes/install/common/install_gpu_driver_nvidia_rhel_warewulf4.tex
@@ -1,11 +1,12 @@
 To add the optional NVIDIA GPU driver to the compute nodes, an
 additional external \pkgmgr{} repository provided by NVIDIA
-must be configured. Once the repository is configured the
-GPU driver and the corresponding toolkit needs to be installed.
+must be configured. Once the repository is configured, the
+GPU driver needs to be installed on the compute image and the
+corresponding toolkit installed on the SMS node.
 
 \OHPC{} provides a convenience package to enable the NVIDIA
 repository locally along with compatibility packages that integrate
-the NVIDIA compiler within the standard \OHPC{} user environment.
+the NVIDIA HPC SDK within the standard \OHPC{} user environment.
 
 % begin_ohpc_run
 % ohpc_validation_newline
@@ -16,10 +17,10 @@ the NVIDIA compiler within the standard \OHPC{} user environment.
 [sms](*\#*) (*\install*) cuda-repo-ohpc
 # Install the toolkit on the SMS
 [sms](*\#*) (*\install*) nvidia-driver-cuda cuda-devel-ohpc
-# Enable NVIDIA repository inside image and install it.  Disable autorebuild.
+# Install NVIDIA repository and GPU driver in the compute image
 [sms](*\#*) wwctl image exec --build=false BOSVER -- /bin/bash -ex <<- EOF
   dnf -y install cuda-repo-ohpc
-  dnf -y module install nvidia-driver:latest-dkms
+  dnf -y kmod-nvidia-latest-dkms nvidia-driver-cuda
   KVER=$(rpm -q --queryformat='%{version}-%{release}.%{arch}\n' \
          kernel-core | sort -r | head -1)
   dkms autoinstall --verbose -k \${KVER}


### PR DESCRIPTION
- Update nvhpc version from 25-1 to 25-9 in cuda-devel spec
- Simplify module file structure to use single cuda module
- Improve NVIDIA GPU installation documentation clarity
- Clarify that GPU driver goes on compute nodes, toolkit on SMS
- Update description to reference NVIDIA HPC SDK instead of compiler

🤖 Generated with [Claude Code](https://claude.com/claude-code)