### PR TITLE
hdf5: fix build with Intel MPI and GCC 15

### DIFF
--- a/components/io-libs/hdf5/SPECS/hdf5.spec
+++ b/components/io-libs/hdf5/SPECS/hdf5.spec
@@ -84,12 +84,15 @@ cmake -DCMAKE_INSTALL_PREFIX=%{install_path} \
 %endif
 %if 0%{?ohpc_mpi_dependent}
       -DHDF5_ENABLE_PARALLEL=ON              \
+%if "%{mpi_family}" == "impi" && "%{compiler_family}" == "gnu15"
+      -DCMAKE_Fortran_FLAGS="-I$MPI_DIR/include/mpi/gfortran/11.1.0 -Wno-array-temporaries" \
+%endif
 %else
       -DHDF5_BUILD_CPP_LIB=ON                \
 %endif
       ..
 
-make %{?_smp_mflags}
+make VERBOSE=1 %{?_smp_mflags}
 
 %install
 


### PR DESCRIPTION
Intel MPI ships precompiled .mod files that are incompatible with newer gfortran versions. Pass CMAKE_Fortran_FLAGS to use the gfortran 11.1.0 modules which are forward-compatible.

Also enable verbose build output.

Generated with Claude Code (https://claude.ai/code)