### PR TITLE
ucx: upgrade to 1.20.0

### DIFF
--- a/.github/workflows/build-order-analysis.yml
+++ b/.github/workflows/build-order-analysis.yml
@@ -24,9 +24,11 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Save PR context
+      env:
+        EVENT_JSON: ${{ toJSON(github.event) }}
       run: |
         mkdir -p artifacts
-        echo '${{ toJSON(github.event) }}' > artifacts/event.json
+        printenv EVENT_JSON > artifacts/event.json
 
     - name: Setup RPM build environment
       run: |

--- a/.github/workflows/package-count-analysis.yml
+++ b/.github/workflows/package-count-analysis.yml
@@ -26,9 +26,11 @@ jobs:
         fetch-depth: 0  # Fetch full history for proper branch detection
 
     - name: Save PR context
+      env:
+        EVENT_JSON: ${{ toJSON(github.event) }}
       run: |
         mkdir -p artifacts
-        echo '${{ toJSON(github.event) }}' > artifacts/event.json
+        printenv EVENT_JSON > artifacts/event.json
 
 
     - name: Run package count analysis

--- a/components/mpi-families/ucx/SPECS/ucx.spec
+++ b/components/mpi-families/ucx/SPECS/ucx.spec
@@ -27,13 +27,13 @@
 %define pname ucx
 
 Name:    ucx%{PROJ_DELIM}
-Version: 1.18.0
+Version: 1.20.0
 Release: 1%{?dist}
 Summary: UCX is a communication library implementing high-performance messaging
 Group:   %{PROJ_NAME}/mpi-families
 License: BSD
 URL:     http://www.openucx.org
-Source0: https://github.com/openucx/%{pname}/releases/download/v%{version}/%{pname}-%{version}.tar.gz
+Source0: https://github.com/openucx/%{pname}/releases/download/%{version}/%{pname}-%{version}.tar.gz
 
 # UCX currently supports only the following architectures
 ExclusiveArch: aarch64 ppc64le x86_64


### PR DESCRIPTION
Unfortunately upstream dropped the v prefix for this release.