### PR TITLE
ci: modernize linting and add ccache support 

### DIFF
--- a/.github/actions/upload-ccache-stats/action.yml
+++ b/.github/actions/upload-ccache-stats/action.yml
@@ -1,0 +1,39 @@
+name: 'Upload CCache Stats'
+description: 'Collect and upload ccache statistics as an artifact'
+inputs:
+  job-name:
+    description: 'Name of the job for the stats header (e.g., "RHEL (x86_64/gnu15)")'
+    required: true
+  artifact-suffix:
+    description: 'Suffix for the artifact name (e.g., "rhel-x86_64-gnu15")'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Collect ccache stats
+      shell: bash
+      run: |
+        mkdir -p /tmp/ccache-stats
+        RAW_STATS=$(ccache --show-stats 2>&1) || RAW_STATS="ccache stats unavailable"
+
+        # Parse key metrics from ccache output (|| true to prevent grep exit code 1 from failing the script)
+        CACHE_HIT_RATE=$(echo "$RAW_STATS" | grep -E "^\s+Hits:" | head -1 | grep -oE '\(\s*[0-9.]+%\)' | tr -d '() ' || true)
+        CACHE_SIZE=$(echo "$RAW_STATS" | grep "Cache size" | grep -oE '[0-9.]+\s*/\s*[0-9.]+' | head -1 || true)
+        DIRECT_HITS=$(echo "$RAW_STATS" | grep "Direct:" | grep -oE '[0-9]+\s*/\s*[0-9]+' | head -1 || true)
+        MISSES=$(echo "$RAW_STATS" | grep -E "^\s+Misses:" | head -1 | grep -oE '[0-9]+\s*/\s*[0-9]+' | head -1 || true)
+
+        # Output key-value data for table generation
+        echo "job_name=${{ inputs.job-name }}" > /tmp/ccache-stats/data.txt
+        echo "hit_rate=${CACHE_HIT_RATE:-N/A}" >> /tmp/ccache-stats/data.txt
+        echo "cache_size=${CACHE_SIZE:-N/A}" >> /tmp/ccache-stats/data.txt
+        echo "direct_hits=${DIRECT_HITS:-N/A}" >> /tmp/ccache-stats/data.txt
+        echo "misses=${MISSES:-N/A}" >> /tmp/ccache-stats/data.txt
+
+        # Raw output for collapsible section
+        echo "$RAW_STATS" > /tmp/ccache-stats/raw.txt
+    - name: Upload ccache stats
+      uses: actions/upload-artifact@v4
+      with:
+        name: ccache-stats-${{ inputs.artifact-suffix }}
+        retention-days: 1
+        path: /tmp/ccache-stats/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,36 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - 3.x
+  pull_request:
+    branches:
+      - 3.x
+
+jobs:
+  lint_markdown:
+    name: Run markdown linter
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Lint markdown
+      uses: DavidAnson/markdownlint-cli2-action@v15
+      with:
+        globs: |
+          README.md
+          CONTRIBUTING.md
+          containers/README.md
+
+  lint:
+    strategy:
+      matrix:
+        step: [codespell, ruff-check, ruff-format, shellcheck, whitespace, shfmt, clang-format]
+    name: Run ${{ matrix.step }} linter
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/openhpc/ohpc-lint:latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run ${{ matrix.step }}
+      run: make -C tests/ci/ ${{ matrix.step }}-lint

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -190,6 +190,12 @@ jobs:
       with:
         path: /var/cache/ccache
         key: ccache-rhel-${{ matrix.os }}-${{ matrix.compiler }}-${{ github.sha }}
+    - name: Upload ccache stats
+      if: always()
+      uses: ./.github/actions/upload-ccache-stats
+      with:
+        job-name: "RHEL (${{ matrix.arch }}/${{ matrix.compiler }})"
+        artifact-suffix: rhel-${{ matrix.arch }}-${{ matrix.compiler }}
 
   build_on_openEuler:
     strategy:
@@ -311,6 +317,12 @@ jobs:
       with:
         path: /var/cache/ccache
         key: ccache-openeuler-${{ matrix.os }}-${{ github.sha }}
+    - name: Upload ccache stats
+      if: always()
+      uses: ./.github/actions/upload-ccache-stats
+      with:
+        job-name: "openEuler (${{ matrix.arch }})"
+        artifact-suffix: openeuler-${{ matrix.arch }}
 
   build_on_leap:
     strategy:
@@ -424,6 +436,12 @@ jobs:
       with:
         path: /var/cache/ccache
         key: ccache-leap-${{ matrix.os }}-${{ github.sha }}
+    - name: Upload ccache stats
+      if: always()
+      uses: ./.github/actions/upload-ccache-stats
+      with:
+        job-name: "LEAP (${{ matrix.arch }}/${{ matrix.compiler }})"
+        artifact-suffix: leap-${{ matrix.arch }}-${{ matrix.compiler }}
 
   event_file:
     name: "Event File"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,11 +37,16 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
         compiler: [gnu15, intel]
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+          - os: ubuntu-24.04-arm
+            arch: aarch64
         exclude:
           - os: ubuntu-24.04-arm
             compiler: intel
     runs-on: ${{ matrix.os }}
-    name: Build on RHEL (${{ matrix.os }}/${{ matrix.compiler}})
+    name: Build on RHEL (${{ matrix.arch }}/${{ matrix.compiler }})
     container:
       image: docker.io/library/rockylinux:9
       volumes:
@@ -106,11 +111,16 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
         compiler: [gnu15, intel]
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+          - os: ubuntu-24.04-arm
+            arch: aarch64
         exclude:
           - os: ubuntu-24.04-arm
             compiler: intel
     runs-on: ${{ matrix.os }}
-    name: Test on RHEL (${{ matrix.os }}/${{ matrix.compiler}})
+    name: Test on RHEL (${{ matrix.arch }}/${{ matrix.compiler }})
     env:
       JOB_SKIP_CI_SPECS: |
         components/perf-tools/likwid/SPECS/likwid.spec
@@ -185,11 +195,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+          - os: ubuntu-24.04-arm
+            arch: aarch64
     env:
       JOB_SKIP_CI_SPECS: |
         components/provisioning/warewulf/SPECS/warewulf.spec
     runs-on: ${{ matrix.os }}
-    name: Build on openEuler (${{ matrix.os }})
+    name: Build on openEuler (${{ matrix.arch }})
     container:
       image: docker.io/openeuler/openeuler:22.03-lts-sp3
     steps:
@@ -242,13 +257,18 @@ jobs:
       matrix:
         compiler: [gnu15]
         os: [ubuntu-latest, ubuntu-24.04-arm]
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+          - os: ubuntu-24.04-arm
+            arch: aarch64
     env:
       JOB_SKIP_CI_SPECS: |
         components/runtimes/charliecloud/SPECS/charliecloud.spec
         components/perf-tools/likwid/SPECS/likwid.spec
         components/provisioning/warewulf/SPECS/warewulf.spec
     runs-on: ${{ matrix.os }}
-    name: Test on openEuler (${{ matrix.os }}/${{ matrix.compiler}})
+    name: Test on openEuler (${{ matrix.arch }}/${{ matrix.compiler }})
     container:
       image: docker.io/openeuler/openeuler:22.03-lts-sp3
     needs: build_on_openEuler
@@ -296,8 +316,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+          - os: ubuntu-24.04-arm
+            arch: aarch64
     runs-on: ${{ matrix.os }}
-    name: Build on LEAP (${{ matrix.os }})
+    name: Build on LEAP (${{ matrix.arch }})
     container:
       image: registry.opensuse.org/opensuse/leap:15.5
     steps:
@@ -348,12 +373,17 @@ jobs:
       matrix:
         compiler: [gnu15]
         os: [ubuntu-latest, ubuntu-24.04-arm]
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+          - os: ubuntu-24.04-arm
+            arch: aarch64
     env:
       JOB_SKIP_CI_SPECS: |
         components/runtimes/charliecloud/SPECS/charliecloud.spec
         components/perf-tools/likwid/SPECS/likwid.spec
     runs-on: ${{ matrix.os }}
-    name: Test on LEAP (${{ matrix.os }}/${{ matrix.compiler}})
+    name: Test on LEAP (${{ matrix.arch }}/${{ matrix.compiler }})
     container:
       image: registry.opensuse.org/opensuse/leap:15.5
     needs: build_on_leap

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,12 +21,9 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: docker.io/library/rockylinux:9
+      image: ghcr.io/openhpc/ohpc-analysis:latest
 
     steps:
-    - name: Setup
-      run: |
-        dnf install -y epel-release git python3
     - uses: actions/checkout@v4
     - id: files
       uses: Ana06/get-changed-files@v2.3.0

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -35,34 +35,6 @@ jobs:
         export SKIP_CI_SPECS="${{ env.SKIP_CI_SPECS }}${{ env.JOB_SKIP_CI_SPECS }}"
         tests/ci/check_spec.py ${{ steps.files.outputs.added_modified }}
 
-  lint_markdown:
-    name: Run markdown linter
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Lint markdown
-      uses: DavidAnson/markdownlint-cli2-action@v15
-      with:
-        globs: |
-          README.md
-          CONTRIBUTING.md
-          containers/README.md
-
-  lint:
-    strategy:
-      matrix:
-        step: [codespell, flake8, shellcheck, whitespace, shfmt, clang-format]
-    name: Run ${{ matrix.step }} linter
-    runs-on: ubuntu-latest
-    container:
-      image: registry.fedoraproject.org/fedora:latest
-    steps:
-    - name: Setup
-      run: dnf -y install codespell make python3-flake8 ShellCheck shfmt clang-tools-extra git
-    - uses: actions/checkout@v4
-    - name: Run ${{ matrix.step }}
-      run: make -C tests/ci/ ${{ matrix.step }}-lint
-
   build_on_rhel:
     strategy:
       matrix:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Build on RHEL (${{ matrix.arch }}/${{ matrix.compiler }})
     container:
-      image: docker.io/library/rockylinux:9
+      image: docker.io/library/almalinux:9
       volumes:
         - /usr:/host/usr
         - /opt:/host/opt
@@ -125,7 +125,7 @@ jobs:
       JOB_SKIP_CI_SPECS: |
         components/perf-tools/likwid/SPECS/likwid.spec
     container:
-      image: docker.io/library/rockylinux:9
+      image: docker.io/library/almalinux:9
       options: --privileged
       volumes:
         - /usr:/host/usr

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -55,6 +55,13 @@ jobs:
     - name: Install git
       run: dnf -y install git
     - uses: actions/checkout@v4
+    - name: Restore ccache
+      uses: actions/cache/restore@v4
+      with:
+        path: /var/cache/ccache
+        key: ccache-rhel-${{ matrix.os }}-${{ matrix.compiler }}-${{ github.sha }}
+        restore-keys: |
+          ccache-rhel-${{ matrix.os }}-${{ matrix.compiler }}-
     - name: Setup
       run: tests/ci/prepare-ci-environment.sh ${{ matrix.compiler }}
     - id: files
@@ -87,6 +94,12 @@ jobs:
           /home/ohpc/rpmbuild/RPMS/noarch/*rpm
           /home/ohpc/rpmbuild/RPMS/x86_64/*rpm
           /tmp/empty
+    - name: Save ccache
+      if: always()
+      uses: actions/cache/save@v4
+      with:
+        path: /var/cache/ccache
+        key: ccache-rhel-${{ matrix.os }}-${{ matrix.compiler }}-${{ github.sha }}-build
 
   test_on_rhel:
     strategy:
@@ -116,6 +129,13 @@ jobs:
     - name: Install git
       run: dnf -y install git
     - uses: actions/checkout@v4
+    - name: Restore ccache
+      uses: actions/cache/restore@v4
+      with:
+        path: /var/cache/ccache
+        key: ccache-rhel-${{ matrix.os }}-${{ matrix.compiler }}-${{ github.sha }}-build
+        restore-keys: |
+          ccache-rhel-${{ matrix.os }}-${{ matrix.compiler }}-
     - name: Setup
       run: tests/ci/prepare-ci-environment.sh ${{ matrix.compiler }}
     - id: files
@@ -154,6 +174,12 @@ jobs:
         name: test-results-${{ matrix.compiler }}-${{ matrix.os }}
         retention-days: 1
         path: tests/**/*.log.xml
+    - name: Save ccache
+      if: always()
+      uses: actions/cache/save@v4
+      with:
+        path: /var/cache/ccache
+        key: ccache-rhel-${{ matrix.os }}-${{ matrix.compiler }}-${{ github.sha }}
 
   build_on_openEuler:
     strategy:
@@ -172,6 +198,13 @@ jobs:
     - name: Install git
       run: dnf -y install git
     - uses: actions/checkout@v4
+    - name: Restore ccache
+      uses: actions/cache/restore@v4
+      with:
+        path: /var/cache/ccache
+        key: ccache-openeuler-${{ matrix.os }}-${{ github.sha }}
+        restore-keys: |
+          ccache-openeuler-${{ matrix.os }}-
     - name: Setup
       run: tests/ci/prepare-ci-environment.sh
     - id: files
@@ -197,6 +230,12 @@ jobs:
           /home/ohpc/rpmbuild/RPMS/noarch/*rpm
           /home/ohpc/rpmbuild/RPMS/x86_64/*rpm
           /tmp/empty
+    - name: Save ccache
+      if: always()
+      uses: actions/cache/save@v4
+      with:
+        path: /var/cache/ccache
+        key: ccache-openeuler-${{ matrix.os }}-${{ github.sha }}-build
 
   test_on_openEuler:
     strategy:
@@ -219,6 +258,13 @@ jobs:
     - name: Install git
       run: dnf -y install git
     - uses: actions/checkout@v4
+    - name: Restore ccache
+      uses: actions/cache/restore@v4
+      with:
+        path: /var/cache/ccache
+        key: ccache-openeuler-${{ matrix.os }}-${{ github.sha }}-build
+        restore-keys: |
+          ccache-openeuler-${{ matrix.os }}-
     - name: Setup
       run: tests/ci/prepare-ci-environment.sh
     - id: files
@@ -239,6 +285,12 @@ jobs:
         . /etc/profile.d/lmod.sh
         chown ohpc -R tests
         tests/ci/setup_slurm_and_run_tests.sh ohpc ${{ matrix.compiler }} ${{ steps.files.outputs.added_modified }}
+    - name: Save ccache
+      if: always()
+      uses: actions/cache/save@v4
+      with:
+        path: /var/cache/ccache
+        key: ccache-openeuler-${{ matrix.os }}-${{ github.sha }}
 
   build_on_leap:
     strategy:
@@ -252,6 +304,13 @@ jobs:
     - name: Install git
       run: zypper -n update; zypper -n install git
     - uses: actions/checkout@v4
+    - name: Restore ccache
+      uses: actions/cache/restore@v4
+      with:
+        path: /var/cache/ccache
+        key: ccache-leap-${{ matrix.os }}-${{ github.sha }}
+        restore-keys: |
+          ccache-leap-${{ matrix.os }}-
     - name: Setup
       run: tests/ci/prepare-ci-environment.sh
     - id: files
@@ -277,6 +336,12 @@ jobs:
           /home/ohpc/rpmbuild/RPMS/noarch/*rpm
           /home/ohpc/rpmbuild/RPMS/x86_64/*rpm
           /tmp/empty
+    - name: Save ccache
+      if: always()
+      uses: actions/cache/save@v4
+      with:
+        path: /var/cache/ccache
+        key: ccache-leap-${{ matrix.os }}-${{ github.sha }}-build
 
   test_on_leap:
     strategy:
@@ -296,6 +361,13 @@ jobs:
     - name: Install git
       run: zypper -n update; zypper -n install git
     - uses: actions/checkout@v4
+    - name: Restore ccache
+      uses: actions/cache/restore@v4
+      with:
+        path: /var/cache/ccache
+        key: ccache-leap-${{ matrix.os }}-${{ github.sha }}-build
+        restore-keys: |
+          ccache-leap-${{ matrix.os }}-
     - name: Setup
       run: tests/ci/prepare-ci-environment.sh
     - id: files
@@ -316,6 +388,12 @@ jobs:
         . /etc/profile.d/lmod.sh
         chown ohpc -R tests
         tests/ci/setup_slurm_and_run_tests.sh ohpc ${{ matrix.compiler }} ${{ steps.files.outputs.added_modified }}
+    - name: Save ccache
+      if: always()
+      uses: actions/cache/save@v4
+      with:
+        path: /var/cache/ccache
+        key: ccache-leap-${{ matrix.os }}-${{ github.sha }}
 
   event_file:
     name: "Event File"

--- a/components/OHPC_macros
+++ b/components/OHPC_macros
@@ -215,6 +215,7 @@ Requires:      %{python_prefix}
 %{?OHPC_CXXFLAGS:export OHPC_CXXFLAGS=%{OHPC_CXXFLAGS}}
 %{?OHPC_FCFLAGS:"export OHPC_FCFLAGS=%{OHPC_FCFLAGS}}
 %{?OHPC_F77FLAGS:"export OHPC_F77FLAGS=%{OHPC_F77FLAGS}}
+%{?OHPC_USE_CCACHE:export OHPC_USE_CCACHE=%{OHPC_USE_CCACHE}}
 . %{OHPC_ADMIN}/ohpc/OHPC_setup_compiler %{compiler_family}}
 
 %if 0%{?ohpc_mpi_dependent} == 01

--- a/components/OHPC_setup_compiler
+++ b/components/OHPC_setup_compiler
@@ -98,6 +98,17 @@ else
 	exit 1
 fi
 
+# Optionally prepend ccache to compiler commands (C/C++ only, not Fortran)
+if [ "${OHPC_USE_CCACHE}" = "yes" ]; then
+	if command -v ccache >/dev/null 2>&1; then
+		export CC="ccache ${CC}"
+		export CXX="ccache ${CXX}"
+		echo "Using ccache for compilation"
+	else
+		echo "Warning: OHPC_USE_CCACHE=yes but ccache not found"
+	fi
+fi
+
 echo " "
 echo "--"
 echo "OpenHPC compiler/build flags":

--- a/misc/build_order.py
+++ b/misc/build_order.py
@@ -37,8 +37,8 @@ def topological_sort(source):
         if not next_emitted:
             # all entries have unmet deps, one of two things is wrong...
             raise ValueError(
-                "cyclic or missing dependency detected: %r" %
-                (next_pending,))
+                "cyclic or missing dependency detected: %r" % (next_pending,)
+            )
         pending = next_pending
         emitted = next_emitted
 
@@ -52,21 +52,21 @@ if len(sys.argv) != 2:
 
 
 for line in open(sys.argv[1]):
-    line = line.rstrip().split(':')
+    line = line.rstrip().split(":")
     # The spec_dict is later used to translate
     # package names into spec files
     spec_dict[line[1]] = line[0]
     # Ignore the meta_packages
-    if line[1] == 'meta-packages':
+    if line[1] == "meta-packages":
         continue
     # Ignore non ohpc (Build)Requires
-    if line[2] == 'NA':
+    if line[2] == "NA":
         continue
     # Ignore kernel modules
-    if line[2].startswith('kmod'):
+    if line[2].startswith("kmod"):
         continue
     # Ignore the nagios_plugins
-    if line[2].startswith('nagios'):
+    if line[2].startswith("nagios"):
         continue
     # This tries to filter out versions with a "." or _isa with a "("
     if "." in line[2] or "(" in line[2]:
@@ -87,14 +87,14 @@ for v in dependency.values():
                 additional[spec_dict[value]] = []
         except KeyError as err:
             # Handle python_prefix rpm macro
-            if '-numpy-' in value:
-                spec_dict[value] = 'python-numpy.spec'
-            elif '-Cython-' in value:
-                spec_dict[value] = 'python-Cython.spec'
-            elif '-scipy-' in value:
-                spec_dict[value] = 'python-scipy.spec'
-            elif '-mpi4py-' in value:
-                spec_dict[value] = 'python-mpi4py.spec'
+            if "-numpy-" in value:
+                spec_dict[value] = "python-numpy.spec"
+            elif "-Cython-" in value:
+                spec_dict[value] = "python-Cython.spec"
+            elif "-scipy-" in value:
+                spec_dict[value] = "python-scipy.spec"
+            elif "-mpi4py-" in value:
+                spec_dict[value] = "python-mpi4py.spec"
             else:
                 print(err)
 
@@ -113,4 +113,4 @@ dep_list = [(k, set(v)) for (k, v) in dependency.items()]
 
 # Sort and print
 for i in topological_sort(dep_list):
-    print('%s' % i, end=' ')
+    print("%s" % i, end=" ")

--- a/tests/ci/Makefile
+++ b/tests/ci/Makefile
@@ -1,4 +1,4 @@
-lint: codespell-lint flake8-lint whitespace-lint shellcheck-lint shfmt-lint clang-format-lint
+lint: codespell-lint ruff-check-lint ruff-format-lint whitespace-lint shellcheck-lint shfmt-lint clang-format-lint
 
 codespell-lint:
 	@echo "Running 'codespell' on all spec files"
@@ -53,9 +53,17 @@ codespell-lint:
 		tests/libs/plasma/tests/test_module \
 		tests/libs/trilinos/tests/rm_execution
 
-flake8-lint:
-	@echo "Running 'flake8' on selected Python files"
-	flake8 \
+ruff-check-lint:
+	@echo "Running 'ruff check' on selected Python files"
+	ruff check \
+		../../tests/ci/check_spec.py \
+		../../tests/ci/run_build.py \
+		../../misc/build_order.py \
+		../../tests/ci/spec_to_test_mapping.py
+
+ruff-format-lint:
+	@echo "Running 'ruff format' on selected Python files"
+	ruff format \
 		../../tests/ci/check_spec.py \
 		../../tests/ci/run_build.py \
 		../../misc/build_order.py \

--- a/tests/ci/check_spec.py
+++ b/tests/ci/check_spec.py
@@ -6,36 +6,36 @@ import sys
 
 regex_wrong = [
     # make sure there is no Source42
-    '^Source42.*$',
+    "^Source42.*$",
     # make sure OHPC_macros is not listed
-    '^Source.*OHPC_macros$',
+    "^Source.*OHPC_macros$",
     # make sure there is no %changelog
-    '^%changelog.*',
+    "^%changelog.*",
     # make sure there is no DocDir
-    '^DocDir.*',
+    "^DocDir.*",
     # make sure there is no BuildRoot
-    '^BuildRoot.*',
+    "^BuildRoot.*",
     # make sure there is no %defattr(-,root,root)
-    '^%defattr(-,root,root).*',
+    "^%defattr(-,root,root).*",
     # make sure there is no global definition of PROJ_DELIM
-    '^.*%global.*PROJ_DELIM.*$',
-    ]
+    "^.*%global.*PROJ_DELIM.*$",
+]
 
 regex_required = [
     # Group designation should include %{PROJ_NAME} delimiter and
     # known component area
-    '^Group:.*%{PROJ_NAME}/(admin|compiler-families|dev-tools|distro-packages|'
-    'io-libs|lustre|meta-package|mpi-families|parallel-libs|perf-tools|'
-    'provisioning|rms|runtimes|serial-libs)$',
+    "^Group:.*%{PROJ_NAME}/(admin|compiler-families|dev-tools|distro-packages|"
+    "io-libs|lustre|meta-package|mpi-families|parallel-libs|perf-tools|"
+    "provisioning|rms|runtimes|serial-libs)$",
     # Need a URL
-    '(^URL:.*$|Url:.*$)',
-    ]
+    "(^URL:.*$|Url:.*$)",
+]
 
 if len(sys.argv) <= 1:
     print("SKIP. Needs a list of files to check")
     sys.exit(0)
 
-regex_wrong_string = '(' + '|'.join(regex_wrong) + ')'
+regex_wrong_string = "(" + "|".join(regex_wrong) + ")"
 
 print("Checking that %s does not exist" % regex_wrong_string)
 
@@ -45,12 +45,12 @@ error = False
 spec_found = False
 
 skip_ci_specs = []
-skip_ci_specs_env = os.getenv('SKIP_CI_SPECS')
+skip_ci_specs_env = os.getenv("SKIP_CI_SPECS")
 if skip_ci_specs_env:
-    skip_ci_specs = skip_ci_specs_env.rstrip().split('\n')
+    skip_ci_specs = skip_ci_specs_env.rstrip().split("\n")
 
 for spec in sys.argv[1:]:
-    if not spec.endswith('.spec'):
+    if not spec.endswith(".spec"):
         continue
     if spec in skip_ci_specs:
         print("--> Skipping spec file %s" % spec)
@@ -64,7 +64,7 @@ for spec in sys.argv[1:]:
     infile.close()
 
     # first, verify patterns which should *not* be present
-    for line in contents.split('\n'):
+    for line in contents.split("\n"):
         if pattern.match(line):
             print("    [+] Found %s" % (line.rstrip()))
             error = True

--- a/tests/ci/prepare-ci-environment.sh
+++ b/tests/ci/prepare-ci-environment.sh
@@ -129,7 +129,7 @@ dnf_rhel() {
 	if [ "${FACTORY_VERSION}" != "" ]; then
 		loop_command wget "${FACTORY_REPOSITORY}" -O "${FACTORY_REPOSITORY_DESTINATION}"
 	fi
-	loop_command "${PKG_MANAGER}" "${YES}" install lmod-ohpc bats "${ENABLE_ONEAPI}"
+	loop_command "${PKG_MANAGER}" "${YES}" install lmod-ohpc bats ccache "${ENABLE_ONEAPI}"
 }
 
 dnf_openeuler() {
@@ -138,7 +138,7 @@ dnf_openeuler() {
 		loop_command wget "${FACTORY_REPOSITORY}" -O "${FACTORY_REPOSITORY_DESTINATION}"
 	fi
 	loop_command wget -P /etc/yum.repos.d/ https://eur.openeuler.openatom.cn/coprs/mgrigorov/OpenHPC/repo/openeuler-22.03_LTS_SP3/mgrigorov-OpenHPC-openeuler-22.03_LTS_SP3.repo
-	loop_command "${PKG_MANAGER}" "${YES}" install ohpc-filesystem lmod-ohpc hostname bats
+	loop_command "${PKG_MANAGER}" "${YES}" install ohpc-filesystem lmod-ohpc hostname bats ccache
 	# This repository contains golang 1.21 copied from 24.03
 	# shellcheck disable=SC2016
 	echo -e '[go.1.21]\nname=go.1.21\nbaseurl=https://repos.openhpc.community/.staging/golang-1.21-openEuler-24.03-LTS/$basearch/\nenabled=1\ngpgcheck=0' >/etc/yum.repos.d/go.1.21.repo
@@ -156,10 +156,12 @@ if [ "${PKG_MANAGER}" = "dnf" ]; then
 	fi
 	adduser ohpc
 else
-	loop_command "${PKG_MANAGER}" "${YES}" --no-gpg-checks install ${COMMON_PKGS} awk rpmbuild bats "${OHPC_RELEASE}"
+	loop_command "${PKG_MANAGER}" "${YES}" --no-gpg-checks install ${COMMON_PKGS} awk rpmbuild bats ccache "${OHPC_RELEASE}"
 	if [ "${FACTORY_VERSION}" != "" ]; then
 		loop_command wget "${FACTORY_REPOSITORY}" -O "${FACTORY_REPOSITORY_DESTINATION}"
 	fi
 	loop_command "${PKG_MANAGER}" "${YES}" --no-gpg-checks install lmod-ohpc "${ENABLE_ONEAPI}"
-	useradd -m ohpc
+	useradd -m ohpc -U
+	mkdir -p /var/cache/ccache
+	chown -R ohpc:ohpc /var/cache/ccache
 fi

--- a/tests/ci/run_build.py
+++ b/tests/ci/run_build.py
@@ -11,59 +11,59 @@ import csv
 import os
 import io
 
-logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
+logging.basicConfig(format="%(asctime)s %(message)s", level=logging.INFO)
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
-    'user',
-    help='non root user to run build as',
+    "user",
+    help="non root user to run build as",
     nargs=1,
 )
 parser.add_argument(
-    'specfiles',
-    help='list of specfiles to check',
-    nargs='*',
+    "specfiles",
+    help="list of specfiles to check",
+    nargs="*",
 )
 parser.add_argument(
-    '--compiler-family',
-    help='compiler family name to use for rebuild',
-    default='gnu15',
+    "--compiler-family",
+    help="compiler family name to use for rebuild",
+    default="gnu15",
 )
 parser.add_argument(
-    '--mpi-family',
+    "--mpi-family",
     help=(
-        'mpi family name to use for rebuild ' +
-        '(defaults to openmpi5, mpich, mvapich2)'
+        "mpi family name to use for rebuild "
+        + "(defaults to openmpi5, mpich, mvapich2)"
     ),
 )
 args = parser.parse_args()
 
 spec_found = False
-build_user = ''.join(args.user)
+build_user = "".join(args.user)
 dnf_based = False
 dist = "9999.ci.ohpc"
-version_id = ''
+version_id = ""
 
 # Check which base OS we are using
-reader = csv.DictReader(open('/etc/os-release'), delimiter="=")
+reader = csv.DictReader(open("/etc/os-release"), delimiter="=")
 
 skip_ci_specs = []
-skip_ci_specs_env = os.getenv('SKIP_CI_SPECS')
+skip_ci_specs_env = os.getenv("SKIP_CI_SPECS")
 if skip_ci_specs_env:
     skip_ci_specs = skip_ci_specs_env.rstrip().split()
 
 for row in reader:
-    key = row.pop('NAME')
-    if key in ['ID_LIKE', 'ID']:
+    key = row.pop("NAME")
+    if key in ["ID_LIKE", "ID"]:
         for item in list(row.items())[0]:
-            if 'fedora' in item or 'openEuler' in item:
+            if "fedora" in item or "openEuler" in item:
                 dnf_based = True
-    if key == 'VERSION_ID':
+    if key == "VERSION_ID":
         version_id = list(row.items())[0][1]
 
 
 def run_command(command):
-    logging.info("About to run command %s" % ' '.join(command))
+    logging.info("About to run command %s" % " ".join(command))
     process = subprocess.Popen(
         command,
         bufsize=1,
@@ -123,14 +123,11 @@ def loop_command(command, max_attempts=5):
 
 
 def build_srpm_and_rpm(
-        command,
-        mpi_family=None,
-        compiler_family=None,
-        not_mpi_dependent=False
+    command, mpi_family=None, compiler_family=None, not_mpi_dependent=False
 ):
     # Build SRPM
     command = [
-        'misc/build_srpm.sh',
+        "misc/build_srpm.sh",
         spec,
     ]
     if compiler_family:
@@ -142,14 +139,14 @@ def build_srpm_and_rpm(
             # This is a shortcoming of the build_srpm script.
             # It only has positional parameters.
             # It needs a dummy parameter here.
-            command.append('openmpi5')
-        command.append('0')
+            command.append("openmpi5")
+        command.append("0")
     success, output = run_command(command)
     if not success:
         # First check if the architecture is not supported
         if output is not None:
-            for line in output.split('\n'):
-                if 'No compatible architectures found for build' in line:
+            for line in output.split("\n"):
+                if "No compatible architectures found for build" in line:
                     logging.info("Skipping unsupported architecture RPM")
                     return True
 
@@ -157,8 +154,8 @@ def build_srpm_and_rpm(
         return False
 
     src_rpm = ""
-    for line in output.split('\n'):
-        if line.endswith('.src.rpm'):
+    for line in output.split("\n"):
+        if line.endswith(".src.rpm"):
             src_rpm = line
             break
 
@@ -170,39 +167,39 @@ def build_srpm_and_rpm(
 
     if dnf_based:
         builddep_command = [
-            'dnf',
-            '-y',
-            'builddep',
+            "dnf",
+            "-y",
+            "builddep",
             src_rpm,
         ]
     else:
         builddep_command = [
-            'zypper',
-            '-n',
-            '--no-gpg-checks',
-            'source-install',
+            "zypper",
+            "-n",
+            "--no-gpg-checks",
+            "source-install",
             src_rpm,
         ]
 
     success, _ = loop_command(builddep_command)
     if not success:
-        logging.error("Running '%s' failed" % ' '.join(builddep_command))
+        logging.error("Running '%s' failed" % " ".join(builddep_command))
         return False
 
-    tmp_src_rpm = os.path.join('/tmp', os.path.basename(src_rpm))
+    tmp_src_rpm = os.path.join("/tmp", os.path.basename(src_rpm))
 
     try:
         os.unlink(tmp_src_rpm)
     except FileNotFoundError:
         pass
-    shutil.move(src_rpm, '/tmp/')
+    shutil.move(src_rpm, "/tmp/")
     src_rpm = tmp_src_rpm
 
     rebuild_command = [
-        'su',
+        "su",
         build_user,
-        '-l',
-        '-c',
+        "-l",
+        "-c",
         'rpmbuild --define "dist %s" --rebuild %s' % (dist, src_rpm),
     ]
 
@@ -210,14 +207,10 @@ def build_srpm_and_rpm(
         rebuild_command[-1] += " --define 'mpi_family %s'" % mpi_family
 
     if compiler_family is not None:
-        rebuild_command[-1] += (
-            " --define 'compiler_family %s'" % compiler_family
-        )
+        rebuild_command[-1] += " --define 'compiler_family %s'" % compiler_family
 
     if not_mpi_dependent:
-        rebuild_command[-1] += (
-            " --define 'ohpc_mpi_dependent 0'"
-        )
+        rebuild_command[-1] += " --define 'ohpc_mpi_dependent 0'"
 
     # Disable parallel builds for below packages on aarch64 to avoid OOM
     pkgs = ["boost-", "paraver-"]
@@ -243,17 +236,17 @@ for spec in args.specfiles:
     # if more than one docs related file are modified then
     # build the docs.spec just once
     # START OF LOGIC FOR DOCS
-    if 'components/admin/docs/SPECS/docs.spec' == spec:
+    if "components/admin/docs/SPECS/docs.spec" == spec:
         if docs_spec_executed:
             continue
         docs_spec_executed = True
-    elif not docs_spec_executed and \
-        ('docs/recipes/install/' in spec
-            or 'components/admin/docs/SOURCES/' in spec):
+    elif not docs_spec_executed and (
+        "docs/recipes/install/" in spec or "components/admin/docs/SOURCES/" in spec
+    ):
         docs_spec_executed = True
-        spec = 'components/admin/docs/SPECS/docs.spec'
+        spec = "components/admin/docs/SPECS/docs.spec"
     # END OF LOGIC FOR DOCS
-    elif not spec.endswith('.spec'):
+    elif not spec.endswith(".spec"):
         continue
     just_spec = os.path.basename(spec)
     total += 1
@@ -266,7 +259,7 @@ for spec in args.specfiles:
     logging.info("--> Building RPM from spec file %s" % spec)
 
     command = [
-        'misc/get_source.sh',
+        "misc/get_source.sh",
         just_spec,
     ]
 
@@ -281,57 +274,53 @@ for spec in args.specfiles:
     contents = infile.read()
     infile.close()
 
-    if 'ohpc_mpi_dependent' in contents:
+    if "ohpc_mpi_dependent" in contents:
         families = [
-            'openmpi5',
-            'mpich',
-            'mvapich2',
+            "openmpi5",
+            "mpich",
+            "mvapich2",
         ]
 
         if args.mpi_family:
             families = [args.mpi_family]
 
         for family in families:
-            if family == 'mvapich2' and os.uname().machine == 'aarch64':
+            if family == "mvapich2" and os.uname().machine == "aarch64":
                 continue
             if not build_srpm_and_rpm(
-                    spec,
-                    mpi_family=family,
-                    compiler_family=args.compiler_family,
+                spec,
+                mpi_family=family,
+                compiler_family=args.compiler_family,
             ):
                 failed.append(just_spec)
             else:
                 rebuild_success.append(
-                    "%s (%s, %s)" %
-                    (just_spec, args.compiler_family, family))
+                    "%s (%s, %s)" % (just_spec, args.compiler_family, family)
+                )
 
-        if '!?ohpc_mpi_dependent' in contents:
+        if "!?ohpc_mpi_dependent" in contents:
             # This is a package that can be built with and without MPI support.
             # It should have the following line:
             # '%{!?ohpc_mpi_dependent:%define ohpc_mpi_dependent 1}'
             # If that exists we need to rebuild it once more with
             # ohpc_mpi_dependent set to 0.
             if not build_srpm_and_rpm(
-                    spec,
-                    compiler_family=args.compiler_family,
-                    not_mpi_dependent=True,
+                spec,
+                compiler_family=args.compiler_family,
+                not_mpi_dependent=True,
             ):
                 failed.append(just_spec)
             else:
-                rebuild_success.append(
-                    "%s (%s)" %
-                    (just_spec, args.compiler_family))
+                rebuild_success.append("%s (%s)" % (just_spec, args.compiler_family))
 
-    elif 'ohpc_compiler_dependent' in contents:
+    elif "ohpc_compiler_dependent" in contents:
         if not build_srpm_and_rpm(
-                spec,
-                compiler_family=args.compiler_family,
+            spec,
+            compiler_family=args.compiler_family,
         ):
             failed.append(just_spec)
         else:
-            rebuild_success.append(
-                "%s (%s)" %
-                (just_spec, args.compiler_family))
+            rebuild_success.append("%s (%s)" % (just_spec, args.compiler_family))
 
     else:
         if not build_srpm_and_rpm(spec):
@@ -344,8 +333,7 @@ if not spec_found:
     logging.info("SKIP. Commit without changes to a SPEC file.")
 
 logging.info("Found %d spec file(s)" % total)
-logging.info("--> %d rebuild successfully" %
-             (total - len(failed) - len(skipped)))
+logging.info("--> %d rebuild successfully" % (total - len(failed) - len(skipped)))
 for success in rebuild_success:
     logging.info("----> %s" % success)
 

--- a/tests/ci/run_build.py
+++ b/tests/ci/run_build.py
@@ -8,6 +8,7 @@ import shutil
 import time
 import sys
 import csv
+import pwd
 import os
 import io
 
@@ -60,6 +61,23 @@ for row in reader:
                 dnf_based = True
     if key == "VERSION_ID":
         version_id = list(row.items())[0][1]
+
+# Enable ccache for CI builds
+os.makedirs("/etc/rpm", exist_ok=True)
+with open("/etc/rpm/macros.ohpc-ci-conf", "w") as f:
+    f.write("%OHPC_USE_CCACHE yes\n")
+
+# Ensure ccache directory is owned by build user
+ccache_dir = "/var/cache/ccache"
+os.makedirs(ccache_dir, exist_ok=True)
+uid = pwd.getpwnam(build_user).pw_uid
+gid = pwd.getpwnam(build_user).pw_gid
+for root, dirs, files in os.walk(ccache_dir):
+    os.chown(root, uid, gid)
+    for d in dirs:
+        os.chown(os.path.join(root, d), uid, gid)
+    for f in files:
+        os.chown(os.path.join(root, f), uid, gid)
 
 
 def run_command(command):

--- a/tests/ci/setup_slurm_and_run_tests.sh
+++ b/tests/ci/setup_slurm_and_run_tests.sh
@@ -112,6 +112,9 @@ fi
 export SIMPLE_CI=1
 TESTS_FAILED=1
 
+export OHPC_USE_CCACHE=yes
+chown -R ohpc:ohpc /var/cache/ccache
+
 set +e
 
 # AppArmor on the Ubuntu GitHub Actions host might block
@@ -125,6 +128,7 @@ sudo --user="${USER}" --login bash -c "cd ${PWD}/tests; find ./ -name '*.log' -d
 if sudo \
 	--user="${USER}" \
 	--preserve-env=SIMPLE_CI \
+	--preserve-env=OHPC_USE_CCACHE \
 	--login \
 	bash -c "\
 		cd ${PWD}/tests; \

--- a/tests/ci/spec_to_test_mapping.py
+++ b/tests/ci/spec_to_test_mapping.py
@@ -16,290 +16,184 @@ import argparse
 #     'required packages for test',
 # ]
 test_map = {
-    'components/rms/slurm/SPECS/slurm.spec': [
-        'munge',
-        '',
-        'magpie-ohpc pdsh-mod-slurm-ohpc pdsh-ohpc'
+    "components/rms/slurm/SPECS/slurm.spec": [
+        "munge",
+        "",
+        "magpie-ohpc pdsh-mod-slurm-ohpc pdsh-ohpc",
     ],
-    'components/dev-tools/hwloc/SPECS/hwloc.spec': [
-        'hwloc',
-        '',
-        '',
+    "components/dev-tools/hwloc/SPECS/hwloc.spec": [
+        "hwloc",
+        "",
+        "",
     ],
-    'components/rms/magpie/SPECS/magpie.spec': [
-        'munge',
-        '',
-        'pdsh-mod-slurm-ohpc pdsh-ohpc'
+    "components/rms/magpie/SPECS/magpie.spec": [
+        "munge",
+        "",
+        "pdsh-mod-slurm-ohpc pdsh-ohpc",
     ],
-    'components/admin/pdsh/SPECS/pdsh.spec': [
-        'munge',
-        '',
-        'magpie-ohpc'
+    "components/admin/pdsh/SPECS/pdsh.spec": ["munge", "", "magpie-ohpc"],
+    "components/dev-tools/easybuild/SPECS/easybuild.spec": [
+        "easybuild",
+        "",
+        ("gcc-c++", "openssl-devel"),
     ],
-    'components/dev-tools/easybuild/SPECS/easybuild.spec': [
-        'easybuild',
-        '',
-        ('gcc-c++',
-         'openssl-devel')
+    "components/io-libs/adios2/SPECS/adios2.spec": [
+        "adios2",
+        "",
+        (
+            "openmpi5-COMPILER_FAMILY-ohpc "
+            "mpich-COMPILER_FAMILY-ohpc "
+            "python3-numpy-COMPILER_FAMILY-ohpc "
+            "python3-mpi4py-COMPILER_FAMILY-mpich-ohpc "
+            "python3-mpi4py-COMPILER_FAMILY-openmpi5-ohpc"
+        ),
     ],
-    'components/io-libs/adios2/SPECS/adios2.spec': [
-        'adios2',
-        '',
-        ('openmpi5-COMPILER_FAMILY-ohpc '
-         'mpich-COMPILER_FAMILY-ohpc '
-         'python3-numpy-COMPILER_FAMILY-ohpc '
-         'python3-mpi4py-COMPILER_FAMILY-mpich-ohpc '
-         'python3-mpi4py-COMPILER_FAMILY-openmpi5-ohpc')
+    "components/io-libs/hdf5/SPECS/hdf5.spec": [
+        "hdf5",
+        "",
+        "zlib-devel automake-ohpc libtool-ohpc autoconf-ohpc",
     ],
-    'components/io-libs/hdf5/SPECS/hdf5.spec': [
-        'hdf5',
-        '',
-        'zlib-devel automake-ohpc libtool-ohpc autoconf-ohpc'
+    "components/parallel-libs/ptscotch/SPECS/ptscotch.spec": [
+        "ptscotch",
+        "",
+        "zlib-devel",
     ],
-    'components/parallel-libs/ptscotch/SPECS/ptscotch.spec': [
-        'ptscotch',
-        '',
-        'zlib-devel'
+    "components/serial-libs/scotch/SPECS/scotch.spec": ["scotch", "", "zlib-devel"],
+    "components/parallel-libs/fftw/SPECS/fftw.spec": ["fftw", "", ""],
+    "components/parallel-libs/hypre/SPECS/hypre.spec": ["hypre", "", ""],
+    "components/parallel-libs/mfem/SPECS/mfem.spec": ["mfem", "", ""],
+    "components/parallel-libs/mumps/SPECS/mumps.spec": ["mumps", "", ""],
+    "components/parallel-libs/opencoarrays/SPECS/opencoarrays.spec": [
+        "opencoarrays",
+        "",
+        "",
     ],
-    'components/serial-libs/scotch/SPECS/scotch.spec': [
-        'scotch',
-        '',
-        'zlib-devel'
+    "components/parallel-libs/petsc/SPECS/petsc.spec": ["petsc", "", ""],
+    "components/io-libs/phdf5/SPECS/hdf5.spec": [
+        "phdf5",
+        "",
+        "zlib-devel automake-ohpc libtool-ohpc autoconf-ohpc",
     ],
-    'components/parallel-libs/fftw/SPECS/fftw.spec': [
-        'fftw',
-        '',
-        ''
+    "components/io-libs/pnetcdf/SPECS/pnetcdf.spec": ["pnetcdf", "", ""],
+    "components/io-libs/netcdf/SPECS/netcdf.spec": ["netcdf", "", ""],
+    "components/parallel-libs/scalapack/SPECS/scalapack.spec": ["scalapack", "", ""],
+    "components/parallel-libs/slepc/SPECS/slepc.spec": ["slepc", "", ""],
+    "components/serial-libs/superlu/SPECS/superlu.spec": ["superlu", "", ""],
+    "components/parallel-libs/superlu_dist/SPECS/superlu_dist.spec": [
+        "superlu_dist",
+        "",
+        (
+            "scalapack-COMPILER_FAMILY-openmpi5-ohpc "
+            "scalapack-COMPILER_FAMILY-mpich-ohpc"
+        ),
     ],
-    'components/parallel-libs/hypre/SPECS/hypre.spec': [
-        'hypre',
-        '',
-        ''
+    "components/parallel-libs/trilinos/SPECS/trilinos.spec": ["trilinos", "", ""],
+    "components/perf-tools/extrae/SPECS/extrae.spec": [
+        "extrae",
+        "",
+        "lmod-defaults-COMPILER_FAMILY-openmpi5-ohpc",
     ],
-    'components/parallel-libs/mfem/SPECS/mfem.spec': [
-        'mfem',
-        '',
-        ''
+    "components/perf-tools/geopm/SPECS/geopm.spec": [
+        "geopm",
+        "",
+        "lmod-defaults-COMPILER_FAMILY-openmpi5-ohpc",
     ],
-    'components/parallel-libs/mumps/SPECS/mumps.spec': [
-        'mumps',
-        '',
-        ''
+    "components/perf-tools/likwid/SPECS/likwid.spec": [
+        "likwid",
+        "",
+        "lmod-defaults-COMPILER_FAMILY-openmpi5-ohpc",
     ],
-    'components/parallel-libs/opencoarrays/SPECS/opencoarrays.spec': [
-        'opencoarrays',
-        '',
-        ''
+    "components/perf-tools/papi/SPECS/papi.spec": ["papi", "", ""],
+    "components/perf-tools/scorep/SPECS/scorep.spec": [
+        "scorep",
+        "",
+        "lmod-defaults-COMPILER_FAMILY-openmpi5-ohpc",
     ],
-    'components/parallel-libs/petsc/SPECS/petsc.spec': [
-        'petsc',
-        '',
-        ''
+    "components/perf-tools/scalasca/SPECS/scalasca.spec": [
+        "scalasca",
+        "",
+        "lmod-defaults-COMPILER_FAMILY-openmpi5-ohpc",
     ],
-    'components/io-libs/phdf5/SPECS/hdf5.spec': [
-        'phdf5',
-        '',
-        'zlib-devel automake-ohpc libtool-ohpc autoconf-ohpc'
+    "components/perf-tools/tau/SPECS/tau.spec": [
+        "tau",
+        "",
+        ("lmod-defaults-COMPILER_FAMILY-openmpi5-ohpc man bc"),
     ],
-    'components/io-libs/pnetcdf/SPECS/pnetcdf.spec': [
-        'pnetcdf',
-        '',
-        ''
+    "components/mpi-families/openmpi/SPECS/openmpi5.spec": ["slurm", "", ""],
+    "components/mpi-families/mpich/SPECS/mpich.spec": ["slurm", "", ""],
+    "components/dev-tools/spack/SPECS/spack.spec": ["", "spack", ""],
+    "components/admin/conman/SPECS/conman.spec": ["", "oob", ""],
+    "components/dev-tools/autoconf/SPECS/autoconf.spec": [
+        "autotools",
+        "",
+        "automake-ohpc libtool-ohpc",
     ],
-    'components/io-libs/netcdf/SPECS/netcdf.spec': [
-        'netcdf',
-        '',
-        ''
+    "components/dev-tools/cmake/SPECS/cmake.spec": ["cmake", "", ""],
+    "components/parallel-libs/boost/SPECS/boost.spec": ["boost boost-mpi", "", ""],
+    "components/serial-libs/openblas/SPECS/openblas.spec": ["openblas", "", ""],
+    "components/serial-libs/R/SPECS/R.spec": ["R", "", ""],
+    "components/perf-tools/dimemas/SPECS/dimemas.spec": [
+        "dimemas",
+        "",
+        "lmod-defaults-COMPILER_FAMILY-openmpi5-ohpc",
     ],
-    'components/parallel-libs/scalapack/SPECS/scalapack.spec': [
-        'scalapack',
-        '',
-        ''
+    "components/runtimes/charliecloud/SPECS/charliecloud.spec": [
+        "charliecloud",
+        "",
+        "singularity-ce",
     ],
-    'components/parallel-libs/slepc/SPECS/slepc.spec': [
-        'slepc',
-        '',
-        ''
+    "components/io-libs/netcdf-fortran/SPECS/netcdf-fortran.spec": [
+        "netcdf",
+        "",
+        (
+            "netcdf-cxx-COMPILER_FAMILY-openmpi5-ohpc "
+            "netcdf-cxx-COMPILER_FAMILY-mpich-ohpc"
+        ),
     ],
-    'components/serial-libs/superlu/SPECS/superlu.spec': [
-        'superlu',
-        '',
-        ''
+    "components/io-libs/netcdf-cxx/SPECS/netcdf-cxx.spec": [
+        "netcdf",
+        "",
+        (
+            "netcdf-fortran-COMPILER_FAMILY-openmpi5-ohpc "
+            "netcdf-fortran-COMPILER_FAMILY-mpich-ohpc"
+        ),
     ],
-    'components/parallel-libs/superlu_dist/SPECS/superlu_dist.spec': [
-        'superlu_dist',
-        '',
-        ('scalapack-COMPILER_FAMILY-openmpi5-ohpc '
-         'scalapack-COMPILER_FAMILY-mpich-ohpc')
+    "components/perf-tools/imb/SPECS/imb.spec": ["imb", "", ""],
+    "components/perf-tools/omb/SPECS/omb.spec": ["omb", "", ""],
+    "components/dev-tools/mpi4py/SPECS/python-mpi4py.spec": ["mpi4py", "", ""],
+    "components/serial-libs/gsl/SPECS/gsl.spec": ["gsl", "", ""],
+    "components/serial-libs/plasma/SPECS/plasma.spec": ["plasma", "", ""],
+    "components/dev-tools/valgrind/SPECS/valgrind.spec": [
+        "valgrind",
+        "",
+        "",
     ],
-    'components/parallel-libs/trilinos/SPECS/trilinos.spec': [
-        'trilinos',
-        '',
-        ''
+    "components/serial-libs/metis/SPECS/metis.spec": [
+        "metis",
+        "",
+        "",
     ],
-    'components/perf-tools/extrae/SPECS/extrae.spec': [
-        'extrae',
-        '',
-        'lmod-defaults-COMPILER_FAMILY-openmpi5-ohpc'
-    ],
-    'components/perf-tools/geopm/SPECS/geopm.spec': [
-        'geopm',
-        '',
-        'lmod-defaults-COMPILER_FAMILY-openmpi5-ohpc'
-    ],
-    'components/perf-tools/likwid/SPECS/likwid.spec': [
-        'likwid',
-        '',
-        'lmod-defaults-COMPILER_FAMILY-openmpi5-ohpc'
-    ],
-    'components/perf-tools/papi/SPECS/papi.spec': [
-        'papi',
-        '',
-        ''
-    ],
-    'components/perf-tools/scorep/SPECS/scorep.spec': [
-        'scorep',
-        '',
-        'lmod-defaults-COMPILER_FAMILY-openmpi5-ohpc'
-    ],
-    'components/perf-tools/scalasca/SPECS/scalasca.spec': [
-        'scalasca',
-        '',
-        'lmod-defaults-COMPILER_FAMILY-openmpi5-ohpc'
-    ],
-    'components/perf-tools/tau/SPECS/tau.spec': [
-        'tau',
-        '',
-        ('lmod-defaults-COMPILER_FAMILY-openmpi5-ohpc '
-         'man bc')
-    ],
-    'components/mpi-families/openmpi/SPECS/openmpi5.spec': [
-        'slurm',
-        '',
-        ''
-    ],
-    'components/mpi-families/mpich/SPECS/mpich.spec': [
-        'slurm',
-        '',
-        ''
-    ],
-    'components/dev-tools/spack/SPECS/spack.spec': [
-        '',
-        'spack',
-        ''
-    ],
-    'components/admin/conman/SPECS/conman.spec': [
-        '',
-        'oob',
-        ''
-    ],
-    'components/dev-tools/autoconf/SPECS/autoconf.spec': [
-        'autotools',
-        '',
-        'automake-ohpc libtool-ohpc'
-    ],
-    'components/dev-tools/cmake/SPECS/cmake.spec': [
-        'cmake',
-        '',
-        ''
-    ],
-    'components/parallel-libs/boost/SPECS/boost.spec': [
-        'boost boost-mpi',
-        '',
-        ''
-    ],
-    'components/serial-libs/openblas/SPECS/openblas.spec': [
-        'openblas',
-        '',
-        ''
-    ],
-    'components/serial-libs/R/SPECS/R.spec': [
-        'R',
-        '',
-        ''
-    ],
-    'components/perf-tools/dimemas/SPECS/dimemas.spec': [
-        'dimemas',
-        '',
-        'lmod-defaults-COMPILER_FAMILY-openmpi5-ohpc'
-    ],
-    'components/runtimes/charliecloud/SPECS/charliecloud.spec': [
-        'charliecloud',
-        '',
-        'singularity-ce'
-     ],
-    'components/io-libs/netcdf-fortran/SPECS/netcdf-fortran.spec': [
-        'netcdf',
-        '',
-        ('netcdf-cxx-COMPILER_FAMILY-openmpi5-ohpc '
-         'netcdf-cxx-COMPILER_FAMILY-mpich-ohpc')
-    ],
-    'components/io-libs/netcdf-cxx/SPECS/netcdf-cxx.spec': [
-        'netcdf',
-        '',
-        ('netcdf-fortran-COMPILER_FAMILY-openmpi5-ohpc '
-         'netcdf-fortran-COMPILER_FAMILY-mpich-ohpc')
-    ],
-    'components/perf-tools/imb/SPECS/imb.spec': [
-        'imb',
-        '',
-        ''
-    ],
-    'components/perf-tools/omb/SPECS/omb.spec': [
-        'omb',
-        '',
-        ''
-    ],
-    'components/dev-tools/mpi4py/SPECS/python-mpi4py.spec': [
-        'mpi4py',
-        '',
-        ''
-    ],
-    'components/serial-libs/gsl/SPECS/gsl.spec': [
-        'gsl',
-        '',
-        ''
-    ],
-    'components/serial-libs/plasma/SPECS/plasma.spec': [
-        'plasma',
-        '',
-        ''
-    ],
-    'components/dev-tools/valgrind/SPECS/valgrind.spec': [
-        'valgrind',
-        '',
-        '',
-    ],
-    'components/serial-libs/metis/SPECS/metis.spec': [
-        'metis',
-        '',
-        '',
-    ],
-    'components/admin/lmod/SPECS/lmod.spec': [
-        '',
-        'lmod',
-        ''
-    ],
+    "components/admin/lmod/SPECS/lmod.spec": ["", "lmod", ""],
 }
 
 # Check which base OS we are using
-reader = csv.DictReader(open('/etc/os-release'), delimiter="=")
+reader = csv.DictReader(open("/etc/os-release"), delimiter="=")
 
-python_prefix = 'python3'
+python_prefix = "python3"
 
 for row in reader:
-    key = row.pop('NAME')
-    if key in ['ID_LIKE', 'ID']:
+    key = row.pop("NAME")
+    if key in ["ID_LIKE", "ID"]:
         for item in list(row.items())[0]:
-            if 'rhel' in item:
-                python_prefix = 'python3.11'
+            if "rhel" in item:
+                python_prefix = "python3.11"
                 break
-            if 'suse' in item:
-                python_prefix = 'python311'
+            if "suse" in item:
+                python_prefix = "python311"
                 break
 
 skip_ci_specs = []
-skip_ci_specs_env = os.getenv('SKIP_CI_SPECS')
+skip_ci_specs_env = os.getenv("SKIP_CI_SPECS")
 if skip_ci_specs_env:
     skip_ci_specs = skip_ci_specs_env.rstrip().split()
 for spec in skip_ci_specs:
@@ -307,40 +201,41 @@ for spec in skip_ci_specs:
         test_map.pop(spec)
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--compiler-family', required=True, help='Compiler family')
-parser.add_argument('specs', nargs='*')
+parser.add_argument("--compiler-family", required=True, help="Compiler family")
+parser.add_argument("specs", nargs="*")
 args = parser.parse_args()
 
 if not args.specs:
-    print('TESTS=() ADMIN_TESTS=() PKGS=()')
+    print("TESTS=() ADMIN_TESTS=() PKGS=()")
     sys.exit(0)
 
-tests = ''
-admin_tests = ''
-pkgs = ''
+tests = ""
+admin_tests = ""
+pkgs = ""
 
 for i in args.specs:
     if i in test_map.keys():
         if len(tests) > 0:
-            tests += ' '
+            tests += " "
         if len(admin_tests) > 0:
-            admin_tests += ' '
+            admin_tests += " "
         if len(pkgs) > 0:
-            pkgs += ' '
+            pkgs += " "
 
         if len(test_map[i][0]) > 0:
             for test in test_map[i][0].split():
-                tests += f'--enable-{test} '
+                tests += f"--enable-{test} "
         if len(test_map[i][1]) > 0:
-            admin_tests += f'--enable-{test_map[i][1]}'
+            admin_tests += f"--enable-{test_map[i][1]}"
         pkgs += test_map[i][2]
 
-pkgs = pkgs.replace('python3', python_prefix)
+pkgs = pkgs.replace("python3", python_prefix)
 
-pkgs = pkgs.replace('COMPILER_FAMILY', args.compiler_family)
+pkgs = pkgs.replace("COMPILER_FAMILY", args.compiler_family)
 
 print(
-    'TESTS=(%s) ADMIN_TESTS=(%s) PKGS=(%s)' % (
+    "TESTS=(%s) ADMIN_TESTS=(%s) PKGS=(%s)"
+    % (
         tests,
         admin_tests,
         pkgs,

--- a/tests/m4/compiler_family.m4
+++ b/tests/m4/compiler_family.m4
@@ -84,6 +84,18 @@ else
    AC_MSG_ERROR([Unknown compiler family - please load a compiler toolchain.])
 fi
 
+# Optionally prepend ccache to compiler commands
+if test "x$OHPC_USE_CCACHE" = "xyes"; then
+   AC_CHECK_PROG([CCACHE], [ccache], [ccache])
+   if test "x$CCACHE" != "x"; then
+      CC="ccache $CC"
+      CXX="ccache $CXX"
+      AC_MSG_NOTICE([Using ccache for compilation])
+   else
+      AC_MSG_WARN([OHPC_USE_CCACHE set but ccache not found])
+   fi
+fi
+
 AC_SUBST(OHPC_BLAS)
 
 ])

--- a/tests/perf-tools/scalasca/tests/serial/configure.ac
+++ b/tests/perf-tools/scalasca/tests/serial/configure.ac
@@ -22,6 +22,11 @@ AC_C_CONST
 
 # Define include path and library linkage from environment variables
 # which should be provided via module loads.
+# Strip ccache prefix if present before prepending scorep
+CC=$(echo $CC | sed 's/^ccache //')
+CXX=$(echo $CXX | sed 's/^ccache //')
+FC=$(echo $FC | sed 's/^ccache //')
+F77=$(echo $F77 | sed 's/^ccache //')
 CC=scorep-${CC}
 CXX=scorep-${CXX}
 FC=scorep-${FC}

--- a/tests/perf-tools/scorep/tests/serial/configure.ac
+++ b/tests/perf-tools/scorep/tests/serial/configure.ac
@@ -22,6 +22,11 @@ AC_C_CONST
 
 # Define include path and library linkage from environment variables
 # which should be provided via module loads.
+# Strip ccache prefix if present before prepending scorep
+CC=$(echo $CC | sed 's/^ccache //')
+CXX=$(echo $CXX | sed 's/^ccache //')
+FC=$(echo $FC | sed 's/^ccache //')
+F77=$(echo $F77 | sed 's/^ccache //')
 CC=scorep-${CC}
 CXX=scorep-${CXX}
 FC=scorep-${FC}


### PR DESCRIPTION
  - Split lint jobs into separate lint.yml workflow using ohpc-lint container                                                                                                                                                                 
  - Switch Python linting from flake8 to ruff                                                                                                                                                                                                 
  - Use ohpc-analysis container for check_spec job                                                                                                                                                                                            
  - Add ccache support to speed up CI builds with GitHub Actions cache   