### PR TITLE
tests: fix double-free in mfem ex1p_perf test

### DIFF
--- a/tests/libs/mfem/tests/parallel/ex1p_perf.cpp
+++ b/tests/libs/mfem/tests/parallel/ex1p_perf.cpp
@@ -338,7 +338,7 @@ int ex1_t<dim>::run(Mesh *mesh, int ser_ref_levels, int par_ref_levels,
       }
       delete fespace;
       delete fec;
-      delete mesh;
+      delete pmesh;
       return 5;
    }
 


### PR DESCRIPTION
The mesh pointer was deleted at line 279 after creating ParMesh, but the error path at line 341 tried to delete it again. Change to delete pmesh instead since that's the active mesh object.

Generated with [Claude Code](https://claude.ai/code)