### PR TITLE
papi: use static version macro for OBS compatibility

### DIFF
--- a/components/perf-tools/papi/SPECS/papi.spec
+++ b/components/perf-tools/papi/SPECS/papi.spec
@@ -13,7 +13,7 @@
 # Base package name
 %define pname papi
 %define papi_version 7-2-0
-%define dot_version %(tr "-" "." <<< %{papi_version})
+%define dot_version 7.2.0
 
 Summary:   Performance Application Programming Interface
 Name:      %{pname}%{PROJ_DELIM}


### PR DESCRIPTION
Change dot_version from shell expansion to a static value. OBS source services run before rpmbuild parses the spec file, so shell command expansion %(tr "-" "." <<< ...) doesn't work when downloading sources.

Generated with [Claude Code](https://claude.com/claude-code)