### PR TITLE
ci: move lint jobs to dedicated workflow with container

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,37 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - 4.x
+  pull_request:
+    branches:
+      - 4.x
+
+jobs:
+  lint_markdown:
+    name: Run markdown linter
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Lint markdown
+      uses: DavidAnson/markdownlint-cli2-action@v15
+      with:
+        globs: |
+          README.md
+          CONTRIBUTING.md
+          containers/README.md
+          .github/workflows/README.md
+
+  lint:
+    strategy:
+      matrix:
+        step: [codespell, ruff-check, ruff-format, shellcheck, whitespace, shfmt, clang-format]
+    name: Run ${{ matrix.step }} linter
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/openhpc/ohpc-lint:latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run ${{ matrix.step }}
+      run: make -C tests/ci/ ${{ matrix.step }}-lint

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -35,34 +35,6 @@ jobs:
         export SKIP_CI_SPECS="${{ env.SKIP_CI_SPECS }}${{ env.JOB_SKIP_CI_SPECS }}"
         tests/ci/check_spec.py ${{ steps.files.outputs.added_modified }}
 
-  lint_markdown:
-    name: Run markdown linter
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Lint markdown
-      uses: DavidAnson/markdownlint-cli2-action@v15
-      with:
-        globs: |
-          README.md
-          CONTRIBUTING.md
-          containers/README.md
-          .github/workflows/README.md
-
-  lint:
-    strategy:
-      matrix:
-        step: [codespell, ruff-check, ruff-format, shellcheck, whitespace, shfmt, clang-format]
-    name: Run ${{ matrix.step }} linter
-    runs-on: ubuntu-latest
-    container:
-      image: registry.fedoraproject.org/fedora:latest
-    steps:
-    - name: Setup
-      run: dnf -y install codespell make ruff ShellCheck shfmt clang-tools-extra git
-    - uses: actions/checkout@v4
-    - name: Run ${{ matrix.step }}
-      run: make -C tests/ci/ ${{ matrix.step }}-lint
 
   build_on_rhel:
     strategy:


### PR DESCRIPTION
Move lint_markdown and lint jobs from validate.yml to new lint.yml workflow. Update lint job to use ghcr.io/openhpc/ohpc-lint:latest container, removing need for manual package installation of linting tools (codespell, ruff, ShellCheck, shfmt, clang-tools-extra).

🤖 Generated with [Claude Code](https://claude.com/claude-code)