### PR TITLE
petsc: update to 3.24.4, add ccache support, and modernize tests

### DIFF
--- a/components/parallel-libs/petsc/SPECS/petsc.spec
+++ b/components/parallel-libs/petsc/SPECS/petsc.spec
@@ -25,7 +25,7 @@ Name:           %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Summary:        Portable Extensible Toolkit for Scientific Computation
 License:        2-clause BSD
 Group:          %{PROJ_NAME}/parallel-libs
-Version:        3.23.5
+Version:        3.24.4
 Release:        1%{?dist}
 Source0:        https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-%{version}.tar.gz
 Url:            http://www.mcs.anl.gov/petsc/
@@ -78,20 +78,52 @@ module load scalapack openblas
 COPTFLAGS="${CFLAGS}"
 CXXOPTFLAGS="${CXXFLAGS}"
 FOPTFLAGS="${FCFLAGS}"
-unset CFLAGS
-unset CXXFLAGS
-unset FCFLAGS
 
-# icc-impi requires mpiicc wrappers, otherwise dynamic libs are not generated.
+# Unset environment variables that conflict with PETSc configure command-line args
+# PETSc warns when these are set both as env vars and on command line
+unset CFLAGS CXXFLAGS FCFLAGS FFLAGS
+unset CC CXX FC F77 F90
+unset LDFLAGS MPI_DIR
+
+# Set compilers - use Intel MPI wrappers for impi+intel combination
+%if "%{mpi_family}" == "impi" && "%{compiler_family}" == "intel"
+PETSC_CC=mpiicc
+PETSC_CXX=mpiicpc
+PETSC_FC=mpiifort
+%else
+PETSC_CC=mpicc
+PETSC_CXX=mpicxx
+PETSC_FC=mpif90
+%endif
+
+# Wrap with ccache if enabled
+%if "%{?OHPC_USE_CCACHE}" == "yes"
+PETSC_CC="ccache ${PETSC_CC}"
+PETSC_CXX="ccache ${PETSC_CXX}"
+%endif
+
 # gnu-impi finds include/4.8.0/mpi.mod first, unless told not to.
 %{__python3} ./config/configure.py \
         --prefix=%{install_path} \
-        --FFLAGS="${FOPTFLAGS} -fPIC" \
+        --with-cc="${PETSC_CC}" \
+        --with-cxx="${PETSC_CXX}" \
+        --with-fc="${PETSC_FC}" \
+        --with-f77="${PETSC_FC}" \
 %if "%{compiler_family}" == "intel"
+        COPTFLAGS="${COPTFLAGS}" \
+        CXXOPTFLAGS="${CXXOPTFLAGS}" \
+        FOPTFLAGS="${FOPTFLAGS}" \
+        FFLAGS+="-fPIC -fpscomp logicals" \
+        CFLAGS+="-fPIC -DPIC" \
+        CXXFLAGS+="-fPIC -DPIC" \
         --with-blas-lapack-dir=$MKLROOT/lib/intel64 \
 %else
-        --CFLAGS="${COPTFLAGS} -fPIC -DPIC" \
-        --CXXFLAGS="${CXXOPTFLAGS} -fPIC -DPIC" \
+        COPTFLAGS="${COPTFLAGS}" \
+        CXXOPTFLAGS="${CXXOPTFLAGS}" \
+        FOPTFLAGS="${FOPTFLAGS}" \
+        FFLAGS+="-fPIC" \
+        CFLAGS+="-fPIC -DPIC" \
+        CXXFLAGS+="-fPIC -DPIC" \
         --with-scalapack-dir=$SCALAPACK_DIR \
 %if "%{compiler_family}" == "arm1"
         --with-blas-lapack-lib=$ARMPL_LIBRARIES/libarmpl.so \
@@ -99,17 +131,8 @@ unset FCFLAGS
         --with-blas-lapack-lib=$OPENBLAS_LIB/libopenblas.so \
 %endif
 %endif
-%if "%{mpi_family}" == "impi"
-%if "%{compiler_family}" == "intel"
-        --with-cc=mpiicc    \
-        --with-cxx=mpiicpc  \
-        --with-fc=mpiifort  \
-        --with-f77=mpiifort \
-%else
-%if "%{compiler_family}" == "gnu"
-        --FFLAGS=-I$I_MPI_ROOT/include64/gfortran/4.9.0/ \
-%endif
-%endif
+%if "%{mpi_family}" == "impi" && "%{compiler_family}" == "gnu"
+        FFLAGS+="-I$I_MPI_ROOT/include64/gfortran/4.9.0/" \
 %endif
 %if 0%{?OHPC_BUILD}
         --with-make-np=3 \

--- a/tests/ci/Makefile
+++ b/tests/ci/Makefile
@@ -68,7 +68,10 @@ codespell-lint:
 		tests/libs/adios2/tests/test_module \
 		tests/libs/adios2/ohpc-tests/test_mpi_families \
 		tests/rms-harness/tests/test_harness \
-		tests/rms-harness/ohpc-tests/test_mpi_families
+		tests/rms-harness/ohpc-tests/test_mpi_families \
+		tests/libs/petsc/tests/rm_execution \
+		tests/libs/petsc/tests/test_module \
+		tests/libs/petsc/ohpc-tests/test_mpi_families
 
 ruff-check-lint:
 	@echo "Running 'ruff check' on selected Python files"
@@ -153,6 +156,9 @@ whitespace-lint:
 		tests/libs/adios2/ohpc-tests/test_mpi_families \
 		tests/rms-harness/tests/test_harness \
 		tests/rms-harness/ohpc-tests/test_mpi_families \
+		tests/libs/petsc/tests/rm_execution \
+		tests/libs/petsc/tests/test_module \
+		tests/libs/petsc/ohpc-tests/test_mpi_families \
 		containers/* \
 		\*.tex
 
@@ -235,7 +241,10 @@ shellcheck-lint:
 		../../tests/libs/adios2/tests/test_module \
 		../../tests/libs/adios2/ohpc-tests/test_mpi_families \
 		../../tests/rms-harness/tests/test_harness \
-		../../tests/rms-harness/ohpc-tests/test_mpi_families
+		../../tests/rms-harness/ohpc-tests/test_mpi_families \
+		../../tests/libs/petsc/tests/rm_execution \
+		../../tests/libs/petsc/tests/test_module \
+		../../tests/libs/petsc/ohpc-tests/test_mpi_families
 
 shfmt-lint:
 	@echo "Running 'shfmt' on selected shell scripts"
@@ -289,7 +298,9 @@ shfmt-lint:
 		../../tests/perf-tools/papi/tests/test_module \
 		../../tests/libs/adios2/tests/rm_execution \
 		../../tests/libs/adios2/tests/test_module \
-		../../tests/rms-harness/tests/test_harness
+		../../tests/rms-harness/tests/test_harness \
+		../../tests/libs/petsc/tests/rm_execution \
+		../../tests/libs/petsc/tests/test_module
 	shfmt -w -d \
 		../../tests/ci/prepare-ci-environment.sh \
 		../../misc/build_order.sh \
@@ -307,7 +318,8 @@ shfmt-lint:
 		../../containers/examples/mpi/*.sh \
 		../../tests/perf-tools/papi/ohpc-tests/test_compiler_families \
 		../../tests/libs/adios2/ohpc-tests/test_mpi_families \
-		../../tests/rms-harness/ohpc-tests/test_mpi_families
+		../../tests/rms-harness/ohpc-tests/test_mpi_families \
+		../../tests/libs/petsc/ohpc-tests/test_mpi_families
 
 clang-format-lint:
 	@echo "Running 'clang-format' on selected source code files"
@@ -330,7 +342,8 @@ clang-format-lint:
 		../../tests/libs/trilinos/tests/*.cpp \
 		../../containers/examples/mpi/mpi.c \
 		../../tests/perf-tools/papi/tests/*.c \
-		../../tests/rms-harness/tests/*.c
+		../../tests/rms-harness/tests/*.c \
+		../../tests/libs/petsc/tests/*.c
 
 build-ohpc-ci:
 	podman build  -f Containerfile.ohpc-lint -t  ghcr.io/openhpc/ohpc-lint:latest

--- a/tests/libs/petsc/Makefile.am
+++ b/tests/libs/petsc/Makefile.am
@@ -1,3 +1,5 @@
 AUTOMAKE_OPTIONS = foreign
 AM_MAKEFLAGS     = --no-print-directory
 SUBDIRS          = tests
+
+DISTCLEANFILES = compile test-driver

--- a/tests/libs/petsc/ohpc-tests/test_mpi_families
+++ b/tests/libs/petsc/ohpc-tests/test_mpi_families
@@ -1,11 +1,12 @@
 #!/bin/bash
 # -*-sh-*-
 
-TEST_LOGS=""
-MAKEFLAGS=""
+# shellcheck disable=SC1091
+#
+export MAKEFLAGS=""
 status=0
 
-source ./common/TEST_ENV  || exit 1
+source ./common/TEST_ENV || exit 1
 source ./common/functions || exit 1
 
 cd libs/petsc || exit 1
@@ -15,30 +16,29 @@ export BATS_JUNIT_CLASS=PETSc
 
 ./bootstrap || exit 1
 
-for compiler in $COMPILER_FAMILIES ; do
-    for mpi in $MPI_FAMILIES ; do
+for COMPILER in ${COMPILER_FAMILIES}; do
+	for MPI in ${MPI_FAMILIES}; do
 
-	echo " "
-	echo " "
-	echo "-------------------------------------------------------"
-	echo "Libraries: petsc tests: $compiler-$mpi"
-	echo "-------------------------------------------------------"
+		echo " "
+		echo " "
+		echo "-------------------------------------------------------"
+		echo "Libraries: petsc tests: ${COMPILER}-${MPI}"
+		echo "-------------------------------------------------------"
 
-	module purge          || exit 1
-        module load prun      || exit 1
-	module load $compiler || exit 1
-	module load $mpi      || exit 1
-	module load petsc     || exit 1
+		module purge || exit 1
+		module load prun || exit 1
+		module load "${COMPILER}" || exit 1
+		module load "${MPI}" || exit 1
+		module load petsc || exit 1
 
-	./configure           || exit 1
-	make clean            || exit 1
-	make -k check         || status=1
+		./configure || exit 1
+		make clean || exit 1
+		make -k check || status=1
 
-        save_logs_mpi_family tests $compiler $mpi
+		save_logs_mpi_family tests "${COMPILER}" "${MPI}"
 
-	make distclean
-    done
+		make distclean
+	done
 done
 
-exit ${status}
-
+exit "${status}"

--- a/tests/libs/petsc/tests/C_mpi_test.c
+++ b/tests/libs/petsc/tests/C_mpi_test.c
@@ -35,31 +35,33 @@ T*/
 /*
    User-defined routines.
 */
-PetscErrorCode FormJacobian(SNES,Vec,Mat,Mat,void*);
-PetscErrorCode FormFunction(SNES,Vec,Vec,void*);
+PetscErrorCode FormJacobian(SNES, Vec, Mat, Mat, void *);
+PetscErrorCode FormFunction(SNES, Vec, Vec, void *);
 PetscErrorCode FormInitialGuess(Vec);
-PetscErrorCode Monitor(SNES,PetscInt,PetscReal,void*);
-PetscErrorCode PreCheck(SNESLineSearch,Vec,Vec,PetscBool*,void*);
-PetscErrorCode PostCheck(SNESLineSearch,Vec,Vec,Vec,PetscBool*,PetscBool*,void*);
-PetscErrorCode PostSetSubKSP(SNESLineSearch,Vec,Vec,Vec,PetscBool*,PetscBool*,void*);
-PetscErrorCode MatrixFreePreconditioner(PC,Vec,Vec);
+PetscErrorCode Monitor(SNES, PetscInt, PetscReal, void *);
+PetscErrorCode PreCheck(SNESLineSearch, Vec, Vec, PetscBool *, void *);
+PetscErrorCode PostCheck(SNESLineSearch, Vec, Vec, Vec, PetscBool *,
+			 PetscBool *, void *);
+PetscErrorCode PostSetSubKSP(SNESLineSearch, Vec, Vec, Vec, PetscBool *,
+			     PetscBool *, void *);
+PetscErrorCode MatrixFreePreconditioner(PC, Vec, Vec);
 
 /*
    User-defined application context
 */
 typedef struct {
-  DM          da;      /* distributed array */
-  Vec         F;       /* right-hand-side of PDE */
-  PetscMPIInt rank;    /* rank of processor */
-  PetscMPIInt size;    /* size of communicator */
-  PetscReal   h;       /* mesh spacing */
+	DM da; /* distributed array */
+	Vec F; /* right-hand-side of PDE */
+	PetscMPIInt rank; /* rank of processor */
+	PetscMPIInt size; /* size of communicator */
+	PetscReal h; /* mesh spacing */
 } ApplicationCtx;
 
 /*
    User-defined context for monitoring
 */
 typedef struct {
-  PetscViewer viewer;
+	PetscViewer viewer;
 } MonitorCtx;
 
 /*
@@ -67,65 +69,81 @@ typedef struct {
    determined by line search methods
 */
 typedef struct {
-  Vec            last_step;  /* previous iterate */
-  PetscReal      tolerance;  /* tolerance for changes between successive iterates */
-  ApplicationCtx *user;
+	Vec last_step; /* previous iterate */
+	PetscReal tolerance; /* tolerance for changes between successive iterates */
+	ApplicationCtx *user;
 } StepCheckCtx;
 
 typedef struct {
-  PetscInt its0; /* num of prevous outer KSP iterations */
+	PetscInt its0; /* num of prevous outer KSP iterations */
 } SetSubKSPCtx;
 
-int main(int argc,char **argv)
+int main(int argc, char **argv)
 {
-  SNES           snes;                 /* SNES context */
-  SNESLineSearch linesearch;           /* SNESLineSearch context */
-  Mat            J;                    /* Jacobian matrix */
-  ApplicationCtx ctx;                  /* user-defined context */
-  Vec            x,r,U,F;              /* vectors */
-  MonitorCtx     monP;                 /* monitoring context */
-  StepCheckCtx   checkP;               /* step-checking context */
-  SetSubKSPCtx   checkP1;
-  PetscBool      pre_check,post_check,post_setsubksp; /* flag indicating whether we're checking candidate iterates */
-  PetscScalar    xp,*FF,*UU,none = -1.0;
-  PetscErrorCode ierr;
-  PetscInt       its,N = 15,i,maxit,maxf,xs,xm;
-  PetscReal      abstol,rtol,stol,norm;
-  PetscBool      flg;
+	SNES snes; /* SNES context */
+	SNESLineSearch linesearch; /* SNESLineSearch context */
+	Mat J; /* Jacobian matrix */
+	ApplicationCtx ctx; /* user-defined context */
+	Vec x, r, U, F; /* vectors */
+	MonitorCtx monP; /* monitoring context */
+	StepCheckCtx checkP; /* step-checking context */
+	SetSubKSPCtx checkP1;
+	PetscBool pre_check, post_check,
+		post_setsubksp; /* flag indicating whether we're checking candidate iterates */
+	PetscScalar xp, *FF, *UU, none = -1.0;
+	PetscErrorCode ierr;
+	PetscInt its, N = 15, i, maxit, maxf, xs, xm;
+	PetscReal abstol, rtol, stol, norm;
+	PetscBool flg;
 
-  ierr = PetscInitialize(&argc,&argv,(char*)0,help);if (ierr) return ierr;
-  ierr  = MPI_Comm_rank(PETSC_COMM_WORLD,&ctx.rank);CHKERRQ(ierr);
-  ierr  = MPI_Comm_size(PETSC_COMM_WORLD,&ctx.size);CHKERRQ(ierr);
-  ierr  = PetscOptionsGetInt(NULL,NULL,"-n",&N,NULL);CHKERRQ(ierr);
-  ctx.h = 1.0/(N-1);
+	ierr = PetscInitialize(&argc, &argv, (char *)0, help);
+	if (ierr)
+		return ierr;
+	ierr = MPI_Comm_rank(PETSC_COMM_WORLD, &ctx.rank);
+	CHKERRQ(ierr);
+	ierr = MPI_Comm_size(PETSC_COMM_WORLD, &ctx.size);
+	CHKERRQ(ierr);
+	ierr = PetscOptionsGetInt(NULL, NULL, "-n", &N, NULL);
+	CHKERRQ(ierr);
+	ctx.h = 1.0 / (N - 1);
 
-  /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
      Create nonlinear solver context
      - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-  ierr = SNESCreate(PETSC_COMM_WORLD,&snes);CHKERRQ(ierr);
+	ierr = SNESCreate(PETSC_COMM_WORLD, &snes);
+	CHKERRQ(ierr);
 
-  /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
      Create vector data structures; set function evaluation routine
      - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-  /*
+	/*
      Create distributed array (DMDA) to manage parallel grid and vectors
   */
-  ierr = DMDACreate1d(PETSC_COMM_WORLD,DM_BOUNDARY_NONE,N,1,1,NULL,&ctx.da);CHKERRQ(ierr);
-  ierr = DMSetFromOptions(ctx.da);CHKERRQ(ierr);
-  ierr = DMSetUp(ctx.da);CHKERRQ(ierr);
+	ierr = DMDACreate1d(PETSC_COMM_WORLD, DM_BOUNDARY_NONE, N, 1, 1, NULL,
+			    &ctx.da);
+	CHKERRQ(ierr);
+	ierr = DMSetFromOptions(ctx.da);
+	CHKERRQ(ierr);
+	ierr = DMSetUp(ctx.da);
+	CHKERRQ(ierr);
 
-  /*
+	/*
      Extract global and local vectors from DMDA; then duplicate for remaining
      vectors that are the same types
   */
-  ierr = DMCreateGlobalVector(ctx.da,&x);CHKERRQ(ierr);
-  ierr = VecDuplicate(x,&r);CHKERRQ(ierr);
-  ierr = VecDuplicate(x,&F);CHKERRQ(ierr); ctx.F = F;
-  ierr = VecDuplicate(x,&U);CHKERRQ(ierr);
+	ierr = DMCreateGlobalVector(ctx.da, &x);
+	CHKERRQ(ierr);
+	ierr = VecDuplicate(x, &r);
+	CHKERRQ(ierr);
+	ierr = VecDuplicate(x, &F);
+	CHKERRQ(ierr);
+	ctx.F = F;
+	ierr = VecDuplicate(x, &U);
+	CHKERRQ(ierr);
 
-  /*
+	/*
      Set function evaluation routine and vector.  Whenever the nonlinear
      solver needs to compute the nonlinear function, it will call this
      routine.
@@ -133,19 +151,25 @@ int main(int argc,char **argv)
         context that provides application-specific data for the
         function evaluation routine.
   */
-  ierr = SNESSetFunction(snes,r,FormFunction,&ctx);CHKERRQ(ierr);
+	ierr = SNESSetFunction(snes, r, FormFunction, &ctx);
+	CHKERRQ(ierr);
 
-  /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
      Create matrix data structure; set Jacobian evaluation routine
      - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-  ierr = MatCreate(PETSC_COMM_WORLD,&J);CHKERRQ(ierr);
-  ierr = MatSetSizes(J,PETSC_DECIDE,PETSC_DECIDE,N,N);CHKERRQ(ierr);
-  ierr = MatSetFromOptions(J);CHKERRQ(ierr);
-  ierr = MatSeqAIJSetPreallocation(J,3,NULL);CHKERRQ(ierr);
-  ierr = MatMPIAIJSetPreallocation(J,3,NULL,3,NULL);CHKERRQ(ierr);
+	ierr = MatCreate(PETSC_COMM_WORLD, &J);
+	CHKERRQ(ierr);
+	ierr = MatSetSizes(J, PETSC_DECIDE, PETSC_DECIDE, N, N);
+	CHKERRQ(ierr);
+	ierr = MatSetFromOptions(J);
+	CHKERRQ(ierr);
+	ierr = MatSeqAIJSetPreallocation(J, 3, NULL);
+	CHKERRQ(ierr);
+	ierr = MatMPIAIJSetPreallocation(J, 3, NULL, 3, NULL);
+	CHKERRQ(ierr);
 
-  /*
+	/*
      Set Jacobian matrix data structure and default Jacobian evaluation
      routine.  Whenever the nonlinear solver needs to compute the
      Jacobian matrix, it will call this routine.
@@ -153,155 +177,220 @@ int main(int argc,char **argv)
         context that provides application-specific data for the
         Jacobian evaluation routine.
   */
-  ierr = SNESSetJacobian(snes,J,J,FormJacobian,&ctx);CHKERRQ(ierr);
+	ierr = SNESSetJacobian(snes, J, J, FormJacobian, &ctx);
+	CHKERRQ(ierr);
 
-  /*
+	/*
      Optionally allow user-provided preconditioner
    */
-  ierr = PetscOptionsHasName(NULL,NULL,"-user_precond",&flg);CHKERRQ(ierr);
-  if (flg) {
-    KSP ksp;
-    PC  pc;
-    ierr = SNESGetKSP(snes,&ksp);CHKERRQ(ierr);
-    ierr = KSPGetPC(ksp,&pc);CHKERRQ(ierr);
-    ierr = PCSetType(pc,PCSHELL);CHKERRQ(ierr);
-    ierr = PCShellSetApply(pc,MatrixFreePreconditioner);CHKERRQ(ierr);
-  }
+	ierr = PetscOptionsHasName(NULL, NULL, "-user_precond", &flg);
+	CHKERRQ(ierr);
+	if (flg) {
+		KSP ksp;
+		PC pc;
+		ierr = SNESGetKSP(snes, &ksp);
+		CHKERRQ(ierr);
+		ierr = KSPGetPC(ksp, &pc);
+		CHKERRQ(ierr);
+		ierr = PCSetType(pc, PCSHELL);
+		CHKERRQ(ierr);
+		ierr = PCShellSetApply(pc, MatrixFreePreconditioner);
+		CHKERRQ(ierr);
+	}
 
-  /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
      Customize nonlinear solver; set runtime options
    - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-  /*
+	/*
      Set an optional user-defined monitoring routine
   */
-  ierr = PetscViewerDrawOpen(PETSC_COMM_WORLD,0,0,0,0,400,400,&monP.viewer);CHKERRQ(ierr);
-  ierr = SNESMonitorSet(snes,Monitor,&monP,0);CHKERRQ(ierr);
+	ierr = PetscViewerDrawOpen(PETSC_COMM_WORLD, 0, 0, 0, 0, 400, 400,
+				   &monP.viewer);
+	CHKERRQ(ierr);
+	ierr = SNESMonitorSet(snes, Monitor, &monP, 0);
+	CHKERRQ(ierr);
 
-  /*
+	/*
      Set names for some vectors to facilitate monitoring (optional)
   */
-  ierr = PetscObjectSetName((PetscObject)x,"Approximate Solution");CHKERRQ(ierr);
-  ierr = PetscObjectSetName((PetscObject)U,"Exact Solution");CHKERRQ(ierr);
+	ierr = PetscObjectSetName((PetscObject)x, "Approximate Solution");
+	CHKERRQ(ierr);
+	ierr = PetscObjectSetName((PetscObject)U, "Exact Solution");
+	CHKERRQ(ierr);
 
-  /*
+	/*
      Set SNES/KSP/KSP/PC runtime options, e.g.,
          -snes_view -snes_monitor -ksp_type <ksp> -pc_type <pc>
   */
-  ierr = SNESSetFromOptions(snes);CHKERRQ(ierr);
+	ierr = SNESSetFromOptions(snes);
+	CHKERRQ(ierr);
 
-  /*
+	/*
      Set an optional user-defined routine to check the validity of candidate
      iterates that are determined by line search methods
   */
-  ierr = SNESGetLineSearch(snes, &linesearch);CHKERRQ(ierr);
-  ierr = PetscOptionsHasName(NULL,NULL,"-post_check_iterates",&post_check);CHKERRQ(ierr);
+	ierr = SNESGetLineSearch(snes, &linesearch);
+	CHKERRQ(ierr);
+	ierr = PetscOptionsHasName(NULL, NULL, "-post_check_iterates",
+				   &post_check);
+	CHKERRQ(ierr);
 
-  if (post_check) {
-    ierr = PetscPrintf(PETSC_COMM_WORLD,"Activating post step checking routine\n");CHKERRQ(ierr);
-    ierr = SNESLineSearchSetPostCheck(linesearch,PostCheck,&checkP);CHKERRQ(ierr);
-    ierr = VecDuplicate(x,&(checkP.last_step));CHKERRQ(ierr);
+	if (post_check) {
+		ierr = PetscPrintf(PETSC_COMM_WORLD,
+				   "Activating post step checking routine\n");
+		CHKERRQ(ierr);
+		ierr = SNESLineSearchSetPostCheck(linesearch, PostCheck,
+						  &checkP);
+		CHKERRQ(ierr);
+		ierr = VecDuplicate(x, &(checkP.last_step));
+		CHKERRQ(ierr);
 
-    checkP.tolerance = 1.0;
-    checkP.user      = &ctx;
+		checkP.tolerance = 1.0;
+		checkP.user = &ctx;
 
-    ierr = PetscOptionsGetReal(NULL,NULL,"-check_tol",&checkP.tolerance,NULL);CHKERRQ(ierr);
-  }
+		ierr = PetscOptionsGetReal(NULL, NULL, "-check_tol",
+					   &checkP.tolerance, NULL);
+		CHKERRQ(ierr);
+	}
 
-  ierr = PetscOptionsHasName(NULL,NULL,"-post_setsubksp",&post_setsubksp);CHKERRQ(ierr);
-  if (post_setsubksp) {
-    ierr = PetscPrintf(PETSC_COMM_WORLD,"Activating post setsubksp\n");CHKERRQ(ierr);
-    ierr = SNESLineSearchSetPostCheck(linesearch,PostSetSubKSP,&checkP1);CHKERRQ(ierr);
-  }
+	ierr = PetscOptionsHasName(NULL, NULL, "-post_setsubksp",
+				   &post_setsubksp);
+	CHKERRQ(ierr);
+	if (post_setsubksp) {
+		ierr = PetscPrintf(PETSC_COMM_WORLD,
+				   "Activating post setsubksp\n");
+		CHKERRQ(ierr);
+		ierr = SNESLineSearchSetPostCheck(linesearch, PostSetSubKSP,
+						  &checkP1);
+		CHKERRQ(ierr);
+	}
 
-  ierr = PetscOptionsHasName(NULL,NULL,"-pre_check_iterates",&pre_check);CHKERRQ(ierr);
-  if (pre_check) {
-    ierr = PetscPrintf(PETSC_COMM_WORLD,"Activating pre step checking routine\n");CHKERRQ(ierr);
-    ierr = SNESLineSearchSetPreCheck(linesearch,PreCheck,&checkP);CHKERRQ(ierr);
-  }
+	ierr = PetscOptionsHasName(NULL, NULL, "-pre_check_iterates",
+				   &pre_check);
+	CHKERRQ(ierr);
+	if (pre_check) {
+		ierr = PetscPrintf(PETSC_COMM_WORLD,
+				   "Activating pre step checking routine\n");
+		CHKERRQ(ierr);
+		ierr = SNESLineSearchSetPreCheck(linesearch, PreCheck, &checkP);
+		CHKERRQ(ierr);
+	}
 
-  /*
+	/*
      Print parameters used for convergence testing (optional) ... just
      to demonstrate this routine; this information is also printed with
      the option -snes_view
   */
-  ierr = SNESGetTolerances(snes,&abstol,&rtol,&stol,&maxit,&maxf);CHKERRQ(ierr);
-  ierr = PetscPrintf(PETSC_COMM_WORLD,"atol=%g, rtol=%g, stol=%g, maxit=%D, maxf=%D\n",(double)abstol,(double)rtol,(double)stol,maxit,maxf);CHKERRQ(ierr);
+	ierr = SNESGetTolerances(snes, &abstol, &rtol, &stol, &maxit, &maxf);
+	CHKERRQ(ierr);
+	ierr = PetscPrintf(PETSC_COMM_WORLD,
+			   "atol=%g, rtol=%g, stol=%g, maxit=%D, maxf=%D\n",
+			   (double)abstol, (double)rtol, (double)stol, maxit,
+			   maxf);
+	CHKERRQ(ierr);
 
-  /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
      Initialize application:
      Store right-hand-side of PDE and exact solution
    - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-  /*
+	/*
      Get local grid boundaries (for 1-dimensional DMDA):
        xs, xm - starting grid index, width of local grid (no ghost points)
   */
-  ierr = DMDAGetCorners(ctx.da,&xs,NULL,NULL,&xm,NULL,NULL);CHKERRQ(ierr);
+	ierr = DMDAGetCorners(ctx.da, &xs, NULL, NULL, &xm, NULL, NULL);
+	CHKERRQ(ierr);
 
-  /*
+	/*
      Get pointers to vector data
   */
-  ierr = DMDAVecGetArray(ctx.da,F,&FF);CHKERRQ(ierr);
-  ierr = DMDAVecGetArray(ctx.da,U,&UU);CHKERRQ(ierr);
+	ierr = DMDAVecGetArray(ctx.da, F, &FF);
+	CHKERRQ(ierr);
+	ierr = DMDAVecGetArray(ctx.da, U, &UU);
+	CHKERRQ(ierr);
 
-  /*
+	/*
      Compute local vector entries
   */
-  xp = ctx.h*xs;
-  for (i=xs; i<xs+xm; i++) {
-    FF[i] = 6.0*xp + PetscPowScalar(xp+1.e-12,6.0); /* +1.e-12 is to prevent 0^6 */
-    UU[i] = xp*xp*xp;
-    xp   += ctx.h;
-  }
+	xp = ctx.h * xs;
+	for (i = xs; i < xs + xm; i++) {
+		FF[i] = 6.0 * xp +
+			PetscPowScalar(xp + 1.e-12,
+				       6.0); /* +1.e-12 is to prevent 0^6 */
+		UU[i] = xp * xp * xp;
+		xp += ctx.h;
+	}
 
-  /*
+	/*
      Restore vectors
   */
-  ierr = DMDAVecRestoreArray(ctx.da,F,&FF);CHKERRQ(ierr);
-  ierr = DMDAVecRestoreArray(ctx.da,U,&UU);CHKERRQ(ierr);
+	ierr = DMDAVecRestoreArray(ctx.da, F, &FF);
+	CHKERRQ(ierr);
+	ierr = DMDAVecRestoreArray(ctx.da, U, &UU);
+	CHKERRQ(ierr);
 
-  /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
      Evaluate initial guess; then solve nonlinear system
    - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-  /*
+	/*
      Note: The user should initialize the vector, x, with the initial guess
      for the nonlinear solver prior to calling SNESSolve().  In particular,
      to employ an initial guess of zero, the user should explicitly set
      this vector to zero by calling VecSet().
   */
-  ierr = FormInitialGuess(x);CHKERRQ(ierr);
-  ierr = SNESSolve(snes,NULL,x);CHKERRQ(ierr);
-  ierr = SNESGetIterationNumber(snes,&its);CHKERRQ(ierr);
-  ierr = PetscPrintf(PETSC_COMM_WORLD,"Number of SNES iterations = %D\n",its);CHKERRQ(ierr);
+	ierr = FormInitialGuess(x);
+	CHKERRQ(ierr);
+	ierr = SNESSolve(snes, NULL, x);
+	CHKERRQ(ierr);
+	ierr = SNESGetIterationNumber(snes, &its);
+	CHKERRQ(ierr);
+	ierr = PetscPrintf(PETSC_COMM_WORLD, "Number of SNES iterations = %D\n",
+			   its);
+	CHKERRQ(ierr);
 
-  /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+	/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
      Check solution and clean up
    - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-  /*
+	/*
      Check the error
   */
-  ierr = VecAXPY(x,none,U);CHKERRQ(ierr);
-  ierr = VecNorm(x,NORM_2,&norm);CHKERRQ(ierr);
-  ierr = PetscPrintf(PETSC_COMM_WORLD,"Norm of error %g Iterations %D\n",(double)norm,its);CHKERRQ(ierr);
+	ierr = VecAXPY(x, none, U);
+	CHKERRQ(ierr);
+	ierr = VecNorm(x, NORM_2, &norm);
+	CHKERRQ(ierr);
+	ierr = PetscPrintf(PETSC_COMM_WORLD, "Norm of error %g Iterations %D\n",
+			   (double)norm, its);
+	CHKERRQ(ierr);
 
-  /*
+	/*
      Free work space.  All PETSc objects should be destroyed when they
      are no longer needed.
   */
-  ierr = PetscViewerDestroy(&monP.viewer);CHKERRQ(ierr);
-  if (post_check) {ierr = VecDestroy(&checkP.last_step);CHKERRQ(ierr);}
-  ierr = VecDestroy(&x);CHKERRQ(ierr);
-  ierr = VecDestroy(&r);CHKERRQ(ierr);
-  ierr = VecDestroy(&U);CHKERRQ(ierr);
-  ierr = VecDestroy(&F);CHKERRQ(ierr);
-  ierr = MatDestroy(&J);CHKERRQ(ierr);
-  ierr = SNESDestroy(&snes);CHKERRQ(ierr);
-  ierr = DMDestroy(&ctx.da);CHKERRQ(ierr);
-  ierr = PetscFinalize();
-  return ierr;
+	ierr = PetscViewerDestroy(&monP.viewer);
+	CHKERRQ(ierr);
+	if (post_check) {
+		ierr = VecDestroy(&checkP.last_step);
+		CHKERRQ(ierr);
+	}
+	ierr = VecDestroy(&x);
+	CHKERRQ(ierr);
+	ierr = VecDestroy(&r);
+	CHKERRQ(ierr);
+	ierr = VecDestroy(&U);
+	CHKERRQ(ierr);
+	ierr = VecDestroy(&F);
+	CHKERRQ(ierr);
+	ierr = MatDestroy(&J);
+	CHKERRQ(ierr);
+	ierr = SNESDestroy(&snes);
+	CHKERRQ(ierr);
+	ierr = DMDestroy(&ctx.da);
+	CHKERRQ(ierr);
+	ierr = PetscFinalize();
+	return ierr;
 }
 
 /* ------------------------------------------------------------------- */
@@ -313,12 +402,13 @@ int main(int argc,char **argv)
 */
 PetscErrorCode FormInitialGuess(Vec x)
 {
-  PetscErrorCode ierr;
-  PetscScalar    pfive = .50;
+	PetscErrorCode ierr;
+	PetscScalar pfive = .50;
 
-  PetscFunctionBeginUser;
-  ierr = VecSet(x,pfive);CHKERRQ(ierr);
-  PetscFunctionReturn(0);
+	PetscFunctionBeginUser;
+	ierr = VecSet(x, pfive);
+	CHKERRQ(ierr);
+	PetscFunctionReturn(0);
 }
 
 /* ------------------------------------------------------------------- */
@@ -337,71 +427,87 @@ PetscErrorCode FormInitialGuess(Vec x)
    The user-defined context can contain any application-specific
    data needed for the function evaluation.
 */
-PetscErrorCode FormFunction(SNES snes,Vec x,Vec f,void *ctx)
+PetscErrorCode FormFunction(SNES snes, Vec x, Vec f, void *ctx)
 {
-  ApplicationCtx *user = (ApplicationCtx*) ctx;
-  DM             da    = user->da;
-  PetscScalar    *xx,*ff,*FF,d;
-  PetscErrorCode ierr;
-  PetscInt       i,M,xs,xm;
-  Vec            xlocal;
+	ApplicationCtx *user = (ApplicationCtx *)ctx;
+	DM da = user->da;
+	PetscScalar *xx, *ff, *FF, d;
+	PetscErrorCode ierr;
+	PetscInt i, M, xs, xm;
+	Vec xlocal;
 
-  PetscFunctionBeginUser;
-  ierr = DMGetLocalVector(da,&xlocal);CHKERRQ(ierr);
-  /*
+	PetscFunctionBeginUser;
+	ierr = DMGetLocalVector(da, &xlocal);
+	CHKERRQ(ierr);
+	/*
      Scatter ghost points to local vector, using the 2-step process
         DMGlobalToLocalBegin(), DMGlobalToLocalEnd().
      By placing code between these two statements, computations can
      be done while messages are in transition.
   */
-  ierr = DMGlobalToLocalBegin(da,x,INSERT_VALUES,xlocal);CHKERRQ(ierr);
-  ierr = DMGlobalToLocalEnd(da,x,INSERT_VALUES,xlocal);CHKERRQ(ierr);
+	ierr = DMGlobalToLocalBegin(da, x, INSERT_VALUES, xlocal);
+	CHKERRQ(ierr);
+	ierr = DMGlobalToLocalEnd(da, x, INSERT_VALUES, xlocal);
+	CHKERRQ(ierr);
 
-  /*
+	/*
      Get pointers to vector data.
        - The vector xlocal includes ghost point; the vectors x and f do
          NOT include ghost points.
        - Using DMDAVecGetArray() allows accessing the values using global ordering
   */
-  ierr = DMDAVecGetArray(da,xlocal,&xx);CHKERRQ(ierr);
-  ierr = DMDAVecGetArray(da,f,&ff);CHKERRQ(ierr);
-  ierr = DMDAVecGetArray(da,user->F,&FF);CHKERRQ(ierr);
+	ierr = DMDAVecGetArray(da, xlocal, &xx);
+	CHKERRQ(ierr);
+	ierr = DMDAVecGetArray(da, f, &ff);
+	CHKERRQ(ierr);
+	ierr = DMDAVecGetArray(da, user->F, &FF);
+	CHKERRQ(ierr);
 
-  /*
+	/*
      Get local grid boundaries (for 1-dimensional DMDA):
        xs, xm  - starting grid index, width of local grid (no ghost points)
   */
-  ierr = DMDAGetCorners(da,&xs,NULL,NULL,&xm,NULL,NULL);CHKERRQ(ierr);
-  ierr = DMDAGetInfo(da,NULL,&M,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL);CHKERRQ(ierr);
+	ierr = DMDAGetCorners(da, &xs, NULL, NULL, &xm, NULL, NULL);
+	CHKERRQ(ierr);
+	ierr = DMDAGetInfo(da, NULL, &M, NULL, NULL, NULL, NULL, NULL, NULL,
+			   NULL, NULL, NULL, NULL, NULL);
+	CHKERRQ(ierr);
 
-  /*
+	/*
      Set function values for boundary points; define local interior grid point range:
         xsi - starting interior grid index
         xei - ending interior grid index
   */
-  if (xs == 0) { /* left boundary */
-    ff[0] = xx[0];
-    xs++;xm--;
-  }
-  if (xs+xm == M) {  /* right boundary */
-    ff[xs+xm-1] = xx[xs+xm-1] - 1.0;
-    xm--;
-  }
+	if (xs == 0) { /* left boundary */
+		ff[0] = xx[0];
+		xs++;
+		xm--;
+	}
+	if (xs + xm == M) { /* right boundary */
+		ff[xs + xm - 1] = xx[xs + xm - 1] - 1.0;
+		xm--;
+	}
 
-  /*
+	/*
      Compute function over locally owned part of the grid (interior points only)
   */
-  d = 1.0/(user->h*user->h);
-  for (i=xs; i<xs+xm; i++) ff[i] = d*(xx[i-1] - 2.0*xx[i] + xx[i+1]) + xx[i]*xx[i] - FF[i];
+	d = 1.0 / (user->h * user->h);
+	for (i = xs; i < xs + xm; i++)
+		ff[i] = d * (xx[i - 1] - 2.0 * xx[i] + xx[i + 1]) +
+			xx[i] * xx[i] - FF[i];
 
-  /*
+	/*
      Restore vectors
   */
-  ierr = DMDAVecRestoreArray(da,xlocal,&xx);CHKERRQ(ierr);
-  ierr = DMDAVecRestoreArray(da,f,&ff);CHKERRQ(ierr);
-  ierr = DMDAVecRestoreArray(da,user->F,&FF);CHKERRQ(ierr);
-  ierr = DMRestoreLocalVector(da,&xlocal);CHKERRQ(ierr);
-  PetscFunctionReturn(0);
+	ierr = DMDAVecRestoreArray(da, xlocal, &xx);
+	CHKERRQ(ierr);
+	ierr = DMDAVecRestoreArray(da, f, &ff);
+	CHKERRQ(ierr);
+	ierr = DMDAVecRestoreArray(da, user->F, &FF);
+	CHKERRQ(ierr);
+	ierr = DMRestoreLocalVector(da, &xlocal);
+	CHKERRQ(ierr);
+	PetscFunctionReturn(0);
 }
 
 /* ------------------------------------------------------------------- */
@@ -418,57 +524,69 @@ PetscErrorCode FormFunction(SNES snes,Vec x,Vec f,void *ctx)
 .  B - optionally different preconditioning matrix
 .  flag - flag indicating matrix structure
 */
-PetscErrorCode FormJacobian(SNES snes,Vec x,Mat jac,Mat B,void *ctx)
+PetscErrorCode FormJacobian(SNES snes, Vec x, Mat jac, Mat B, void *ctx)
 {
-  ApplicationCtx *user = (ApplicationCtx*) ctx;
-  PetscScalar    *xx,d,A[3];
-  PetscErrorCode ierr;
-  PetscInt       i,j[3],M,xs,xm;
-  DM             da = user->da;
+	ApplicationCtx *user = (ApplicationCtx *)ctx;
+	PetscScalar *xx, d, A[3];
+	PetscErrorCode ierr;
+	PetscInt i, j[3], M, xs, xm;
+	DM da = user->da;
 
-  PetscFunctionBeginUser;
-  /*
+	PetscFunctionBeginUser;
+	/*
      Get pointer to vector data
   */
-  ierr = DMDAVecGetArrayRead(da,x,&xx);CHKERRQ(ierr);
-  ierr = DMDAGetCorners(da,&xs,NULL,NULL,&xm,NULL,NULL);CHKERRQ(ierr);
+	ierr = DMDAVecGetArrayRead(da, x, &xx);
+	CHKERRQ(ierr);
+	ierr = DMDAGetCorners(da, &xs, NULL, NULL, &xm, NULL, NULL);
+	CHKERRQ(ierr);
 
-  /*
+	/*
     Get range of locally owned matrix
   */
-  ierr = DMDAGetInfo(da,NULL,&M,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL);CHKERRQ(ierr);
+	ierr = DMDAGetInfo(da, NULL, &M, NULL, NULL, NULL, NULL, NULL, NULL,
+			   NULL, NULL, NULL, NULL, NULL);
+	CHKERRQ(ierr);
 
-  /*
+	/*
      Determine starting and ending local indices for interior grid points.
      Set Jacobian entries for boundary points.
   */
 
-  if (xs == 0) {  /* left boundary */
-    i = 0; A[0] = 1.0;
+	if (xs == 0) { /* left boundary */
+		i = 0;
+		A[0] = 1.0;
 
-    ierr = MatSetValues(jac,1,&i,1,&i,A,INSERT_VALUES);CHKERRQ(ierr);
-    xs++;xm--;
-  }
-  if (xs+xm == M) { /* right boundary */
-    i    = M-1;
-    A[0] = 1.0;
-    ierr = MatSetValues(jac,1,&i,1,&i,A,INSERT_VALUES);CHKERRQ(ierr);
-    xm--;
-  }
+		ierr = MatSetValues(jac, 1, &i, 1, &i, A, INSERT_VALUES);
+		CHKERRQ(ierr);
+		xs++;
+		xm--;
+	}
+	if (xs + xm == M) { /* right boundary */
+		i = M - 1;
+		A[0] = 1.0;
+		ierr = MatSetValues(jac, 1, &i, 1, &i, A, INSERT_VALUES);
+		CHKERRQ(ierr);
+		xm--;
+	}
 
-  /*
+	/*
      Interior grid points
       - Note that in this case we set all elements for a particular
         row at once.
   */
-  d = 1.0/(user->h*user->h);
-  for (i=xs; i<xs+xm; i++) {
-    j[0] = i - 1; j[1] = i; j[2] = i + 1;
-    A[0] = A[2] = d; A[1] = -2.0*d + 2.0*xx[i];
-    ierr = MatSetValues(jac,1,&i,3,j,A,INSERT_VALUES);CHKERRQ(ierr);
-  }
+	d = 1.0 / (user->h * user->h);
+	for (i = xs; i < xs + xm; i++) {
+		j[0] = i - 1;
+		j[1] = i;
+		j[2] = i + 1;
+		A[0] = A[2] = d;
+		A[1] = -2.0 * d + 2.0 * xx[i];
+		ierr = MatSetValues(jac, 1, &i, 3, j, A, INSERT_VALUES);
+		CHKERRQ(ierr);
+	}
 
-  /*
+	/*
      Assemble matrix, using the 2-step process:
        MatAssemblyBegin(), MatAssemblyEnd().
      By placing code between these two statements, computations can be
@@ -477,11 +595,14 @@ PetscErrorCode FormJacobian(SNES snes,Vec x,Mat jac,Mat B,void *ctx)
      Also, restore vector.
   */
 
-  ierr = MatAssemblyBegin(jac,MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
-  ierr = DMDAVecRestoreArrayRead(da,x,&xx);CHKERRQ(ierr);
-  ierr = MatAssemblyEnd(jac,MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
+	ierr = MatAssemblyBegin(jac, MAT_FINAL_ASSEMBLY);
+	CHKERRQ(ierr);
+	ierr = DMDAVecRestoreArrayRead(da, x, &xx);
+	CHKERRQ(ierr);
+	ierr = MatAssemblyEnd(jac, MAT_FINAL_ASSEMBLY);
+	CHKERRQ(ierr);
 
-  PetscFunctionReturn(0);
+	PetscFunctionReturn(0);
 }
 
 /* ------------------------------------------------------------------- */
@@ -500,17 +621,22 @@ PetscErrorCode FormJacobian(SNES snes,Vec x,Mat jac,Mat B,void *ctx)
    See the manpage for PetscViewerDrawOpen() for useful runtime options,
    such as -nox to deactivate all x-window output.
  */
-PetscErrorCode Monitor(SNES snes,PetscInt its,PetscReal fnorm,void *ctx)
+PetscErrorCode Monitor(SNES snes, PetscInt its, PetscReal fnorm, void *ctx)
 {
-  PetscErrorCode ierr;
-  MonitorCtx     *monP = (MonitorCtx*) ctx;
-  Vec            x;
+	PetscErrorCode ierr;
+	MonitorCtx *monP = (MonitorCtx *)ctx;
+	Vec x;
 
-  PetscFunctionBeginUser;
-  ierr = PetscPrintf(PETSC_COMM_WORLD,"iter = %D,SNES Function norm %g\n",its,(double)fnorm);CHKERRQ(ierr);
-  ierr = SNESGetSolution(snes,&x);CHKERRQ(ierr);
-  ierr = VecView(x,monP->viewer);CHKERRQ(ierr);
-  PetscFunctionReturn(0);
+	PetscFunctionBeginUser;
+	ierr = PetscPrintf(PETSC_COMM_WORLD,
+			   "iter = %D,SNES Function norm %g\n", its,
+			   (double)fnorm);
+	CHKERRQ(ierr);
+	ierr = SNESGetSolution(snes, &x);
+	CHKERRQ(ierr);
+	ierr = VecView(x, monP->viewer);
+	CHKERRQ(ierr);
+	PetscFunctionReturn(0);
 }
 
 /* ------------------------------------------------------------------- */
@@ -527,11 +653,12 @@ PetscErrorCode Monitor(SNES snes,PetscInt its,PetscReal fnorm,void *ctx)
    y         - proposed step (search direction and length) (possibly changed)
    changed_y - tells if the step has changed or not
  */
-PetscErrorCode PreCheck(SNESLineSearch linesearch,Vec xcurrent,Vec y, PetscBool *changed_y, void * ctx)
+PetscErrorCode PreCheck(SNESLineSearch linesearch, Vec xcurrent, Vec y,
+			PetscBool *changed_y, void *ctx)
 {
-  PetscFunctionBeginUser;
-  *changed_y = PETSC_FALSE;
-  PetscFunctionReturn(0);
+	PetscFunctionBeginUser;
+	*changed_y = PETSC_FALSE;
+	PetscFunctionReturn(0);
 }
 
 /* ------------------------------------------------------------------- */
@@ -552,57 +679,80 @@ PetscErrorCode PreCheck(SNESLineSearch linesearch,Vec xcurrent,Vec y, PetscBool 
    x    - current iterate (possibly modified)
 
  */
-PetscErrorCode PostCheck(SNESLineSearch linesearch,Vec xcurrent,Vec y,Vec x,PetscBool  *changed_y,PetscBool  *changed_x, void * ctx)
+PetscErrorCode PostCheck(SNESLineSearch linesearch, Vec xcurrent, Vec y, Vec x,
+			 PetscBool *changed_y, PetscBool *changed_x, void *ctx)
 {
-  PetscErrorCode ierr;
-  PetscInt       i,iter,xs,xm;
-  StepCheckCtx   *check;
-  ApplicationCtx *user;
-  PetscScalar    *xa,*xa_last,tmp;
-  PetscReal      rdiff;
-  DM             da;
-  SNES           snes;
+	PetscErrorCode ierr;
+	PetscInt i, iter, xs, xm;
+	StepCheckCtx *check;
+	ApplicationCtx *user;
+	PetscScalar *xa, *xa_last, tmp;
+	PetscReal rdiff;
+	DM da;
+	SNES snes;
 
-  PetscFunctionBeginUser;
-  *changed_x = PETSC_FALSE;
-  *changed_y = PETSC_FALSE;
+	PetscFunctionBeginUser;
+	*changed_x = PETSC_FALSE;
+	*changed_y = PETSC_FALSE;
 
-  ierr  = SNESLineSearchGetSNES(linesearch, &snes);CHKERRQ(ierr);
-  check = (StepCheckCtx*)ctx;
-  user  = check->user;
-  ierr  = SNESGetIterationNumber(snes,&iter);CHKERRQ(ierr);
+	ierr = SNESLineSearchGetSNES(linesearch, &snes);
+	CHKERRQ(ierr);
+	check = (StepCheckCtx *)ctx;
+	user = check->user;
+	ierr = SNESGetIterationNumber(snes, &iter);
+	CHKERRQ(ierr);
 
-  /* iteration 1 indicates we are working on the second iteration */
-  if (iter > 0) {
-    da   = user->da;
-    ierr = PetscPrintf(PETSC_COMM_WORLD,"Checking candidate step at iteration %D with tolerance %g\n",iter,(double)check->tolerance);CHKERRQ(ierr);
+	/* iteration 1 indicates we are working on the second iteration */
+	if (iter > 0) {
+		da = user->da;
+		ierr = PetscPrintf(
+			PETSC_COMM_WORLD,
+			"Checking candidate step at iteration %D with tolerance %g\n",
+			iter, (double)check->tolerance);
+		CHKERRQ(ierr);
 
-    /* Access local array data */
-    ierr = DMDAVecGetArray(da,check->last_step,&xa_last);CHKERRQ(ierr);
-    ierr = DMDAVecGetArray(da,x,&xa);CHKERRQ(ierr);
-    ierr = DMDAGetCorners(da,&xs,NULL,NULL,&xm,NULL,NULL);CHKERRQ(ierr);
+		/* Access local array data */
+		ierr = DMDAVecGetArray(da, check->last_step, &xa_last);
+		CHKERRQ(ierr);
+		ierr = DMDAVecGetArray(da, x, &xa);
+		CHKERRQ(ierr);
+		ierr = DMDAGetCorners(da, &xs, NULL, NULL, &xm, NULL, NULL);
+		CHKERRQ(ierr);
 
-    /*
+		/*
        If we fail the user-defined check for validity of the candidate iterate,
        then modify the iterate as we like.  (Note that the particular modification
        below is intended simply to demonstrate how to manipulate this data, not
        as a meaningful or appropriate choice.)
     */
-    for (i=xs; i<xs+xm; i++) {
-      if (!PetscAbsScalar(xa[i])) rdiff = 2*check->tolerance;
-      else rdiff = PetscAbsScalar((xa[i] - xa_last[i])/xa[i]);
-      if (rdiff > check->tolerance) {
-        tmp        = xa[i];
-        xa[i]      = .5*(xa[i] + xa_last[i]);
-        *changed_x = PETSC_TRUE;
-        ierr       = PetscPrintf(PETSC_COMM_WORLD,"  Altering entry %D: x=%g, x_last=%g, diff=%g, x_new=%g\n",i,(double)PetscAbsScalar(tmp),(double)PetscAbsScalar(xa_last[i]),(double)rdiff,(double)PetscAbsScalar(xa[i]));CHKERRQ(ierr);
-      }
-    }
-    ierr = DMDAVecRestoreArray(da,check->last_step,&xa_last);CHKERRQ(ierr);
-    ierr = DMDAVecRestoreArray(da,x,&xa);CHKERRQ(ierr);
-  }
-  ierr = VecCopy(x,check->last_step);CHKERRQ(ierr);
-  PetscFunctionReturn(0);
+		for (i = xs; i < xs + xm; i++) {
+			if (!PetscAbsScalar(xa[i]))
+				rdiff = 2 * check->tolerance;
+			else
+				rdiff = PetscAbsScalar((xa[i] - xa_last[i]) /
+						       xa[i]);
+			if (rdiff > check->tolerance) {
+				tmp = xa[i];
+				xa[i] = .5 * (xa[i] + xa_last[i]);
+				*changed_x = PETSC_TRUE;
+				ierr = PetscPrintf(
+					PETSC_COMM_WORLD,
+					"  Altering entry %D: x=%g, x_last=%g, diff=%g, x_new=%g\n",
+					i, (double)PetscAbsScalar(tmp),
+					(double)PetscAbsScalar(xa_last[i]),
+					(double)rdiff,
+					(double)PetscAbsScalar(xa[i]));
+				CHKERRQ(ierr);
+			}
+		}
+		ierr = DMDAVecRestoreArray(da, check->last_step, &xa_last);
+		CHKERRQ(ierr);
+		ierr = DMDAVecRestoreArray(da, x, &xa);
+		CHKERRQ(ierr);
+	}
+	ierr = VecCopy(x, check->last_step);
+	CHKERRQ(ierr);
+	PetscFunctionReturn(0);
 }
 
 /* ------------------------------------------------------------------- */
@@ -623,37 +773,56 @@ PetscErrorCode PostCheck(SNESLineSearch linesearch,Vec xcurrent,Vec y,Vec x,Pets
    x    - current iterate (possibly modified)
 
  */
-PetscErrorCode PostSetSubKSP(SNESLineSearch linesearch,Vec xcurrent,Vec y,Vec x,PetscBool  *changed_y,PetscBool  *changed_x, void * ctx)
+PetscErrorCode PostSetSubKSP(SNESLineSearch linesearch, Vec xcurrent, Vec y,
+			     Vec x, PetscBool *changed_y, PetscBool *changed_x,
+			     void *ctx)
 {
-  PetscErrorCode ierr;
-  SetSubKSPCtx   *check;
-  PetscInt       iter,its,sub_its,maxit;
-  KSP            ksp,sub_ksp,*sub_ksps;
-  PC             pc;
-  PetscReal      ksp_ratio;
-  SNES           snes;
+	PetscErrorCode ierr;
+	SetSubKSPCtx *check;
+	PetscInt iter, its, sub_its, maxit;
+	KSP ksp, sub_ksp, *sub_ksps;
+	PC pc;
+	PetscReal ksp_ratio;
+	SNES snes;
 
-  PetscFunctionBeginUser;
-  ierr    = SNESLineSearchGetSNES(linesearch, &snes);CHKERRQ(ierr);
-  check   = (SetSubKSPCtx*)ctx;
-  ierr    = SNESGetIterationNumber(snes,&iter);CHKERRQ(ierr);
-  ierr    = SNESGetKSP(snes,&ksp);CHKERRQ(ierr);
-  ierr    = KSPGetPC(ksp,&pc);CHKERRQ(ierr);
-  ierr    = PCBJacobiGetSubKSP(pc,NULL,NULL,&sub_ksps);CHKERRQ(ierr);
-  sub_ksp = sub_ksps[0];
-  ierr    = KSPGetIterationNumber(ksp,&its);CHKERRQ(ierr);      /* outer KSP iteration number */
-  ierr    = KSPGetIterationNumber(sub_ksp,&sub_its);CHKERRQ(ierr); /* inner KSP iteration number */
+	PetscFunctionBeginUser;
+	ierr = SNESLineSearchGetSNES(linesearch, &snes);
+	CHKERRQ(ierr);
+	check = (SetSubKSPCtx *)ctx;
+	ierr = SNESGetIterationNumber(snes, &iter);
+	CHKERRQ(ierr);
+	ierr = SNESGetKSP(snes, &ksp);
+	CHKERRQ(ierr);
+	ierr = KSPGetPC(ksp, &pc);
+	CHKERRQ(ierr);
+	ierr = PCBJacobiGetSubKSP(pc, NULL, NULL, &sub_ksps);
+	CHKERRQ(ierr);
+	sub_ksp = sub_ksps[0];
+	ierr = KSPGetIterationNumber(ksp, &its);
+	CHKERRQ(ierr); /* outer KSP iteration number */
+	ierr = KSPGetIterationNumber(sub_ksp, &sub_its);
+	CHKERRQ(ierr); /* inner KSP iteration number */
 
-  if (iter) {
-    ierr      = PetscPrintf(PETSC_COMM_WORLD,"    ...PostCheck snes iteration %D, ksp_it %d %d, subksp_it %d\n",iter,check->its0,its,sub_its);CHKERRQ(ierr);
-    ksp_ratio = ((PetscReal)(its))/check->its0;
-    maxit     = (PetscInt)(ksp_ratio*sub_its + 0.5);
-    if (maxit < 2) maxit = 2;
-    ierr = KSPSetTolerances(sub_ksp,PETSC_DEFAULT,PETSC_DEFAULT,PETSC_DEFAULT,maxit);CHKERRQ(ierr);
-    ierr = PetscPrintf(PETSC_COMM_WORLD,"    ...ksp_ratio %g, new maxit %d\n\n",ksp_ratio,maxit);CHKERRQ(ierr);
-  }
-  check->its0 = its; /* save current outer KSP iteration number */
-  PetscFunctionReturn(0);
+	if (iter) {
+		ierr = PetscPrintf(
+			PETSC_COMM_WORLD,
+			"    ...PostCheck snes iteration %D, ksp_it %d %d, subksp_it %d\n",
+			iter, check->its0, its, sub_its);
+		CHKERRQ(ierr);
+		ksp_ratio = ((PetscReal)(its)) / check->its0;
+		maxit = (PetscInt)(ksp_ratio * sub_its + 0.5);
+		if (maxit < 2)
+			maxit = 2;
+		ierr = KSPSetTolerances(sub_ksp, PETSC_DEFAULT, PETSC_DEFAULT,
+					PETSC_DEFAULT, maxit);
+		CHKERRQ(ierr);
+		ierr = PetscPrintf(PETSC_COMM_WORLD,
+				   "    ...ksp_ratio %g, new maxit %d\n\n",
+				   ksp_ratio, maxit);
+		CHKERRQ(ierr);
+	}
+	check->its0 = its; /* save current outer KSP iteration number */
+	PetscFunctionReturn(0);
 }
 
 /* ------------------------------------------------------------------- */
@@ -669,9 +838,10 @@ PetscErrorCode PostSetSubKSP(SNESLineSearch linesearch,Vec xcurrent,Vec y,Vec x,
    Output Parameter:
 .  y - preconditioned vector
 */
-PetscErrorCode MatrixFreePreconditioner(PC pc,Vec x,Vec y)
+PetscErrorCode MatrixFreePreconditioner(PC pc, Vec x, Vec y)
 {
-  PetscErrorCode ierr;
-  ierr = VecCopy(x,y);CHKERRQ(ierr);
-  return 0;
+	PetscErrorCode ierr;
+	ierr = VecCopy(x, y);
+	CHKERRQ(ierr);
+	return 0;
 }

--- a/tests/libs/petsc/tests/C_test.c
+++ b/tests/libs/petsc/tests/C_test.c
@@ -28,137 +28,211 @@ static char help[] = "Solves 2D Poisson equation using multigrid.\n\n";
 #include <petscsys.h>
 #include <petscvec.h>
 
-extern PetscErrorCode ComputeJacobian(KSP,Mat,Mat,void*);
-extern PetscErrorCode ComputeRHS(KSP,Vec,void*);
+extern PetscErrorCode ComputeJacobian(KSP, Mat, Mat, void *);
+extern PetscErrorCode ComputeRHS(KSP, Vec, void *);
 
 typedef struct {
-  PetscScalar uu, tt;
+	PetscScalar uu, tt;
 } UserContext;
 
-int main(int argc,char **argv)
+int main(int argc, char **argv)
 {
-  KSP            ksp;
-  DM             da;
-  UserContext    user;
-  PetscErrorCode ierr;
+	KSP ksp;
+	DM da;
+	UserContext user;
+	PetscErrorCode ierr;
 
-  ierr = PetscInitialize(&argc,&argv,(char*)0,help);if (ierr) return ierr;
-  ierr = KSPCreate(PETSC_COMM_WORLD,&ksp);CHKERRQ(ierr);
-  ierr = DMDACreate2d(PETSC_COMM_WORLD, DM_BOUNDARY_NONE, DM_BOUNDARY_NONE,DMDA_STENCIL_STAR,11,11,PETSC_DECIDE,PETSC_DECIDE,1,1,NULL,NULL,&da);CHKERRQ(ierr);
-  ierr = DMSetFromOptions(da);CHKERRQ(ierr);
-  ierr = DMSetUp(da);CHKERRQ(ierr);
-  ierr = KSPSetDM(ksp,(DM)da);CHKERRQ(ierr);
-  ierr = DMSetApplicationContext(da,&user);CHKERRQ(ierr);
+	ierr = PetscInitialize(&argc, &argv, (char *)0, help);
+	if (ierr)
+		return ierr;
+	ierr = KSPCreate(PETSC_COMM_WORLD, &ksp);
+	CHKERRQ(ierr);
+	ierr = DMDACreate2d(PETSC_COMM_WORLD, DM_BOUNDARY_NONE,
+			    DM_BOUNDARY_NONE, DMDA_STENCIL_STAR, 11, 11,
+			    PETSC_DECIDE, PETSC_DECIDE, 1, 1, NULL, NULL, &da);
+	CHKERRQ(ierr);
+	ierr = DMSetFromOptions(da);
+	CHKERRQ(ierr);
+	ierr = DMSetUp(da);
+	CHKERRQ(ierr);
+	ierr = KSPSetDM(ksp, (DM)da);
+	CHKERRQ(ierr);
+	ierr = DMSetApplicationContext(da, &user);
+	CHKERRQ(ierr);
 
-  user.uu     = 1.0;
-  user.tt     = 1.0;
+	user.uu = 1.0;
+	user.tt = 1.0;
 
-  ierr = KSPSetComputeRHS(ksp,ComputeRHS,&user);CHKERRQ(ierr);
-  ierr = KSPSetComputeOperators(ksp,ComputeJacobian,&user);CHKERRQ(ierr);
-  ierr = KSPSetFromOptions(ksp);CHKERRQ(ierr);
-  ierr = KSPSolve(ksp,NULL,NULL);CHKERRQ(ierr);
+	ierr = KSPSetComputeRHS(ksp, ComputeRHS, &user);
+	CHKERRQ(ierr);
+	ierr = KSPSetComputeOperators(ksp, ComputeJacobian, &user);
+	CHKERRQ(ierr);
+	ierr = KSPSetFromOptions(ksp);
+	CHKERRQ(ierr);
+	ierr = KSPSolve(ksp, NULL, NULL);
+	CHKERRQ(ierr);
 
-  ierr = DMDestroy(&da);CHKERRQ(ierr);
-  ierr = KSPDestroy(&ksp);CHKERRQ(ierr);
-  ierr = PetscFinalize();
-  return ierr;
+	ierr = DMDestroy(&da);
+	CHKERRQ(ierr);
+	ierr = KSPDestroy(&ksp);
+	CHKERRQ(ierr);
+	ierr = PetscFinalize();
+	return ierr;
 }
 
-PetscErrorCode ComputeRHS(KSP ksp,Vec b,void *ctx)
+PetscErrorCode ComputeRHS(KSP ksp, Vec b, void *ctx)
 {
-  UserContext    *user = (UserContext*)ctx;
-  PetscErrorCode ierr;
-  PetscInt       i,j,M,N,xm,ym,xs,ys;
-  PetscScalar    Hx,Hy,pi,uu,tt;
-  PetscScalar    **array;
-  DM             da;
-  MatNullSpace   nullspace;
+	UserContext *user = (UserContext *)ctx;
+	PetscErrorCode ierr;
+	PetscInt i, j, M, N, xm, ym, xs, ys;
+	PetscScalar Hx, Hy, pi, uu, tt;
+	PetscScalar **array;
+	DM da;
+	MatNullSpace nullspace;
 
-  PetscFunctionBeginUser;
-  ierr = KSPGetDM(ksp,&da);CHKERRQ(ierr);
-  ierr = DMDAGetInfo(da, 0, &M, &N, 0,0,0,0,0,0,0,0,0,0);CHKERRQ(ierr);
-  uu   = user->uu; tt = user->tt;
-  pi   = 4*atan(1.0);
-  Hx   = 1.0/(PetscReal)(M);
-  Hy   = 1.0/(PetscReal)(N);
+	PetscFunctionBeginUser;
+	ierr = KSPGetDM(ksp, &da);
+	CHKERRQ(ierr);
+	ierr = DMDAGetInfo(da, 0, &M, &N, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+	CHKERRQ(ierr);
+	uu = user->uu;
+	tt = user->tt;
+	pi = 4 * atan(1.0);
+	Hx = 1.0 / (PetscReal)(M);
+	Hy = 1.0 / (PetscReal)(N);
 
-  ierr = DMDAGetCorners(da,&xs,&ys,0,&xm,&ym,0);CHKERRQ(ierr); /* Fine grid */
-  ierr = DMDAVecGetArray(da, b, &array);CHKERRQ(ierr);
-  for (j=ys; j<ys+ym; j++) {
-    for (i=xs; i<xs+xm; i++) {
-      array[j][i] = -PetscCosScalar(uu*pi*((PetscReal)i+0.5)*Hx)*PetscCosScalar(tt*pi*((PetscReal)j+0.5)*Hy)*Hx*Hy;
-    }
-  }
-  ierr = DMDAVecRestoreArray(da, b, &array);CHKERRQ(ierr);
-  ierr = VecAssemblyBegin(b);CHKERRQ(ierr);
-  ierr = VecAssemblyEnd(b);CHKERRQ(ierr);
+	ierr = DMDAGetCorners(da, &xs, &ys, 0, &xm, &ym, 0);
+	CHKERRQ(ierr); /* Fine grid */
+	ierr = DMDAVecGetArray(da, b, &array);
+	CHKERRQ(ierr);
+	for (j = ys; j < ys + ym; j++) {
+		for (i = xs; i < xs + xm; i++) {
+			array[j][i] =
+				-PetscCosScalar(uu * pi * ((PetscReal)i + 0.5) *
+						Hx) *
+				PetscCosScalar(tt * pi * ((PetscReal)j + 0.5) *
+					       Hy) *
+				Hx * Hy;
+		}
+	}
+	ierr = DMDAVecRestoreArray(da, b, &array);
+	CHKERRQ(ierr);
+	ierr = VecAssemblyBegin(b);
+	CHKERRQ(ierr);
+	ierr = VecAssemblyEnd(b);
+	CHKERRQ(ierr);
 
-  /* force right hand side to be consistent for singular matrix */
-  /* note this is really a hack, normally the model would provide you with a consistent right handside */
-  ierr = MatNullSpaceCreate(PETSC_COMM_WORLD,PETSC_TRUE,0,0,&nullspace);CHKERRQ(ierr);
-  ierr = MatNullSpaceRemove(nullspace,b);CHKERRQ(ierr);
-  ierr = MatNullSpaceDestroy(&nullspace);CHKERRQ(ierr);
-  PetscFunctionReturn(0);
+	/* force right hand side to be consistent for singular matrix */
+	/* note this is really a hack, normally the model would provide you with a consistent right handside */
+	ierr = MatNullSpaceCreate(PETSC_COMM_WORLD, PETSC_TRUE, 0, 0,
+				  &nullspace);
+	CHKERRQ(ierr);
+	ierr = MatNullSpaceRemove(nullspace, b);
+	CHKERRQ(ierr);
+	ierr = MatNullSpaceDestroy(&nullspace);
+	CHKERRQ(ierr);
+	PetscFunctionReturn(0);
 }
 
-PetscErrorCode ComputeJacobian(KSP ksp,Mat J, Mat jac,void *ctx)
+PetscErrorCode ComputeJacobian(KSP ksp, Mat J, Mat jac, void *ctx)
 {
-  PetscErrorCode ierr;
-  PetscInt       i, j, M, N, xm, ym, xs, ys, num, numi, numj;
-  PetscScalar    v[5], Hx, Hy, HydHx, HxdHy;
-  MatStencil     row, col[5];
-  DM             da;
-  MatNullSpace   nullspace;
+	PetscErrorCode ierr;
+	PetscInt i, j, M, N, xm, ym, xs, ys, num, numi, numj;
+	PetscScalar v[5], Hx, Hy, HydHx, HxdHy;
+	MatStencil row, col[5];
+	DM da;
+	MatNullSpace nullspace;
 
-  PetscFunctionBeginUser;
-  ierr  = KSPGetDM(ksp,&da);CHKERRQ(ierr);
-  ierr  = DMDAGetInfo(da,0,&M,&N,0,0,0,0,0,0,0,0,0,0);CHKERRQ(ierr);
-  Hx    = 1.0 / (PetscReal)(M);
-  Hy    = 1.0 / (PetscReal)(N);
-  HxdHy = Hx/Hy;
-  HydHx = Hy/Hx;
-  ierr  = DMDAGetCorners(da,&xs,&ys,0,&xm,&ym,0);CHKERRQ(ierr);
-  for (j=ys; j<ys+ym; j++) {
-    for (i=xs; i<xs+xm; i++) {
-      row.i = i; row.j = j;
+	PetscFunctionBeginUser;
+	ierr = KSPGetDM(ksp, &da);
+	CHKERRQ(ierr);
+	ierr = DMDAGetInfo(da, 0, &M, &N, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+	CHKERRQ(ierr);
+	Hx = 1.0 / (PetscReal)(M);
+	Hy = 1.0 / (PetscReal)(N);
+	HxdHy = Hx / Hy;
+	HydHx = Hy / Hx;
+	ierr = DMDAGetCorners(da, &xs, &ys, 0, &xm, &ym, 0);
+	CHKERRQ(ierr);
+	for (j = ys; j < ys + ym; j++) {
+		for (i = xs; i < xs + xm; i++) {
+			row.i = i;
+			row.j = j;
 
-      if (i==0 || j==0 || i==M-1 || j==N-1) {
-        num=0; numi=0; numj=0;
-        if (j!=0) {
-          v[num] = -HxdHy;              col[num].i = i;   col[num].j = j-1;
-          num++; numj++;
-        }
-        if (i!=0) {
-          v[num] = -HydHx;              col[num].i = i-1; col[num].j = j;
-          num++; numi++;
-        }
-        if (i!=M-1) {
-          v[num] = -HydHx;              col[num].i = i+1; col[num].j = j;
-          num++; numi++;
-        }
-        if (j!=N-1) {
-          v[num] = -HxdHy;              col[num].i = i;   col[num].j = j+1;
-          num++; numj++;
-        }
-        v[num] = ((PetscReal)(numj)*HxdHy + (PetscReal)(numi)*HydHx); col[num].i = i;   col[num].j = j;
-        num++;
-        ierr = MatSetValuesStencil(jac,1,&row,num,col,v,INSERT_VALUES);CHKERRQ(ierr);
-      } else {
-        v[0] = -HxdHy;              col[0].i = i;   col[0].j = j-1;
-        v[1] = -HydHx;              col[1].i = i-1; col[1].j = j;
-        v[2] = 2.0*(HxdHy + HydHx); col[2].i = i;   col[2].j = j;
-        v[3] = -HydHx;              col[3].i = i+1; col[3].j = j;
-        v[4] = -HxdHy;              col[4].i = i;   col[4].j = j+1;
-        ierr = MatSetValuesStencil(jac,1,&row,5,col,v,INSERT_VALUES);CHKERRQ(ierr);
-      }
-    }
-  }
-  ierr = MatAssemblyBegin(jac,MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
-  ierr = MatAssemblyEnd(jac,MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
+			if (i == 0 || j == 0 || i == M - 1 || j == N - 1) {
+				num = 0;
+				numi = 0;
+				numj = 0;
+				if (j != 0) {
+					v[num] = -HxdHy;
+					col[num].i = i;
+					col[num].j = j - 1;
+					num++;
+					numj++;
+				}
+				if (i != 0) {
+					v[num] = -HydHx;
+					col[num].i = i - 1;
+					col[num].j = j;
+					num++;
+					numi++;
+				}
+				if (i != M - 1) {
+					v[num] = -HydHx;
+					col[num].i = i + 1;
+					col[num].j = j;
+					num++;
+					numi++;
+				}
+				if (j != N - 1) {
+					v[num] = -HxdHy;
+					col[num].i = i;
+					col[num].j = j + 1;
+					num++;
+					numj++;
+				}
+				v[num] = ((PetscReal)(numj)*HxdHy +
+					  (PetscReal)(numi)*HydHx);
+				col[num].i = i;
+				col[num].j = j;
+				num++;
+				ierr = MatSetValuesStencil(jac, 1, &row, num,
+							   col, v,
+							   INSERT_VALUES);
+				CHKERRQ(ierr);
+			} else {
+				v[0] = -HxdHy;
+				col[0].i = i;
+				col[0].j = j - 1;
+				v[1] = -HydHx;
+				col[1].i = i - 1;
+				col[1].j = j;
+				v[2] = 2.0 * (HxdHy + HydHx);
+				col[2].i = i;
+				col[2].j = j;
+				v[3] = -HydHx;
+				col[3].i = i + 1;
+				col[3].j = j;
+				v[4] = -HxdHy;
+				col[4].i = i;
+				col[4].j = j + 1;
+				ierr = MatSetValuesStencil(jac, 1, &row, 5, col,
+							   v, INSERT_VALUES);
+				CHKERRQ(ierr);
+			}
+		}
+	}
+	ierr = MatAssemblyBegin(jac, MAT_FINAL_ASSEMBLY);
+	CHKERRQ(ierr);
+	ierr = MatAssemblyEnd(jac, MAT_FINAL_ASSEMBLY);
+	CHKERRQ(ierr);
 
-  ierr = MatNullSpaceCreate(PETSC_COMM_WORLD,PETSC_TRUE,0,0,&nullspace);CHKERRQ(ierr);
-  ierr = MatSetNullSpace(J,nullspace);CHKERRQ(ierr);
-  ierr = MatNullSpaceDestroy(&nullspace);CHKERRQ(ierr);
-  PetscFunctionReturn(0);
+	ierr = MatNullSpaceCreate(PETSC_COMM_WORLD, PETSC_TRUE, 0, 0,
+				  &nullspace);
+	CHKERRQ(ierr);
+	ierr = MatSetNullSpace(J, nullspace);
+	CHKERRQ(ierr);
+	ierr = MatNullSpaceDestroy(&nullspace);
+	CHKERRQ(ierr);
+	PetscFunctionReturn(0);
 }
-

--- a/tests/libs/petsc/tests/rm_execution
+++ b/tests/libs/petsc/tests/rm_execution
@@ -1,45 +1,47 @@
-#!/usr/bin/env -S bats --report-formatter junit --formatter tap
+#!/usr/bin/env -S bats --report-formatter junit --formatter tap -j 4
 # -*-sh-*-
 
-load ./common/test_helper_functions || exit 1
-source ./common/functions || exit 1
+load ../../../common/test_helper_functions || exit 1
+source ../../../common/functions || exit 1
 
-if [ -s ./common/TEST_ENV ];then
-    source ./common/TEST_ENV
+if [ -s ../../../common/TEST_ENV ]; then
+	source ../../../common/TEST_ENV
 fi
 
-check_rms
-rm=$RESOURCE_MANAGER
+setup_file() {
+	TESTNAME="libs/PETSc"
+	NODES=2
+	TASKS=$(tasks_count 8)
+	ARGS=8
 
-testname="libs/PETSc"
+	check_rms
 
-NODES=2
-TASKS=`tasks_count 8`
-ARGS=8
-
-@test "[$testname] C binary runs under resource manager ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
-    if [ ! -x C_test ];then
-	flunk "C_test binary does not exist"
-    fi
-
-    run_mpi_binary ./C_test $ARGS $NODES $TASKS
-    assert_success
+	export TESTNAME NODES TASKS ARGS
 }
 
-@test "[$testname] MPI C binary runs under resource manager ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
-    if [ ! -x C_mpi_test ];then
-	flunk "C_mpi_test binary does not exist"
-    fi
+@test "[${TESTNAME}] C binary runs under resource manager (${RESOURCE_MANAGER}/${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	if [ ! -x C_test ]; then
+		flunk "C_test binary does not exist"
+	fi
 
-    run_mpi_binary ./C_mpi_test $ARGS $NODES $TASKS
-    assert_success
+	run_mpi_binary ./C_test "${ARGS}" "${NODES}" "${TASKS}"
+	assert_success
 }
 
-@test "[$testname] MPI F90 binary runs under resource manager ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
-    if [ ! -x F90_test ];then
-	flunk "F_test binary does not exist"
-    fi
+@test "[${TESTNAME}] MPI C binary runs under resource manager (${RESOURCE_MANAGER}/${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	if [ ! -x C_mpi_test ]; then
+		flunk "C_mpi_test binary does not exist"
+	fi
 
-    run_mpi_binary ./F90_test 2 $NODES $TASKS
-    assert_success
+	run_mpi_binary ./C_mpi_test "${ARGS}" "${NODES}" "${TASKS}"
+	assert_success
+}
+
+@test "[${TESTNAME}] MPI F90 binary runs under resource manager (${RESOURCE_MANAGER}/${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	if [ ! -x F90_test ]; then
+		flunk "F90_test binary does not exist"
+	fi
+
+	run_mpi_binary ./F90_test 2 "${NODES}" "${TASKS}"
+	assert_success
 }

--- a/tests/libs/petsc/tests/test_module
+++ b/tests/libs/petsc/tests/test_module
@@ -1,133 +1,134 @@
-#!/usr/bin/env -S bats --report-formatter junit --formatter tap
+#!/usr/bin/env -S bats --report-formatter junit --formatter tap -j 4
 # -*-sh-*-
 
-source ./common/test_helper_functions.bash || exit 1
-source ./common/functions || exit 1
+source ../../../common/test_helper_functions.bash || exit 1
+source ../../../common/functions || exit 1
 
-if [ -s ./common/TEST_ENV ];then
-    source ./common/TEST_ENV
+if [ -s ../../../common/TEST_ENV ]; then
+	source ../../../common/TEST_ENV
 fi
 
-PKG=PETSC
-module=petsc
-testname=libs/PETSc
-library=libpetsc
-header=petsc.h
+setup_file() {
+	PKG=PETSC
+	MODULE=petsc
+	TESTNAME=libs/PETSc
+	LIBRARY=libpetsc
+	HEADER=petsc.h
 
-check_rms
+	check_rms
 
-@test "[$testname] Verify $PKG module is loaded and matches rpm version ($LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
-    module list $module | grep "1) $module" >& .cmd_output || exit 1
-    run grep $module .cmd_output 
-    assert_success
-    
-    # check version against rpm
-    local rpm
-    rpm=$(get_rpm_name ${module})
-    local version="$(rpm -q --queryformat='%{VERSION}\n' $rpm)"
-    run cat .cmd_output
-    assert_output "  1) $module/$version"
-
-    rm -f .cmd_output
+	export PKG MODULE TESTNAME LIBRARY HEADER
 }
 
-@test "[$testname] Verify module ${PKG}_DIR is defined and exists ($LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
-    DIR=${PKG}_DIR
-    if [ -z ${!DIR} ];then
-        flunk "${PKG}_DIR directory not defined"
-    fi
-    
-    if [ ! -d ${!DIR} || -z "${!DIR}" ];then
-        flunk "directory ${!DIR} does not exist"
-    fi 
+setup() {
+	OUTPUT="$(mktemp)"
+
+	export OUTPUT
 }
 
-@test "[$testname] Verify module ${PKG}_BIN is defined and exists" {
-    BIN=${PKG}_BIN
-    if [ -z ${!BIN} ];then
-        flunk "${PKG}_BIN directory not defined"
-    fi
-    
-    if [ ! -d ${!BIN} || -z "${!BIN}" ];then
-        flunk "directory ${!BIN} does not exist"
-    fi 
+teardown() {
+	rm -f "${OUTPUT}"
 }
 
+@test "[${TESTNAME}] Verify ${PKG} module is loaded and matches rpm version (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	module list "${MODULE}" | grep "1) ${MODULE}" >&"${OUTPUT}" || exit 1
+	run grep "${MODULE}" "${OUTPUT}"
+	assert_success
+
+	# check version against rpm
+	local rpm
+	rpm=$(get_rpm_name "${MODULE}")
+	local version
+	version="$(rpm -q --queryformat='%{VERSION}\n' "${rpm}")"
+	run cat "${OUTPUT}"
+	assert_output "  1) ${MODULE}/${version}"
+}
+
+@test "[${TESTNAME}] Verify module ${PKG}_DIR is defined and exists (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	PKG_DIR="${PKG}_DIR"
+
+	if [ -z "${!PKG_DIR}" ]; then
+		flunk "${PKG}_DIR directory not defined"
+	fi
+
+	if [ ! -d "${!PKG_DIR}" ]; then
+		flunk "directory ${!PKG_DIR} does not exist"
+	fi
+}
 
 # ----------
 # Lib Tests
 # ----------
 
-@test "[$testname] Verify module ${PKG}_LIB is defined and exists ($LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
-    LIB=${PKG}_LIB
+@test "[${TESTNAME}] Verify module ${PKG}_LIB is defined and exists (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	PKG_LIB="${PKG}_LIB"
 
-    if [ -z ${!LIB} ];then
-        flunk "${PKG}_LIB directory not defined"
-    fi
- 
-    if [ ! -d ${!LIB} ];then
-        flunk "directory ${!LIB} does not exist"
-    fi 
+	if [ -z "${!PKG_LIB}" ]; then
+		flunk "${PKG}_LIB directory not defined"
+	fi
+
+	if [ ! -d "${!PKG_LIB}" ]; then
+		flunk "directory ${!PKG_LIB} does not exist"
+	fi
 }
 
-@test "[$testname] Verify dynamic library available in ${PKG}_LIB ($LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
-    LIB=${PKG}_LIB
+@test "[${TESTNAME}] Verify dynamic library available in ${PKG}_LIB (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	PKG_LIB="${PKG}_LIB"
 
-    if [ -z ${!LIB} ];then
-        flunk "${PKG}_LIB directory not defined"
-    fi
+	if [ -z "${!PKG_LIB}" ]; then
+		flunk "${PKG}_LIB directory not defined"
+	fi
 
-    if [ ! -s ${!LIB}/${library}.so ];then
-        flunk "${library}.so does not exist"
-    fi 
+	if [ ! -s "${!PKG_LIB}/${LIBRARY}.so" ]; then
+		flunk "${LIBRARY}.so does not exist"
+	fi
 }
 
-@test "[$testname] Verify static library is not present in ${PKG}_LIB ($LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
-    LIB=${PKG}_LIB
+@test "[${TESTNAME}] Verify static library is not present in ${PKG}_LIB (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	PKG_LIB="${PKG}_LIB"
 
-    if [ -z ${!LIB} ];then
-        flunk "${PKG}_LIB directory not defined"
-    fi
+	if [ -z "${!PKG_LIB}" ]; then
+		flunk "${PKG}_LIB directory not defined"
+	fi
 
-    if [ -e ${!LIB}/${library}.a ];then
-        flunk "${library}.a exists when not expecting it"
-    fi 
+	if [ -e "${!PKG_LIB}/${LIBRARY}.a" ]; then
+		flunk "${LIBRARY}.a exists when not expecting it"
+	fi
 }
 
 # --------------
 # Include Tests
 # --------------
 
-@test "[$testname] Verify module ${PKG}_INC is defined and exists ($LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
-    INC=${PKG}_INC
+@test "[${TESTNAME}] Verify module ${PKG}_INC is defined and exists (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	PKG_INC="${PKG}_INC"
 
-    if [ -z ${!INC} ];then
-        flunk "${PKG}_INC directory not defined"
-    fi
-    
-    if [ ! -d ${!INC} ];then
-        flunk "directory ${!INC} does not exist"
-    fi 
+	if [ -z "${!PKG_INC}" ]; then
+		flunk "${PKG}_INC directory not defined"
+	fi
+
+	if [ ! -d "${!PKG_INC}" ]; then
+		flunk "directory ${!PKG_INC} does not exist"
+	fi
 }
 
-@test "[$testname] Verify header file is present in ${PKG}_INC ($LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
-    INC=${PKG}_INC
+@test "[${TESTNAME}] Verify header file is present in ${PKG}_INC (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	PKG_INC="${PKG}_INC"
 
-    if [ -z ${!INC} ];then
-        flunk "${PKG}_INC directory not defined"
-    fi
-    
-    if [ ! -s ${!INC}/${header} ];then
-        flunk "directory $header file does not exist"
-    fi 
+	if [ -z "${!PKG_INC}" ]; then
+		flunk "${PKG}_INC directory not defined"
+	fi
+
+	if [ ! -s "${!PKG_INC}/${HEADER}" ]; then
+		flunk "${HEADER} file does not exist"
+	fi
 }
 
-@test "[$testname] Sample job ($RESOURCE_MANAGER/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
-    if [ ! -x "C_test" ];then
-        flunk "C_test binary not available"
-    fi
+@test "[${TESTNAME}] Sample job (${RESOURCE_MANAGER}/${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	if [ ! -x C_test ]; then
+		flunk "C_test binary not available"
+	fi
 
-    run_mpi_binary ./C_test "atest" 1 1
-    assert_success
+	run_mpi_binary ./C_test "atest" 1 1
+	assert_success
 }
-


### PR DESCRIPTION
  - Update PETSc from 3.23.5 to 3.24.4                                                                                                                                                                                                        
  - Add optional ccache support for faster rebuilds                                                                                                                                                                                           
  - Modernize test suite to follow BEST_PRACTICES.md guidelines  