### PR TITLE
Use system provided autotools and libtool

### DIFF
--- a/components/admin/meta-packages/SPECS/meta-packages.spec
+++ b/components/admin/meta-packages/SPECS/meta-packages.spec
@@ -33,9 +33,9 @@ not make sense.
 
 %package -n %{PROJ_NAME}-autotools
 Summary:   OpenHPC autotools
-Requires:  autoconf%{PROJ_DELIM}
-Requires:  automake%{PROJ_DELIM}
-Requires:  libtool%{PROJ_DELIM}
+Requires:  autoconf
+Requires:  automake
+Requires:  libtool
 %description -n %{PROJ_NAME}-autotools
 Collection of GNU autotools packages
 

--- a/components/admin/test-suite/SPECS/tests.spec
+++ b/components/admin/test-suite/SPECS/tests.spec
@@ -22,8 +22,8 @@ Source0:   tests-ohpc.tar
 
 BuildRequires:  perl(File::Copy)
 BuildRequires:  perl(File::Compare)
-BuildRequires:  autoconf%{PROJ_DELIM}
-BuildRequires:  automake%{PROJ_DELIM}
+BuildRequires:  autoconf
+BuildRequires:  automake
 
 Requires: which bats
 
@@ -54,7 +54,6 @@ is made available under an '%{testuser}' user account.
 
 %build
 
-export PATH=/opt/ohpc/pub/utils/autotools/bin:$PATH
 cd tests
 ./bootstrap
 

--- a/components/io-libs/hdf5/SPECS/hdf5.spec
+++ b/components/io-libs/hdf5/SPECS/hdf5.spec
@@ -29,7 +29,7 @@ BuildRequires: perl(File::Compare)
 BuildRequires: perl(File::Copy)
 
 %if "%{compiler_family}" == "intel"
-BuildRequires: libtool%{PROJ_DELIM}
+BuildRequires: libtool
 %endif
 
 #!BuildIgnore: post-build-checks rpmlint-Factory
@@ -65,7 +65,6 @@ cp /usr/lib/rpm/config.guess bin
 %ohpc_setup_compiler
 
 %if "%{compiler_family}" == "intel"
-export PATH=%{OHPC_UTILS}/autotools/bin:${PATH}
 autoreconf -if
 sed -e 's/NO_SYMBOLS_CFLAGS="-Wl,-s"/NO_SYMBOLS_CFLAGS=/g' -i config/intel-flags
 sed -e 's/NO_SYMBOLS_CFLAGS="-Wl,-s"/NO_SYMBOLS_CFLAGS=/g' -i config/intel-cxxflags

--- a/components/io-libs/phdf5/SPECS/hdf5.spec
+++ b/components/io-libs/phdf5/SPECS/hdf5.spec
@@ -31,7 +31,7 @@ BuildRequires: perl(File::Compare)
 BuildRequires: perl(File::Copy)
 
 %if "%{compiler_family}" == "intel"
-BuildRequires: libtool%{PROJ_DELIM}
+BuildRequires: libtool
 %endif
 
 #!BuildIgnore: post-build-checks rpmlint-Factory
@@ -95,7 +95,6 @@ export CFLAGS="$CFLAGS -Wno-redundant-decls"
 %endif
 
 %if "%{compiler_family}" == "intel"
-export PATH=%{OHPC_UTILS}/autotools/bin:${PATH}
 autoreconf -if
 sed -e 's/NO_SYMBOLS_CFLAGS="-Wl,-s"/NO_SYMBOLS_CFLAGS=/g' -i config/intel-flags
 sed -e 's/NO_SYMBOLS_CFLAGS="-Wl,-s"/NO_SYMBOLS_CFLAGS=/g' -i config/intel-cxxflags

--- a/components/io-libs/pnetcdf/SPECS/pnetcdf.spec
+++ b/components/io-libs/pnetcdf/SPECS/pnetcdf.spec
@@ -36,7 +36,7 @@ BuildRequires: m4
 BuildRequires: zlib-devel
 BuildRequires: perl(File::Compare)
 BuildRequires: perl(File::Copy)
-BuildRequires: libtool%{PROJ_DELIM}
+BuildRequires: libtool
 
 # Default library install path
 %define install_path %{OHPC_LIBS}/%{compiler_family}/%{mpi_family}/%{pname}/%version
@@ -64,7 +64,6 @@ cp /usr/lib/rpm/config.guess bin
 %endif
 %endif
 
-export PATH=%{OHPC_UTILS}/autotools/bin:${PATH}
 autoreconf -if
 
 # OpenHPC compiler/mpi designation

--- a/components/perf-tools/extrae/SPECS/extrae.spec
+++ b/components/perf-tools/extrae/SPECS/extrae.spec
@@ -27,9 +27,9 @@ Source0:	https://ftp.tools.bsc.es/extrae/extrae-%{version}-src.tar.bz2
 Patch0:		arm.function.definition.patch
 
 
-BuildRequires:	autoconf%{PROJ_DELIM}
-BuildRequires:	automake%{PROJ_DELIM}
-BuildRequires:	libtool%{PROJ_DELIM} make which
+BuildRequires:	autoconf
+BuildRequires:	automake
+BuildRequires:	libtool make which
 BuildRequires:	binutils-devel
 BuildRequires:	libxml2-devel
 BuildRequires:	papi%{PROJ_DELIM}
@@ -65,7 +65,6 @@ export compiler_vars="CC=${CC} CXX=${CXX} MPIF90=mpiifort $compiler_vars"
 %endif
 %endif
 
-export PATH=%{OHPC_UTILS}/autotools/bin:${PATH}
 ./bootstrap
 export LDFLAGS="$LDFLAGS -lz"
 %if 0%{?sle_version}


### PR DESCRIPTION
No reason to ship autotools and libtool anymore. The versions from the OS are good enough.