### PR TITLE
ci: add Intel oneAPI package caching for faster builds

### DIFF
--- a/.github/actions/oneapi-cache/action.yml
+++ b/.github/actions/oneapi-cache/action.yml
@@ -1,0 +1,37 @@
+name: 'OneAPI Package Cache'
+description: 'Restore or save Intel oneAPI dnf package cache'
+inputs:
+  mode:
+    description: 'Operation mode: restore or save'
+    required: true
+  max-size-mb:
+    description: 'Maximum cache size in MB (only used for save mode)'
+    required: false
+    default: '2048'
+runs:
+  using: 'composite'
+  steps:
+    - name: Restore oneAPI package cache
+      if: inputs.mode == 'restore'
+      uses: actions/cache/restore@v4
+      with:
+        path: /var/cache/dnf/oneAPI-*/packages
+        key: dnf-oneapi-rhel-${{ github.sha }}
+        restore-keys: |
+          dnf-oneapi-rhel-
+    - name: Clean oneAPI package cache
+      if: inputs.mode == 'save'
+      shell: bash
+      run: |
+        MAX_SIZE=${{ inputs.max-size-mb }}
+        # Limit cache by removing oldest files
+        while [ $(du -sm /var/cache/dnf/oneAPI-*/packages 2>/dev/null | awk '{sum+=$1} END {print sum+0}') -gt $MAX_SIZE ]; do
+          oldest=$(find /var/cache/dnf/oneAPI-*/packages -type f -printf '%T+ %p\n' 2>/dev/null | sort | head -1 | cut -d' ' -f2-)
+          [ -n "$oldest" ] && rm -f "$oldest" || break
+        done
+    - name: Save oneAPI package cache
+      if: inputs.mode == 'save'
+      uses: actions/cache/save@v4
+      with:
+        path: /var/cache/dnf/oneAPI-*/packages
+        key: dnf-oneapi-rhel-${{ github.sha }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -71,6 +71,11 @@ jobs:
         key: ccache-rhel-${{ matrix.arch }}-${{ matrix.compiler }}-${{ github.sha }}
         restore-keys: |
           ccache-rhel-${{ matrix.arch }}-${{ matrix.compiler }}-
+    - name: Restore oneAPI package cache
+      if: matrix.compiler == 'intel'
+      uses: ./.github/actions/oneapi-cache
+      with:
+        mode: restore
     - name: Setup
       run: tests/ci/prepare-ci-environment.sh  ${{ matrix.compiler }}
     - id: files
@@ -102,6 +107,11 @@ jobs:
           /home/ohpc/rpmbuild/RPMS/noarch/*rpm
           /home/ohpc/rpmbuild/RPMS/x86_64/*rpm
           /tmp/empty
+    - name: Save oneAPI package cache
+      if: always() && matrix.compiler == 'intel'
+      uses: ./.github/actions/oneapi-cache
+      with:
+        mode: save
     - name: Save ccache
       if: always()
       uses: actions/cache/save@v4
@@ -150,6 +160,11 @@ jobs:
         key: ccache-rhel-${{ matrix.arch }}-${{ matrix.compiler }}-${{ github.sha }}-build
         restore-keys: |
           ccache-rhel-${{ matrix.arch }}-${{ matrix.compiler }}-
+    - name: Restore oneAPI package cache
+      if: matrix.compiler == 'intel'
+      uses: ./.github/actions/oneapi-cache
+      with:
+        mode: restore
     - name: Setup
       run: tests/ci/prepare-ci-environment.sh  ${{ matrix.compiler }}
     - id: files
@@ -198,6 +213,11 @@ jobs:
         name: test-results-${{ matrix.compiler }}-${{ matrix.os }}
         retention-days: 1
         path: tests/**/*.log.xml
+    - name: Save oneAPI package cache
+      if: always() && matrix.compiler == 'intel'
+      uses: ./.github/actions/oneapi-cache
+      with:
+        mode: save
     - name: Save ccache
       if: always()
       uses: actions/cache/save@v4

--- a/tests/ci/prepare-ci-environment.sh
+++ b/tests/ci/prepare-ci-environment.sh
@@ -166,6 +166,10 @@ if [ "${FACTORY_VERSION}" != "" ]; then
 fi
 
 dnf_rhel() {
+	# Enable keepcache for dnf if OneAPI is enabled to cache large Intel packages
+	if [ -n "${ENABLE_ONEAPI}" ]; then
+		echo "keepcache=1" >>/etc/dnf/dnf.conf
+	fi
 	loop_command "${PKG_MANAGER}" "${YES}" install ${COMMON_PKGS} lua epel-release dnf-plugins-core git rpm-build gawk "${OHPC_RELEASE}"
 	loop_command "${PKG_MANAGER}" config-manager --set-enabled crb
 	if [ "${FACTORY_VERSION}" != "" ]; then


### PR DESCRIPTION
Add a reusable composite action to cache Intel oneAPI dnf packages between workflow runs. This avoids re-downloading large Intel compiler packages on every build.

Changes:
- Add .github/actions/oneapi-cache/ composite action with restore/save modes and configurable max cache size (default 2GB)
- Enable dnf keepcache in prepare-ci-environment.sh when Intel oneAPI is being installed
- Add oneAPI cache restore/save steps to RHEL build and test jobs (only for intel compiler matrix)

Generated with [Claude Code](https://claude.ai/code)