### PR TITLE
ci: fix YAML syntax error in ccache-stats-comment.yml

### DIFF
--- a/.github/workflows/ccache-stats-comment.yml
+++ b/.github/workflows/ccache-stats-comment.yml
@@ -85,10 +85,8 @@ jobs:
         }
 
         # Start building the comment
-        cat > artifacts/comment.md << 'HEADER'
-## 🚀 CCache Statistics
-
-HEADER
+        echo '## 🚀 CCache Statistics' > artifacts/comment.md
+        echo '' >> artifacts/comment.md
 
         # Build the main table
         echo "| Configuration | 🐧 RHEL | 🦊 openEuler |" >> artifacts/comment.md


### PR DESCRIPTION
Replace heredoc with echo statements to avoid YAML parsing issues with indented heredoc terminators.

Generated with [Claude Code](https://claude.ai/code)