### PR TITLE
Update LIKWID to version 5.5.0

### DIFF
--- a/components/perf-tools/likwid/SPECS/likwid.spec
+++ b/components/perf-tools/likwid/SPECS/likwid.spec
@@ -17,7 +17,7 @@
 
 Summary:   Performance tools for the Linux console
 Name:      %{pname}-%{compiler_family}%{PROJ_DELIM}
-Version:   5.4.1
+Version:   5.5.0
 Release:   1%{?dist}
 License:   GPL-3.0+
 Group:     %{PROJ_NAME}/perf-tools


### PR DESCRIPTION
Just a version update, no new build features.

- Add support for AMD Zen5
- Change hashtable to cwisstable
- New internals for error handling and memory management
- Topdown metrics for Intel SPR, ENR and GNR
- Update for Nvidia GPU support
- Less startup overhead by using optimized Uncore discovery for Intel
- A lot of warnings got fixed
- Wider data types for power readings
- Measure energy consumption for Nvidia GPUs
- Better messages when connection to access daemon fails
- Fix for SPR UPI and M3UPI units
- More peakflops benchmarks in likwid-bench
- Fixes for sysfeatures
- Update to buildsystem to allow parallel builds
- Wrapper mode for GPU monitoring
- Memory controllers (UMC) for AMD Zen4
- Minor fixes for Intel SierraForrest and Coffeelake