### PR TITLE
Use ohpc-analysis container in CI workflows

### DIFF
--- a/.github/workflows/build-order-analysis.yml
+++ b/.github/workflows/build-order-analysis.yml
@@ -17,13 +17,9 @@ jobs:
     name: Analyze Package Build Order
     runs-on: ubuntu-latest
     container:
-      image: docker.io/library/almalinux:10
+      image: ghcr.io/openhpc/ohpc-analysis:latest
 
     steps:
-    - name: Setup AlmaLinux Environment
-      run: |
-        dnf install -y epel-release git python3 rpm-build rpmdevtools
-
     - name: Checkout code
       uses: actions/checkout@v4
 

--- a/.github/workflows/cleanup-packages.yml
+++ b/.github/workflows/cleanup-packages.yml
@@ -44,11 +44,23 @@ jobs:
           delete-only-untagged-versions: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Delete untagged ohpc-analysis images
+        id: cleanup-analysis
+        continue-on-error: true
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: ohpc-analysis
+          package-type: container
+          min-versions-to-keep: 3
+          delete-only-untagged-versions: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Report cleanup results
         run: |
           echo "Cleanup Results:"
           echo "Main container cleanup: ${{ steps.cleanup-main.outcome }}"
           echo "Lint container cleanup: ${{ steps.cleanup-lint.outcome }}"
+          echo "Analysis container cleanup: ${{ steps.cleanup-analysis.outcome }}"
 
           if [[ "${{ steps.cleanup-main.outcome }}" == "failure" ]]; then
             echo "⚠️ Main container cleanup failed - package may not exist yet"
@@ -56,6 +68,10 @@ jobs:
 
           if [[ "${{ steps.cleanup-lint.outcome }}" == "failure" ]]; then
             echo "⚠️ Lint container cleanup failed - package may not exist yet"
+          fi
+
+          if [[ "${{ steps.cleanup-analysis.outcome }}" == "failure" ]]; then
+            echo "⚠️ Analysis container cleanup failed - package may not exist yet"
           fi
 
           echo "✅ Cleanup workflow completed"

--- a/.github/workflows/package-count-analysis.yml
+++ b/.github/workflows/package-count-analysis.yml
@@ -17,13 +17,9 @@ jobs:
     name: Analyze Available Package Counts
     runs-on: ubuntu-latest
     container:
-      image: registry.access.redhat.com/ubi10:latest
+      image: ghcr.io/openhpc/ohpc-analysis:latest
 
     steps:
-    - name: Setup Environment
-      run: |
-        dnf install -y yum-utils git rpm-build rpmdevtools dnf-plugins-core curl
-
     - name: Checkout code
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Update package-count-analysis and build-order-analysis workflows to use the new ohpc-analysis container instead of installing packages at runtime. Add cleanup for ohpc-analysis container images.

Generated with [Claude Code](https://claude.com/claude-code)