### PR TITLE
Add enable_dracut for Warewulf one-stage testing

### DIFF
--- a/docs/recipes/install/almalinux10/input.local.template
+++ b/docs/recipes/install/almalinux10/input.local.template
@@ -73,6 +73,7 @@ enable_opafm="${enable_opafm:-0}"
 enable_mpi_defaults="${enable_mpi_defaults:-1}"
 enable_mpich_ucx="${enable_mpich_ucx:-1}"
 enable_ipoib="${enable_ipoib:-0}"
+enable_dracut="${enable_dracut:-1}"
 enable_todisk="${enable_todisk:-0}"
 
 enable_clustershell="${enable_clustershell:-0}"

--- a/docs/recipes/install/common/finalize_warewulf4_provisioning.tex
+++ b/docs/recipes/install/common/finalize_warewulf4_provisioning.tex
@@ -21,6 +21,7 @@ Section~\ref{sec:optional_kargs} to aid in debugging.
 
 
 % begin_ohpc_run
+% ohpc_command if [[ ${enable_dracut} -eq 1 ]];then
 % ohpc_comment_header Two-Stage provision to ramfs
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true,literate={BOSVER}{\baseos{}}1]
 ## Install Dracut in the image
@@ -36,6 +37,7 @@ Section~\ref{sec:optional_kargs} to aid in debugging.
 ## Enable Dracut boot for compute nodes that use the "nodes" profile
 [sms](*\#*) wwctl profile set --yes nodes --tagadd IPXEMenuEntry=dracut
 \end{lstlisting}
+% ohpc_command fi
 % end_ohpc_run
 
 Optionally, configure the compute node to provision to disk.  Two stage
@@ -43,7 +45,7 @@ provisioning (previous step) must also be enabled.  The compute node will use,
 \textbf{and erase}, the disk specified by \texttt{node\_disk}.
 
 % begin_ohpc_run
-% ohpc_command if [[ ${enable_todisk} -eq 1 ]];then
+% ohpc_command if [[ ${enable_dracut} -eq 1 && ${enable_todisk} -eq 1 ]];then
 % ohpc_comment_header Configure two-stage provision-to-disk
 \begin{lstlisting}[language=bash,literate={-}{-}1,keywords={},upquote=true,literate={BOSVER}{\baseos{}}1]
 ## Create the target "rootfs" partition and filesystem

--- a/docs/recipes/install/rocky10/input.local.template
+++ b/docs/recipes/install/rocky10/input.local.template
@@ -73,6 +73,7 @@ enable_opafm="${enable_opafm:-0}"
 enable_mpi_defaults="${enable_mpi_defaults:-1}"
 enable_mpich_ucx="${enable_mpich_ucx:-1}"
 enable_ipoib="${enable_ipoib:-0}"
+enable_dracut="${enable_dracut:-1}"
 enable_todisk="${enable_todisk:-0}"
 
 enable_clustershell="${enable_clustershell:-0}"


### PR DESCRIPTION
Add `enable_dracut` to Warewulf two-stage (Dracut) to completely disable two-stage and use single stage provisioning.  Templates default to two-stage provision to tmpfs.
