### PR TITLE
Bump Score-P to v9.3

### DIFF
--- a/components/perf-tools/scorep/SPECS/scorep.spec
+++ b/components/perf-tools/scorep/SPECS/scorep.spec
@@ -18,7 +18,7 @@
 
 Summary:   Scalable Performance Measurement Infrastructure for Parallel Codes
 Name:      %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-Version:   9.2
+Version:   9.3
 Release:   1%{?dist}
 License:   BSD
 Group:     %{PROJ_NAME}/perf-tools


### PR DESCRIPTION
No dependency version changes required, since this is only a bug fix release.