### PR TITLE
spec: optimize lmod-defaults.spec with macros and improved scripting

### DIFF
--- a/components/admin/lmod-defaults/SPECS/lmod-defaults.spec
+++ b/components/admin/lmod-defaults/SPECS/lmod-defaults.spec
@@ -8,8 +8,20 @@
 #
 #----------------------------------------------------------------------------eh-
 
+%if "%{mpi_family}" == "impi"
+# For the Intel MPI based combinations, this adds a 'Requires:' to the compiler.
+# Usually the appropriate compiler is pulled in via the MPI packages, but this
+# does not happen for the Intel MPI compatibility package.
+# Unfortunately this also adds a 'BuildRequires:' which means some unnecessary
+# packages are downloaded during the build, but the package does not change.
+%define ohpc_compiler_dependent 1
+%endif
+
 %include %{_sourcedir}/OHPC_macros
 %{!?transport: %global transport %{nil}}
+
+# Define commonly used paths to reduce repetition
+%define mpi_module_dir %{OHPC_MODULEDEPS}/%{compiler_family}/%{mpi_family}
 
 Summary:   OpenHPC default login environments
 Name:      lmod-defaults-%{compiler_family}-%{mpi_family}%{transport}%{PROJ_DELIM}
@@ -20,16 +32,16 @@ Group:     %{PROJ_NAME}/admin
 URL:       https://github.com/openhpc/ohpc
 BuildArch: noarch
 Requires:  lmod%{PROJ_DELIM}
+
+%if "%{mpi_family}" == "impi"
+Requires:   intel-mpi-devel%{PROJ_DELIM}
+%else
 Requires:  %{mpi_family}%{transport}-%{compiler_family}%{PROJ_DELIM}
+%endif
 
 %description
-
 Provides default login configuration using the %{compiler_family} compiler
 toolchain and %{mpi_family} MPI environment.
-
-%prep
-
-%build
 
 %install
 
@@ -40,7 +52,7 @@ mkdir -p %{buildroot}/%{OHPC_MODULES}
 #############################################################################
 
 proc ModulesHelp { } {
-puts stderr "Setup default login environment"
+        puts stderr "Setup default login environment"
 }
 
 #
@@ -52,19 +64,20 @@ prepend-path     PATH   %{OHPC_PUB}/bin
 # include local packages installed via spack
 prepend-path MODULEPATH %{OHPC_MODULEDEPS}/spack/
 
+# Define modules to load/unload in order
+set modules_list [list autotools prun %{compiler_family} %{mpi_family}]
+
 if { [ expr [module-info mode load] || [module-info mode display] ] } {
         prepend-path MANPATH /usr/local/share/man:/usr/share/man/overrides:/usr/share/man/en:/usr/share/man
-        module try-add autotools
-        module try-add prun
-        module try-add %{compiler_family}
-        module try-add %{mpi_family}
+        foreach mod \$modules_list {
+                module try-add \$mod
+        }
 }
 
 if [ module-info mode remove ] {
-        module del %{mpi_family}
-        module del %{compiler_family}
-        module del prun
-        module del autotools
+        foreach mod [lreverse \$modules_list] {
+                module del \$mod
+        }
 }
 EOF
 
@@ -72,31 +85,32 @@ EOF
 %if "%{mpi_family}" == "mpich"
 %post
 
-if [ $1 -ge 1 ];then
+if [ "${1}" -ge 1 ]; then
+    # Get the latest version of the MPI package
+    version=$(rpm -q --qf '%%{VERSION}\n' "%{mpi_family}%{transport}-%{compiler_family}%{PROJ_DELIM}" | sort -rV | head -1)
 
-    version=`rpm -q --qf '%%{VERSION}\n' %{mpi_family}%{transport}-%{compiler_family}%{PROJ_DELIM} | sort -rV | head -1`
+    if [ -n "${version}" ]; then
+        moduleFile="${version}%{transport}"
+        module_dir="%{mpi_module_dir}"
 
-    moduleFile=$version%{transport}
-    echo $moduleFile
-    if [ -f %{OHPC_MODULEDEPS}/%{compiler_family}/%{mpi_family}/$moduleFile ];then
-        pushd %{OHPC_MODULEDEPS}/%{compiler_family}/%{mpi_family}
-        # remove previous default if it exists
-        if [ -f default ];then
-            rm -f default
+        if [ -f "${module_dir}/${moduleFile}" ]; then
+            pushd "${module_dir}" > /dev/null || exit 1
+            # Remove previous default if it exists
+            [ -L "default" ] && rm -f "default"
+            # Establish latest default
+            ln -s "${moduleFile}" "default"
+            popd > /dev/null
         fi
-        # establish latest default
-        ln -s $moduleFile default
-        popd
     fi
 fi
 
 %preun
 
-if [ $1 -ge 0 ];then
-    if [ -L %{OHPC_MODULEDEPS}/%{compiler_family}/%{mpi_family}/default ];then
-        rm -f %{OHPC_MODULEDEPS}/%{compiler_family}/%{mpi_family}/default
+if [ "${1}" -ge 0 ]; then
+    default_link="%{mpi_module_dir}/default"
+    if [ -L "${default_link}" ]; then
+        rm -f "${default_link}"
     fi
-
 fi
 
 %endif


### PR DESCRIPTION
- Add macro for commonly used OHPC_MODULEDEPS path pattern
- Optimize module loading/unloading with TCL list operations
- Improve shell scripting with proper variable quoting and error handling
- Reorganize Requires section to handle Intel MPI separately
- Clean up formatting and remove empty build sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)



(cherry picked from commit b4df832df2d69936cc37d46325c9885bd0f93f8c)