### PR TITLE
docs: remove GEOPM references from installation recipes

### DIFF
--- a/docs/recipes/install/almalinux9/aarch64/warewulf4/slurm/steps.tex
+++ b/docs/recipes/install/almalinux9/aarch64/warewulf4/slurm/steps.tex
@@ -199,10 +199,6 @@
 \input{common/nhc}
 \input{common/nhc_slurm}
 
-\vspace*{0.3cm}
-\paragraph{Add \GEOPM{}} \label{sec:add_geopm}
-\input{common/geopm_config}
-
 %\clearpage
 \subsubsection{Import files} \label{sec:file_import}
 \input{common/import_ww4_files}
@@ -239,9 +235,6 @@
 %\clearpage
 \subsection{MPI Stacks} \label{sec:mpi}
 \input{common/mpi_slurm}
-
-\subsection{Performance Tools} \label{sec:install_perf_tools}
-\input{common/perf_tools_with_geopm}
 
 \subsection{Setup default development environment}
 \input{common/default_dev}

--- a/docs/recipes/install/almalinux9/x86_64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/almalinux9/x86_64/warewulf/slurm/steps.tex
@@ -227,10 +227,6 @@
 \input{common/nhc}
 \input{common/nhc_slurm}
 
-\vspace*{0.3cm}
-\paragraph{Add \GEOPM{}} \label{sec:add_geopm}
-\input{common/geopm_config}
-
 %\clearpage
 \subsubsection{Import files} \label{sec:file_import}
 \input{common/import_ww_files}
@@ -274,9 +270,6 @@
 %\clearpage
 \subsection{MPI Stacks} \label{sec:mpi}
 \input{common/mpi_slurm}
-
-\subsection{Performance Tools} \label{sec:install_perf_tools}
-\input{common/perf_tools_with_geopm}
 
 \subsection{Setup default development environment}
 \input{common/default_dev}

--- a/docs/recipes/install/almalinux9/x86_64/warewulf4/slurm/steps.tex
+++ b/docs/recipes/install/almalinux9/x86_64/warewulf4/slurm/steps.tex
@@ -200,10 +200,6 @@
 \input{common/nhc}
 \input{common/nhc_slurm}
 
-\vspace*{0.3cm}
-\paragraph{Add \GEOPM{}} \label{sec:add_geopm}
-\input{common/geopm_config}
-
 %\clearpage
 \subsubsection{Import files} \label{sec:file_import}
 \input{common/import_ww4_files}
@@ -240,9 +236,6 @@
 %\clearpage
 \subsection{MPI Stacks} \label{sec:mpi}
 \input{common/mpi_slurm}
-
-\subsection{Performance Tools} \label{sec:install_perf_tools}
-\input{common/perf_tools_with_geopm}
 
 \subsection{Setup default development environment}
 \input{common/default_dev}

--- a/docs/recipes/install/leap15/x86_64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/leap15/x86_64/warewulf/slurm/steps.tex
@@ -229,9 +229,6 @@
 \input{common/nhc}
 \input{common/nhc_slurm}
 
-\paragraph{Add \GEOPM{}} \label{sec:add_geopm}
-\input{common/geopm_config}
-
 %\clearpage
 \subsubsection{Import files} \label{sec:file_import}
 \input{common/import_ww_files}
@@ -267,11 +264,6 @@
 
 \subsection{MPI Stacks} \label{sec:mpi}
 \input{common/mpi_slurm}
-
-%\clearpage
-\subsection{Performance Tools} \label{sec:install_perf_tools}
-\input{common/perf_tools_with_geopm}
-\input{common/perf_tools_sles}
 
 \subsection{Setup default development environment}
 \input{common/default_dev}

--- a/docs/recipes/install/openeuler22.03/x86_64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/openeuler22.03/x86_64/warewulf/slurm/steps.tex
@@ -227,10 +227,6 @@
 \input{common/nhc}
 \input{common/nhc_slurm}
 
-\vspace*{0.3cm}
-\paragraph{Add \GEOPM{}} \label{sec:add_geopm}
-\input{common/geopm_config}
-
 %\clearpage
 \subsubsection{Import files} \label{sec:file_import}
 \input{common/import_ww_files}
@@ -274,9 +270,6 @@
 %\clearpage
 \subsection{MPI Stacks} \label{sec:mpi}
 \input{common/mpi_slurm}
-
-\subsection{Performance Tools} \label{sec:install_perf_tools}
-\input{common/perf_tools_with_geopm}
 
 \subsection{Setup default development environment}
 \input{common/default_dev}

--- a/docs/recipes/install/rocky9/aarch64/warewulf4/slurm/steps.tex
+++ b/docs/recipes/install/rocky9/aarch64/warewulf4/slurm/steps.tex
@@ -199,10 +199,6 @@
 \input{common/nhc}
 \input{common/nhc_slurm}
 
-\vspace*{0.3cm}
-\paragraph{Add \GEOPM{}} \label{sec:add_geopm}
-\input{common/geopm_config}
-
 %\clearpage
 \subsubsection{Import files} \label{sec:file_import}
 \input{common/import_ww4_files}
@@ -239,9 +235,6 @@
 %\clearpage
 \subsection{MPI Stacks} \label{sec:mpi}
 \input{common/mpi_slurm}
-
-\subsection{Performance Tools} \label{sec:install_perf_tools}
-\input{common/perf_tools_with_geopm}
 
 \subsection{Setup default development environment}
 \input{common/default_dev}

--- a/docs/recipes/install/rocky9/x86_64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/rocky9/x86_64/warewulf/slurm/steps.tex
@@ -227,10 +227,6 @@
 \input{common/nhc}
 \input{common/nhc_slurm}
 
-\vspace*{0.3cm}
-\paragraph{Add \GEOPM{}} \label{sec:add_geopm}
-\input{common/geopm_config}
-
 %\clearpage
 \subsubsection{Import files} \label{sec:file_import}
 \input{common/import_ww_files}
@@ -274,9 +270,6 @@
 %\clearpage
 \subsection{MPI Stacks} \label{sec:mpi}
 \input{common/mpi_slurm}
-
-\subsection{Performance Tools} \label{sec:install_perf_tools}
-\input{common/perf_tools_with_geopm}
 
 \subsection{Setup default development environment}
 \input{common/default_dev}

--- a/docs/recipes/install/rocky9/x86_64/warewulf4/slurm/steps.tex
+++ b/docs/recipes/install/rocky9/x86_64/warewulf4/slurm/steps.tex
@@ -200,10 +200,6 @@
 \input{common/nhc}
 \input{common/nhc_slurm}
 
-\vspace*{0.3cm}
-\paragraph{Add \GEOPM{}} \label{sec:add_geopm}
-\input{common/geopm_config}
-
 %\clearpage
 \subsubsection{Import files} \label{sec:file_import}
 \input{common/import_ww4_files}
@@ -240,9 +236,6 @@
 %\clearpage
 \subsection{MPI Stacks} \label{sec:mpi}
 \input{common/mpi_slurm}
-
-\subsection{Performance Tools} \label{sec:install_perf_tools}
-\input{common/perf_tools_with_geopm}
 
 \subsection{Setup default development environment}
 \input{common/default_dev}


### PR DESCRIPTION
Remove GEOPM configuration and performance tools sections from all installation recipe documentation files across different distributions and architectures.

Fixes: #2143