### PR TITLE
docs: add performance tools section to installation recipes

### DIFF
--- a/docs/recipes/install/almalinux9/aarch64/warewulf4/slurm/steps.tex
+++ b/docs/recipes/install/almalinux9/aarch64/warewulf4/slurm/steps.tex
@@ -236,6 +236,9 @@
 \subsection{MPI Stacks} \label{sec:mpi}
 \input{common/mpi_slurm}
 
+\subsection{Performance Tools} \label{sec:install_perf_tools}
+\input{common/perf_tools}
+
 \subsection{Setup default development environment}
 \input{common/default_dev}
 

--- a/docs/recipes/install/almalinux9/x86_64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/almalinux9/x86_64/warewulf/slurm/steps.tex
@@ -271,6 +271,9 @@
 \subsection{MPI Stacks} \label{sec:mpi}
 \input{common/mpi_slurm}
 
+\subsection{Performance Tools} \label{sec:install_perf_tools}
+\input{common/perf_tools}
+
 \subsection{Setup default development environment}
 \input{common/default_dev}
 

--- a/docs/recipes/install/almalinux9/x86_64/warewulf4/slurm/steps.tex
+++ b/docs/recipes/install/almalinux9/x86_64/warewulf4/slurm/steps.tex
@@ -237,6 +237,9 @@
 \subsection{MPI Stacks} \label{sec:mpi}
 \input{common/mpi_slurm}
 
+\subsection{Performance Tools} \label{sec:install_perf_tools}
+\input{common/perf_tools}
+
 \subsection{Setup default development environment}
 \input{common/default_dev}
 

--- a/docs/recipes/install/leap15/x86_64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/leap15/x86_64/warewulf/slurm/steps.tex
@@ -265,6 +265,9 @@
 \subsection{MPI Stacks} \label{sec:mpi}
 \input{common/mpi_slurm}
 
+\subsection{Performance Tools} \label{sec:install_perf_tools}
+\input{common/perf_tools}
+
 \subsection{Setup default development environment}
 \input{common/default_dev}
 

--- a/docs/recipes/install/openeuler22.03/x86_64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/openeuler22.03/x86_64/warewulf/slurm/steps.tex
@@ -271,6 +271,9 @@
 \subsection{MPI Stacks} \label{sec:mpi}
 \input{common/mpi_slurm}
 
+\subsection{Performance Tools} \label{sec:install_perf_tools}
+\input{common/perf_tools}
+
 \subsection{Setup default development environment}
 \input{common/default_dev}
 

--- a/docs/recipes/install/rocky9/aarch64/warewulf4/slurm/steps.tex
+++ b/docs/recipes/install/rocky9/aarch64/warewulf4/slurm/steps.tex
@@ -236,6 +236,9 @@
 \subsection{MPI Stacks} \label{sec:mpi}
 \input{common/mpi_slurm}
 
+\subsection{Performance Tools} \label{sec:install_perf_tools}
+\input{common/perf_tools}
+
 \subsection{Setup default development environment}
 \input{common/default_dev}
 

--- a/docs/recipes/install/rocky9/x86_64/warewulf/slurm/steps.tex
+++ b/docs/recipes/install/rocky9/x86_64/warewulf/slurm/steps.tex
@@ -271,6 +271,9 @@
 \subsection{MPI Stacks} \label{sec:mpi}
 \input{common/mpi_slurm}
 
+\subsection{Performance Tools} \label{sec:install_perf_tools}
+\input{common/perf_tools}
+
 \subsection{Setup default development environment}
 \input{common/default_dev}
 

--- a/docs/recipes/install/rocky9/x86_64/warewulf4/slurm/steps.tex
+++ b/docs/recipes/install/rocky9/x86_64/warewulf4/slurm/steps.tex
@@ -237,6 +237,9 @@
 \subsection{MPI Stacks} \label{sec:mpi}
 \input{common/mpi_slurm}
 
+\subsection{Performance Tools} \label{sec:install_perf_tools}
+\input{common/perf_tools}
+
 \subsection{Setup default development environment}
 \input{common/default_dev}
 


### PR DESCRIPTION
Add Performance Tools section back to all installation recipe documentation files across different distributions and architectures. Replaces GEOPM-specific performance tools with generic perf_tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)