### PR TITLE
docs: Make pandoc dependencies and build conditional on RHEL

### DIFF
--- a/components/admin/docs/SPECS/docs.spec
+++ b/components/admin/docs/SPECS/docs.spec
@@ -28,6 +28,7 @@ BuildRequires:  make
 BuildRequires:  python3
 
 # Requirements for markdown-based documentation (pandoc + jinja2)
+%if 0%{?rhel}
 BuildRequires:  pandoc
 BuildRequires:  python3-jinja2
 BuildRequires:  python3-pyyaml
@@ -37,6 +38,7 @@ BuildRequires:  texlive-adjustbox
 BuildRequires:  texlive-collectbox
 BuildRequires:  texlive-unicode-math
 BuildRequires:  texlive-lm-math
+%endif
 
 # Requirements for LaTeX-based documentation (and shared with markdown/pandoc)
 BuildRequires:  texlive-latex
@@ -89,7 +91,8 @@ from the OpenHPC software stack.
 %define parser_perl ../../../../parse_doc.pl
 %define parser_python ../../../../parse_doc.py
 
-# Build markdown-based documentation
+# Build markdown-based documentation (RHEL only)
+%if 0%{?rhel}
 for recipe_path in \
 	"almalinux10/x86_64/confluent/slurm" \
 	"almalinux10/x86_64/warewulf4/slurm" \
@@ -104,6 +107,7 @@ for recipe_path in \
 
 	popd
 done
+%endif
 
 # Build LaTeX-based documentation
 for recipe_path in \
@@ -159,7 +163,8 @@ done
 install -m 0644 -p docs/ChangeLog %{buildroot}/%{OHPC_PUB}/doc/ChangeLog
 install -m 0644 -p docs/Release_Notes.txt %{buildroot}/%{OHPC_PUB}/doc/Release_Notes.txt
 
-# Install markdown-based documentation
+# Install markdown-based documentation (RHEL only)
+%if 0%{?rhel}
 for recipe_path in \
 	"almalinux10/x86_64/confluent/slurm" \
 	"almalinux10/x86_64/warewulf4/slurm" \
@@ -168,6 +173,7 @@ for recipe_path in \
 	install -m 0644 -p -D "%{recipe_base_md}/${recipe_path}/steps.pdf" "%{recipe_dest}/${recipe_path}/Install_guide.pdf"
 	install -m 0755 -p -D "%{recipe_base_md}/${recipe_path}/recipe.sh" "%{recipe_dest}/${recipe_path}/recipe.sh"
 done
+%endif
 
 # Install LaTeX-based documentation
 for recipe_path in \


### PR DESCRIPTION
Wrap the markdown-based documentation build requirements (pandoc, python3-jinja2, python3-pyyaml, mdtoc, and related texlive packages) in a %{rhel} conditional. Also wrap the markdown documentation build and install sections so they only run on RHEL-based distributions.

This ensures that non-RHEL distributions (like openEuler) continue to use the LaTeX-based documentation without requiring pandoc.

Generated with Claude Code (https://claude.ai/code)