### PR TITLE
Update ADIOS2 to 2.11.0 and modernize tests

### DIFF
--- a/components/admin/ohpc-filesystem/SPECS/ohpc-filesystem.spec
+++ b/components/admin/ohpc-filesystem/SPECS/ohpc-filesystem.spec
@@ -8,14 +8,8 @@
 #
 #----------------------------------------------------------------------------eh-
 
-%if 0%{?rhel} >= 9 || 0%{?openEuler} || 0%{?sle_version} >= 150400
-%define version 3.4
-%else
-%define version 2.7
-%endif
-
 Name: ohpc-filesystem
-Version: %{version}
+Version: 4.1
 Release: %{?dist}.3
 Summary: Common top-level OpenHPC directories
 

--- a/components/io-libs/adios2/SPECS/adios2.spec
+++ b/components/io-libs/adios2/SPECS/adios2.spec
@@ -20,7 +20,7 @@
 
 Summary: The Adaptable IO System v2 (ADIOS2)
 Name:    %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-Version: 2.10.2
+Version: 2.11.0
 Release: 1%{?dist}
 License: Apache License 2.0
 Group:   %{PROJ_NAME}/io-libs
@@ -28,14 +28,9 @@ Url:     https://adios2.readthedocs.io/en/latest/index.html
 Source0: https://github.com/ornladios/ADIOS2/archive/refs/tags/v%{version}.tar.gz
 AutoReq: no
 
-%if 0%{?rhel} || 0%{?openEuler}
 BuildRequires:  bzip2-devel
 BuildRequires:  yaml-cpp-devel
 Requires: yaml-cpp
-%endif
-%if 0%{?suse_version}
-BuildRequires:  libbz2-devel
-%endif
 
 BuildRequires: libtool cmake make
 Requires:      lmod%{PROJ_DELIM} >= 7.6.1
@@ -120,8 +115,7 @@ cmake \
     -DPYTHON_EXECUTABLE=%{__python} \
     -DPython_FIND_STRATEGY=LOCATION \
     ..
-make -j$(nproc)
-# make test
+make %{?_smp_mflags}
 
 
 %install

--- a/tests/ci/Makefile
+++ b/tests/ci/Makefile
@@ -63,7 +63,10 @@ codespell-lint:
 		tests/libs/trilinos/tests/rm_execution \
 		tests/perf-tools/papi/tests/rm_execution \
 		tests/perf-tools/papi/tests/test_module \
-		tests/perf-tools/papi/ohpc-tests/test_compiler_families
+		tests/perf-tools/papi/ohpc-tests/test_compiler_families \
+		tests/libs/adios2/tests/rm_execution \
+		tests/libs/adios2/tests/test_module \
+		tests/libs/adios2/ohpc-tests/test_mpi_families
 
 ruff-check-lint:
 	@echo "Running 'ruff check' on selected Python files"
@@ -143,6 +146,9 @@ whitespace-lint:
 		tests/perf-tools/papi/tests/rm_execution \
 		tests/perf-tools/papi/tests/test_module \
 		tests/perf-tools/papi/ohpc-tests/test_compiler_families \
+		tests/libs/adios2/tests/rm_execution \
+		tests/libs/adios2/tests/test_module \
+		tests/libs/adios2/ohpc-tests/test_mpi_families \
 		containers/* \
 		\*.tex
 
@@ -220,7 +226,10 @@ shellcheck-lint:
 		../../tests/perf-tools/scorep/tests/test_module \
 		../../tests/perf-tools/papi/tests/rm_execution \
 		../../tests/perf-tools/papi/tests/test_module \
-		../../tests/perf-tools/papi/ohpc-tests/test_compiler_families
+		../../tests/perf-tools/papi/ohpc-tests/test_compiler_families \
+		../../tests/libs/adios2/tests/rm_execution \
+		../../tests/libs/adios2/tests/test_module \
+		../../tests/libs/adios2/ohpc-tests/test_mpi_families
 
 shfmt-lint:
 	@echo "Running 'shfmt' on selected shell scripts"
@@ -271,7 +280,9 @@ shfmt-lint:
 		../../tests/libs/fftw/tests/rm_execution \
 		../../tests/libs/trilinos/tests/rm_execution \
 		../../tests/perf-tools/papi/tests/rm_execution \
-		../../tests/perf-tools/papi/tests/test_module
+		../../tests/perf-tools/papi/tests/test_module \
+		../../tests/libs/adios2/tests/rm_execution \
+		../../tests/libs/adios2/tests/test_module
 	shfmt -w -d \
 		../../tests/ci/prepare-ci-environment.sh \
 		../../misc/build_order.sh \
@@ -287,7 +298,8 @@ shfmt-lint:
 		../../docs/recipes/install/common/listohpc \
 		../../containers/*.sh \
 		../../containers/examples/mpi/*.sh \
-		../../tests/perf-tools/papi/ohpc-tests/test_compiler_families
+		../../tests/perf-tools/papi/ohpc-tests/test_compiler_families \
+		../../tests/libs/adios2/ohpc-tests/test_mpi_families
 
 clang-format-lint:
 	@echo "Running 'clang-format' on selected source code files"

--- a/tests/libs/adios2/configure.ac
+++ b/tests/libs/adios2/configure.ac
@@ -2,8 +2,8 @@
 # Process this file with autoconf to produce a configure script.
 #
 
-AC_PREREQ(2.59)
-AC_INIT([adios2], [2.8.3], [https://github.com/openhpc/ohpc])
+AC_PREREQ([2.71])
+AC_INIT([adios2],[2.8.3],[https://github.com/openhpc/ohpc])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
@@ -14,7 +14,7 @@ AC_MSG_CHECKING([for ADIOS2_DIR environment variable])
 if test "x$ADIOS2_DIR" = "x"; then
    AC_MSG_RESULT([no])
    echo
-   AC_ERROR([ADIOS2_DIR not defined - please load adios2 environment.])
+   AC_MSG_ERROR(ADIOS2_DIR not defined - please load adios2 environment.)
 else
    AC_MSG_RESULT([yes])
 fi
@@ -24,7 +24,7 @@ AC_MSG_CHECKING([for HDF5_DIR environment variable])
 if test "x$HDF5_DIR" = "x"; then
    AC_MSG_RESULT([no])
    echo
-   AC_ERROR([HDF5_DIR not defined - please load phdf5 environment.])
+   AC_MSG_ERROR(HDF5_DIR not defined - please load phdf5 environment.)
 else
    AC_MSG_RESULT([yes])
 fi
@@ -47,7 +47,7 @@ LIBS="-lm -lhdf5"
 AC_CONFIG_FILES(Makefile tests/Makefile )
 
 # Configure
-AC_OUTPUT()
+AC_OUTPUT
 
 echo
 echo '-------------------------------------------------- SUMMARY --------------------------------------------------'

--- a/tests/libs/adios2/ohpc-tests/test_mpi_families
+++ b/tests/libs/adios2/ohpc-tests/test_mpi_families
@@ -1,42 +1,44 @@
 #!/bin/bash
 # -*-sh-*-
 
-TEST_LOGS=""
-MAKEFLAGS=""
+export MAKEFLAGS=""
 status=0
 
-source ./common/TEST_ENV  || exit 1
+source ./common/TEST_ENV || exit 1
 source ./common/functions || exit 1
 
 cd libs/adios2 || exit 1
+
 export BATS_JUNIT_CLASS=Adios2
 
 # bootstrap the local autotools project if necessary
 
 ./bootstrap || exit 1
 
-for compiler in $COMPILER_FAMILIES ; do
-    for mpi in $MPI_FAMILIES ; do
+for compiler in ${COMPILER_FAMILIES}; do
+	for mpi in ${MPI_FAMILIES}; do
 
-      echo " "
-      echo " "
-      echo "-------------------------------------------------------"
-      echo "Libraries: ADIOS2 tests: $compiler-$mpi"
-      echo "-------------------------------------------------------"
+		echo " "
+		echo " "
+		echo "-------------------------------------------------------"
+		echo "Libraries: ADIOS2 tests: ${compiler}-${mpi}"
+		echo "-------------------------------------------------------"
 
-      module purge          || exit 1 
-      module load prun      || exit 1
-      module load $compiler || exit 1
-      module load $mpi      || exit 1
-      module load adios2    || exit 1
+		module purge || exit 1
+		module load prun || exit 1
+		module load "${compiler}" || exit 1
+		module load "${mpi}" || exit 1
+		module load adios2 || exit 1
 
-      ./configure           || exit 1
-      make clean            || exit 1
-      make -k check         || status=1
+		./configure || exit 1
+		make clean || exit 1
+		make -k check || status=1
 
-      save_logs_mpi_family tests $compiler $mpi
-      make distclean
-    done
+		save_logs_mpi_family tests "${compiler}" "${mpi}"
+
+		make distclean
+
+	done
 done
 
 exit ${status}

--- a/tests/libs/adios2/tests/Makefile.am
+++ b/tests/libs/adios2/tests/Makefile.am
@@ -2,12 +2,12 @@
 TESTS                   = arrays_write
 check_PROGRAMS          = arrays_write
 arrays_write_SOURCES    = arrays_write.cpp
-arrays_write_LDADD      = -ladios2_cxx11 -ladios2_cxx11_mpi
+arrays_write_LDADD      = -ladios2_cxx -ladios2_cxx_mpi
 
 TESTS                  += arrays_read
 check_PROGRAMS         += arrays_read
 arrays_read_SOURCES     = arrays_read.cpp
-arrays_read_LDADD       = -ladios2_cxx11 -ladios2_cxx11_mpi
+arrays_read_LDADD       = -ladios2_cxx -ladios2_cxx_mpi
 
 TESTS                  += scalars_write
 check_PROGRAMS         += scalars_write

--- a/tests/libs/adios2/tests/rm_execution
+++ b/tests/libs/adios2/tests/rm_execution
@@ -1,39 +1,39 @@
-#!/usr/bin/env -S bats --report-formatter junit --formatter tap
+#!/usr/bin/env -S bats --report-formatter junit --formatter tap -j 2
 # -*-sh-*-
 
-load ./common/test_helper_functions || exit 1
-source ./common/functions || exit 1
+load ../../../common/test_helper_functions || exit 1
+source ../../../common/functions || exit 1
 
-if [ -s ./common/TEST_ENV ];then
-    source ./common/TEST_ENV
+if [ -s ../../../TEST_ENV ]; then
+	source ../../../TEST_ENV
 fi
 
-check_rms
-rm=$RESOURCE_MANAGER
-testname="libs/ADIOS2"
+setup_file() {
+	check_rms
 
-NODES=2
-TASKS=`tasks_count 8`
+	NODES=2
+	TASKS=$(tasks_count 8)
+	ARGS=""
+	TIMEOUT="00:05:00"
+	TESTNAME="libs/adios2"
 
-@test "[$testname] MPI C binary runs under resource manager ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
-    binary=arrays_write
-    if [ ! -x $binary ];then
-	flunk "$binary binary does not exist"
-    fi
-
-    run_mpi_binary ./${binary} "" $NODES $TASKS 
-    assert_success
+	export NODES TASKS ARGS TIMEOUT TESTNAME
 }
 
-@test "[$testname] MPI F90 binary runs under resource manager ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
-    binary=scalars_write
-    if [ ! -x $binary ];then
-	flunk "$binary binary does not exist"
-    fi
+@test "[${TESTNAME}] MPI C binary runs under resource manager (${RESOURCE_MANAGER}/${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	if [ ! -x arrays_write ]; then
+		flunk "arrays_write binary does not exist"
+	fi
 
-    run_mpi_binary ./${binary} "" $NODES $TASKS
-    assert_success
+	run_mpi_binary -t "${TIMEOUT}" ./arrays_write "${ARGS}" "${NODES}" "${TASKS}"
+	assert_success
 }
 
+@test "[${TESTNAME}] MPI F90 binary runs under resource manager (${RESOURCE_MANAGER}/${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	if [ ! -x scalars_write ]; then
+		flunk "scalars_write binary does not exist"
+	fi
 
-
+	run_mpi_binary -t "${TIMEOUT}" ./scalars_write "${ARGS}" "${NODES}" "${TASKS}"
+	assert_success
+}

--- a/tests/libs/adios2/tests/test_module
+++ b/tests/libs/adios2/tests/test_module
@@ -1,117 +1,128 @@
-#!/usr/bin/env -S bats --report-formatter junit --formatter tap
+#!/usr/bin/env -S bats --report-formatter junit --formatter tap -j 8
 # -*-sh-*-
 
-source ./common/test_helper_functions.bash || exit 1
-source ./common/functions || exit 1
+source ../../../common/test_helper_functions.bash || exit 1
+source ../../../common/functions || exit 1
 
-if [ -s ./common/TEST_ENV ];then
-    source ./common/TEST_ENV
+if [ -s ../../../common/TEST_ENV ]; then
+	source ../../../common/TEST_ENV
 fi
 
-PKG=ADIOS2
-module=adios2
-testname=libs/ADIOS2
-library=libadios2
-header=adios2.h
+setup_file() {
+	PKG=ADIOS2
+	MODULE=adios2
+	TESTNAME="libs/adios2"
+	LIBRARY=libadios2
+	HEADER=adios2.h
 
-check_rms
-
-@test "[$testname] Verify $PKG module is loaded and matches rpm version ($LMOD_FAMILY_COMPILER)" {
-    module list $module | grep "1) $module" >& .cmd_output || exit 1
-    run grep $module .cmd_output 
-    assert_success
-    
-    # check version against rpm
-    local rpm
-    rpm=$(get_rpm_name ${module})
-    local version="$(rpm -q --queryformat='%{VERSION}\n' $rpm)"
-    run cat .cmd_output
-    assert_output "  1) $module/$version"
-
-    rm -f .cmd_output
+	export PKG MODULE TESTNAME LIBRARY HEADER
 }
 
-@test "[$testname] Verify module ${PKG}_DIR is defined and exists ($LMOD_FAMILY_COMPILER)" {
-    DIR=${PKG}_DIR
-    if [ -z ${!DIR} ];then
-        flunk "${PKG}_DIR directory not defined"
-    fi
-    
-    if [ ! -d ${!DIR} || -z "${!DIR}" ];then
-        flunk "directory ${!DIR} does not exist"
-    fi 
+setup() {
+	OUTPUT="$(mktemp)"
+
+	export OUTPUT
 }
 
-@test "[$testname] Verify module ${PKG}_BIN is defined and exists" {
-    BIN=${PKG}_BIN
-    if [ -z ${!BIN} ];then
-        flunk "${PKG}_BIN directory not defined"
-    fi
-    
-    if [ ! -d ${!BIN} || -z "${!BIN}" ];then
-        flunk "directory ${!BIN} does not exist"
-    fi 
+teardown() {
+	rm -f "${OUTPUT}"
 }
 
+@test "[${TESTNAME}] Verify ${PKG} module is loaded and matches rpm version (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	module list "${MODULE}" | grep "1) ${MODULE}" >&"${OUTPUT}" || exit 1
+	run grep "${MODULE}" "${OUTPUT}"
+	assert_success
+
+	# check version against rpm
+	local rpm
+	rpm=$(get_rpm_name "${MODULE}")
+	local version
+	version="$(rpm -q --queryformat='%{VERSION}\n' "${rpm}")"
+	run cat "${OUTPUT}"
+	assert_output "  1) ${MODULE}/${version}"
+}
+
+@test "[${TESTNAME}] Verify module ${PKG}_DIR is defined and exists (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	PKG_DIR="${PKG}_DIR"
+
+	if [ -z "${!PKG_DIR}" ]; then
+		flunk "${PKG}_DIR directory not defined"
+	fi
+
+	if [ ! -d "${!PKG_DIR}" ]; then
+		flunk "directory ${!PKG_DIR} does not exist"
+	fi
+}
+
+@test "[${TESTNAME}] Verify module ${PKG}_BIN is defined and exists (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	BIN="${PKG}_BIN"
+
+	if [ -z "${!BIN}" ]; then
+		flunk "${PKG}_BIN directory not defined"
+	fi
+
+	if [ ! -d "${!BIN}" ]; then
+		flunk "directory ${!BIN} does not exist"
+	fi
+}
 
 # ----------
 # Lib Tests
 # ----------
 
-@test "[$testname] Verify module ${PKG}_LIB is defined and exists ($LMOD_FAMILY_COMPILER)" {
-    LIB=${PKG}_LIB
+@test "[${TESTNAME}] Verify module ${PKG}_LIB is defined and exists (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	LIB="${PKG}_LIB"
 
-    if [ -z ${!LIB} ];then
-        flunk "${PKG}_LIB directory not defined"
-    fi
- 
-    if [ ! -d ${!LIB} ];then
-        flunk "directory ${!LIB} does not exist"
-    fi 
+	if [ -z "${!LIB}" ]; then
+		flunk "${PKG}_LIB directory not defined"
+	fi
+
+	if [ ! -d "${!LIB}" ]; then
+		flunk "directory ${!LIB} does not exist"
+	fi
 }
 
-@test "[$testname] Verify (dynamic) library available in ${PKG}_LIB ($LMOD_FAMILY_COMPILER)" {
-    LIB=${PKG}_LIB
+@test "[${TESTNAME}] Verify dynamic library available in ${PKG}_LIB (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	LIB="${PKG}_LIB"
 
-    if [ -z ${!LIB} ];then
-        flunk "${PKG}_LIB directory not defined"
-    fi
+	if [ -z "${!LIB}" ]; then
+		flunk "${PKG}_LIB directory not defined"
+	fi
 
-    for flavor in c core cxx11 fortran; do
-        if [ ! -s ${!LIB}/${library}_${flavor}.so ];then
-            flunk "${library}_${flavor}.so does not exist"
-        fi
-        if [ ! -s ${!LIB}/${library}_${flavor}_mpi.so ];then
-            flunk "${library}_${flavor}_mpi.so does not exist"
-        fi 
-    done
+	for flavor in c core cxx fortran; do
+		if [ ! -s "${!LIB}/${LIBRARY}_${flavor}.so" ]; then
+			flunk "${LIBRARY}_${flavor}.so does not exist"
+		fi
+		if [ ! -s "${!LIB}/${LIBRARY}_${flavor}_mpi.so" ]; then
+			flunk "${LIBRARY}_${flavor}_mpi.so does not exist"
+		fi
+	done
 }
 
 # --------------
 # Include Tests
 # --------------
 
-@test "[$testname] Verify module ${PKG}_INC is defined and exists ($LMOD_FAMILY_COMPILER)" {
-    INC=${PKG}_INC
+@test "[${TESTNAME}] Verify module ${PKG}_INC is defined and exists (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	INC="${PKG}_INC"
 
-    if [ -z ${!INC} ];then
-        flunk "${PKG}_INC directory not defined"
-    fi
-    
-    if [ ! -d ${!INC} ];then
-        flunk "directory ${!INC} does not exist"
-    fi 
+	if [ -z "${!INC}" ]; then
+		flunk "${PKG}_INC directory not defined"
+	fi
+
+	if [ ! -d "${!INC}" ]; then
+		flunk "directory ${!INC} does not exist"
+	fi
 }
 
-@test "[$testname] Verify header file is present in ${PKG}_INC ($LMOD_FAMILY_COMPILER)" {
-    INC=${PKG}_INC
+@test "[${TESTNAME}] Verify header file is present in ${PKG}_INC (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	INC="${PKG}_INC"
 
-    if [ -z ${!INC} ];then
-        flunk "${PKG}_INC directory not defined"
-    fi
-    
-    if [ ! -s ${!INC}/${header} ];then
-        flunk "directory $header file does not exist"
-    fi 
+	if [ -z "${!INC}" ]; then
+		flunk "${PKG}_INC directory not defined"
+	fi
+
+	if [ ! -s "${!INC}/${HEADER}" ]; then
+		flunk "${HEADER} file does not exist"
+	fi
 }
-


### PR DESCRIPTION
  - Bump ohpc-filesystem version to 4.1
  - Update ADIOS2 from 2.10.x to 2.11.0
  - Modernize adios2 tests following best practices (parallel execution, proper variable quoting, setup_file/teardown patterns)
  - Add adios2 tests to CI lint targets (shellcheck, shfmt, codespell, whitespace)