### PR TITLE
Include the x86_64 documentation for openeuler/warewulf4

### DIFF
--- a/components/admin/docs/SPECS/docs.spec
+++ b/components/admin/docs/SPECS/docs.spec
@@ -80,6 +80,7 @@ for recipe_path in \
 	"almalinux10/x86_64/openchami/slurm" \
 	"almalinux10/x86_64/warewulf4/slurm" \
 	"almalinux10/aarch64/warewulf4/slurm" \
+	"openeuler24.03/x86_64/warewulf4/slurm" \
 	"openeuler24.03/aarch64/warewulf4/slurm" \
 	"rocky10/x86_64/warewulf4/slurm" \
 	"rocky10/aarch64/warewulf4/slurm" \
@@ -135,6 +136,7 @@ for recipe_path in \
 	"almalinux10/x86_64/openchami/slurm" \
 	"almalinux10/x86_64/warewulf4/slurm" \
 	"almalinux10/aarch64/warewulf4/slurm" \
+	"openeuler24.03/x86_64/warewulf4/slurm" \
 	"openeuler24.03/aarch64/warewulf4/slurm" \
 	"rocky10/x86_64/warewulf4/slurm" \
 	"rocky10/aarch64/warewulf4/slurm" \


### PR DESCRIPTION
This pull request adds support for the `openeuler24.03/x86_64/warewulf4/slurm` recipe in the documentation specification script. This change ensures that documentation is generated for this additional platform combination alongside the existing ones.

Platform support updates:

* Added `openeuler24.03/x86_64/warewulf4/slurm` to the list of recipe paths in two places within `components/admin/docs/SPECS/docs.spec`, enabling documentation generation for this platform. [[1]](diffhunk://#diff-368545b10fef36577a7687c4a4316c93fb9ab5ff8178d3d94eb6f1435e7c94d8R83) [[2]](diffhunk://#diff-368545b10fef36577a7687c4a4316c93fb9ab5ff8178d3d94eb6f1435e7c94d8R139)