### PR TITLE
tests: modernize extrae and dimemas tests

### DIFF
--- a/components/parallel-libs/slepc/SPECS/slepc.spec
+++ b/components/parallel-libs/slepc/SPECS/slepc.spec
@@ -21,7 +21,7 @@
 %define pname slepc
 
 Name:           %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-Version:        3.23.0
+Version:        3.24.2
 Release:        1
 Summary:        A library for solving large scale sparse eigenvalue problems
 License:        LGPL-3.0

--- a/tests/apps/miniDFT/ohpc-tests/test_mpi_families
+++ b/tests/apps/miniDFT/ohpc-tests/test_mpi_families
@@ -11,10 +11,6 @@ source ./common/functions || exit 1
 cd apps/miniDFT || exit 1
 export BATS_JUNIT_CLASS=MiniDFT
 
-# bootstrap the local autotools project
-
-./bootstrap || exit 1
-
 rm -f tests/test/miniDFT.*.out tests/log.miniDFT >& /dev/null
 
 make_check_failure=0
@@ -45,6 +41,7 @@ for compiler in $COMPILER_FAMILIES ; do
         fi
     fi
 
+	./bootstrap           || exit 1
 	./configure           || exit 1
 	make clean            || exit 1
 	make -k check         || status=1

--- a/tests/apps/miniFE/ohpc-tests/test_mpi_families
+++ b/tests/apps/miniFE/ohpc-tests/test_mpi_families
@@ -11,10 +11,6 @@ source ./common/functions || exit 1
 cd apps/miniFE || exit 1
 export BATS_JUNIT_CLASS=MiniFE
 
-# bootstrap the local autotools project
-
-./bootstrap || exit 1
-
 rm -f tests/miniFE.*.yaml tests/log.miniFE >& /dev/null
 
 make_check_failure=0
@@ -35,6 +31,7 @@ for compiler in $COMPILER_FAMILIES ; do
 	module load $compiler || exit 1
 	module load $mpi      || exit 1
 
+	./bootstrap           || exit 1
 	./configure           || exit 1
 	make clean            || exit 1
 

--- a/tests/apps/prk/ohpc-tests/test_mpi_families
+++ b/tests/apps/prk/ohpc-tests/test_mpi_families
@@ -11,10 +11,6 @@ source ./common/functions || exit 1
 cd apps/prk || exit 1
 export BATS_JUNIT_CLASS=PRK
 
-# bootstrap the local autotools project
-
-./bootstrap || exit 1
-
 make_check_failure=0
 
 for compiler in $COMPILER_FAMILIES ; do
@@ -33,6 +29,7 @@ for compiler in $COMPILER_FAMILIES ; do
 	module load $compiler || exit 1
 	module load $mpi      || exit 1
 
+	./bootstrap           || exit 1
 	./configure           || exit 1
 	make clean            || exit 1
 

--- a/tests/ci/Makefile
+++ b/tests/ci/Makefile
@@ -27,6 +27,9 @@ codespell-lint:
 		tests/user-env/ompi_info \
 		tests/perf-tools/dimemas/tests/test_module \
 		tests/perf-tools/extrae/tests/test_module \
+		tests/perf-tools/extrae/tests/rm_execution \
+		tests/perf-tools/extrae/tests/tracec.sh \
+		tests/perf-tools/extrae/tests/tracef.sh \
 		tests/perf-tools/likwid/tests/rm_execution \
 		tests/perf-tools/likwid/tests/test_module \
 		tests/perf-tools/omb/tests/rm_execution \
@@ -118,6 +121,9 @@ whitespace-lint:
 		tests/user-env/ompi_info \
 		tests/perf-tools/dimemas/tests/test_module \
 		tests/perf-tools/extrae/tests/test_module \
+		tests/perf-tools/extrae/tests/rm_execution \
+		tests/perf-tools/extrae/tests/tracec.sh \
+		tests/perf-tools/extrae/tests/tracef.sh \
 		tests/perf-tools/likwid/tests/rm_execution \
 		tests/perf-tools/likwid/tests/test_module \
 		tests/perf-tools/omb/tests/rm_execution \
@@ -210,6 +216,9 @@ shellcheck-lint:
 		../../tests/user-env/ompi_info \
 		../../tests/perf-tools/dimemas/tests/test_module \
 		../../tests/perf-tools/extrae/tests/test_module \
+		../../tests/perf-tools/extrae/tests/rm_execution \
+		../../tests/perf-tools/extrae/tests/tracec.sh \
+		../../tests/perf-tools/extrae/tests/tracef.sh \
 		../../tests/perf-tools/likwid/tests/rm_execution \
 		../../tests/perf-tools/likwid/tests/test_module \
 		../../tests/perf-tools/omb/tests/rm_execution \
@@ -272,6 +281,7 @@ shfmt-lint:
 		../../tests/user-env/ompi_info \
 		../../tests/perf-tools/dimemas/tests/test_module \
 		../../tests/perf-tools/extrae/tests/test_module \
+		../../tests/perf-tools/extrae/tests/rm_execution \
 		../../tests/perf-tools/likwid/tests/rm_execution \
 		../../tests/perf-tools/likwid/tests/test_module \
 		../../tests/perf-tools/omb/tests/rm_execution \
@@ -318,6 +328,8 @@ shfmt-lint:
 		../../tests/libs/openblas/tests/test_module \
 		../../tests/libs/openblas/tests/test_lapack
 	shfmt -w -d \
+		../../tests/perf-tools/extrae/tests/tracec.sh \
+		../../tests/perf-tools/extrae/tests/tracef.sh \
 		../../tests/ci/prepare-ci-environment.sh \
 		../../misc/build_order.sh \
 		../../misc/dist/count_avail_packages.sh \
@@ -357,6 +369,7 @@ clang-format-lint:
 		../../tests/libs/fftw/tests/*.cpp \
 		../../tests/libs/trilinos/tests/*.cpp \
 		../../containers/examples/mpi/mpi.c \
+		../../tests/perf-tools/extrae/tests/*.c \
 		../../tests/perf-tools/papi/tests/*.c \
 		../../tests/rms-harness/tests/*.c \
 		../../tests/libs/petsc/tests/*.c \

--- a/tests/compilers/ohpc-tests/test_compiler_families
+++ b/tests/compilers/ohpc-tests/test_compiler_families
@@ -11,10 +11,6 @@ source ./common/functions || exit 1
 cd compilers || exit 1
 export BATS_JUNIT_CLASS=Compilers
 
-# bootstrap the local autotools project
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
 
     echo " "
@@ -26,6 +22,7 @@ for compiler in $COMPILER_FAMILIES ; do
     module purge 
     module load $compiler 
 
+    ./bootstrap           || exit 1
     ./configure         || exit 1
     make clean          || exit 1
     make -j 4 -k check  || status=1

--- a/tests/dev-tools/hwloc/ohpc-tests/test_compiler_families
+++ b/tests/dev-tools/hwloc/ohpc-tests/test_compiler_families
@@ -11,10 +11,6 @@ source ./common/functions || exit 1
 cd dev-tools/hwloc || exit 1
 export BATS_JUNIT_CLASS=HWLOC
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
 
     # gnu families only
@@ -30,6 +26,7 @@ for compiler in $COMPILER_FAMILIES ; do
     module load $compiler || exit 1
     module load hwloc  || exit 1
     
+    ./bootstrap           || exit 1
     ./configure   || exit 1
     make clean    || exit 1
     make -k check || status=1

--- a/tests/dev-tools/valgrind/ohpc-tests/test_compiler_families
+++ b/tests/dev-tools/valgrind/ohpc-tests/test_compiler_families
@@ -11,10 +11,6 @@ source ./common/functions || exit 1
 cd dev-tools/valgrind || exit 1
 export BATS_JUNIT_CLASS=Valgrind
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
 
     echo " "
@@ -27,6 +23,7 @@ for compiler in $COMPILER_FAMILIES ; do
     module load $compiler || exit 1
     module load valgrind  || exit 1
     
+    ./bootstrap           || exit 1
     ./configure   || exit 1
     make clean    || exit 1
     make -k check || status=1

--- a/tests/libs/R/ohpc-tests/test_compiler_families
+++ b/tests/libs/R/ohpc-tests/test_compiler_families
@@ -11,10 +11,6 @@ source ./common/functions || exit 1
 cd libs/R || exit 1
 export BATS_JUNIT_CLASS="R"
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
 
     # gnu families only
@@ -30,6 +26,7 @@ for compiler in $COMPILER_FAMILIES ; do
     module load $compiler || exit 1
     module load R         || exit 1
     
+    ./bootstrap           || exit 1
     ./configure   || exit 1
     make clean    || exit 1
     make -k check || status=1

--- a/tests/libs/adios2/ohpc-tests/test_mpi_families
+++ b/tests/libs/adios2/ohpc-tests/test_mpi_families
@@ -11,10 +11,6 @@ cd libs/adios2 || exit 1
 
 export BATS_JUNIT_CLASS=Adios2
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in ${COMPILER_FAMILIES}; do
 	for mpi in ${MPI_FAMILIES}; do
 
@@ -30,6 +26,7 @@ for compiler in ${COMPILER_FAMILIES}; do
 		module load "${mpi}" || exit 1
 		module load adios2 || exit 1
 
+		./bootstrap || exit 1
 		./configure || exit 1
 		make clean || exit 1
 		make -k check || status=1

--- a/tests/libs/boost-mpi/ohpc-tests/test_mpi_families
+++ b/tests/libs/boost-mpi/ohpc-tests/test_mpi_families
@@ -12,10 +12,6 @@ cd libs/boost-mpi         || exit 1
 
 export BATS_JUNIT_CLASS="Boost-MPI"
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
     for mpi in $MPI_FAMILIES ; do
 
@@ -31,6 +27,7 @@ for compiler in $COMPILER_FAMILIES ; do
 	module load $mpi      || exit 1
 	module load boost     || exit 1
 
+	./bootstrap           || exit 1
 	./configure           || exit 1
 	make clean            || exit 1
 	make -k check         || status=1

--- a/tests/libs/boost/ohpc-tests/test_mpi_families
+++ b/tests/libs/boost/ohpc-tests/test_mpi_families
@@ -12,10 +12,6 @@ cd libs/boost             || exit 1
 
 export BATS_JUNIT_CLASS="Boost"
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
     for mpi in $MPI_FAMILIES ; do
 	echo " "
@@ -30,6 +26,7 @@ for compiler in $COMPILER_FAMILIES ; do
         module load $mpi      || exit 1
 	module load boost     || exit 1
 
+	./bootstrap           || exit 1
 	./configure           || exit 1
 	make    clean         || exit 1
 	make -k check         || status=1

--- a/tests/libs/fftw/ohpc-tests/test_mpi_families
+++ b/tests/libs/fftw/ohpc-tests/test_mpi_families
@@ -14,10 +14,6 @@ export BATS_JUNIT_CLASS=FFTW
 
 MPIs_local=`echo $MPI_FAMILIES | sed 's/impi//'`
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
 
     # gnu families only
@@ -37,6 +33,7 @@ for compiler in $COMPILER_FAMILIES ; do
 	module load $mpi      || exit 1
 	module load fftw      || exit 1
 
+	./bootstrap           || exit 1
 	./configure           || exit 1
 	make clean            || exit 1
 	make -k check         || status=1

--- a/tests/libs/gsl/ohpc-tests/test_compiler_families
+++ b/tests/libs/gsl/ohpc-tests/test_compiler_families
@@ -11,10 +11,6 @@ cd libs/gsl               || exit 1
 
 export BATS_JUNIT_CLASS=GSL
 
-# bootstrap the local autotools project
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
 
     # gnu families only
@@ -30,6 +26,7 @@ for compiler in $COMPILER_FAMILIES ; do
     module load $compiler       || exit 1
     module load gsl             || exit 1
 
+    ./bootstrap           || exit 1
     ./configure                 || exit 1
     make clean     >& /dev/null || exit 1
     pushd tests    >& /dev/null || exit 1

--- a/tests/libs/hdf5/ohpc-tests/test_compiler_families
+++ b/tests/libs/hdf5/ohpc-tests/test_compiler_families
@@ -15,10 +15,6 @@ pushd libs/hdf5/test-h5-wrappers-new/ >/dev/null || exit 1
 
 export BATS_JUNIT_CLASS=HDF5
 
-# bootstrap the local autotools project
-
-./bootstrap || exit 1
-
 for COMPILER in ${COMPILER_FAMILIES}; do
 
 	echo " "
@@ -31,6 +27,7 @@ for COMPILER in ${COMPILER_FAMILIES}; do
 	module load "${COMPILER}" || exit 1
 	module load hdf5 || exit 1
 
+	./bootstrap || exit 1
 	./configure || exit 1
 	make -j 4 check || status=1
 
@@ -46,10 +43,6 @@ popd >/dev/null || exit 1
 
 cd libs/hdf5/test-env-variables-new || exit 1
 
-# bootstrap the local autotools project
-
-./bootstrap || exit 1
-
 for COMPILER in ${COMPILER_FAMILIES}; do
 
 	echo " "
@@ -62,6 +55,7 @@ for COMPILER in ${COMPILER_FAMILIES}; do
 	module load "${COMPILER}" || exit 1
 	module load hdf5 || exit 1
 
+	./bootstrap || exit 1
 	./configure || exit 1
 	make -j 4 check || status=1
 

--- a/tests/libs/hypre/ohpc-tests/test_mpi_families
+++ b/tests/libs/hypre/ohpc-tests/test_mpi_families
@@ -11,10 +11,6 @@ source ./common/functions || exit 1
 cd libs/hypre || exit 1
 export BATS_JUNIT_CLASS=Hypre
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
     for mpi in $MPI_FAMILIES ; do
 
@@ -30,6 +26,7 @@ for compiler in $COMPILER_FAMILIES ; do
 	module load $mpi      || exit 1
 	module load hypre     || exit 1
 
+	./bootstrap           || exit 1
 	./configure           || exit 1
 	make clean            || exit 1
 	make -k check         || status=1

--- a/tests/libs/metis/ohpc-tests/test_compiler_families
+++ b/tests/libs/metis/ohpc-tests/test_compiler_families
@@ -12,10 +12,6 @@ cd libs/metis             || exit 1
 
 export BATS_JUNIT_CLASS=metis
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
 
     echo " "
@@ -28,6 +24,7 @@ for compiler in $COMPILER_FAMILIES ; do
     module load $compiler       || exit 1
     module load metis           || exit 1
 
+    ./bootstrap           || exit 1
     ./configure                 || exit 1
     make clean                  || exit 1
     make -k check               || status=1

--- a/tests/libs/mfem/ohpc-tests/test_mpi_families
+++ b/tests/libs/mfem/ohpc-tests/test_mpi_families
@@ -11,10 +11,6 @@ source ./common/functions || exit 1
 cd libs/mfem || exit 1
 export BATS_JUNIT_CLASS="Mfem"
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
     for mpi in $MPI_FAMILIES ; do
 
@@ -30,6 +26,7 @@ for compiler in $COMPILER_FAMILIES ; do
 	module load $mpi      || exit 1
 	module load mfem      || exit 1
 
+	./bootstrap           || exit 1
 	./configure           || exit 1
 	make clean            || exit 1
 	make -k check         || status=1

--- a/tests/libs/mumps/ohpc-tests/test_mpi_families
+++ b/tests/libs/mumps/ohpc-tests/test_mpi_families
@@ -12,10 +12,6 @@ cd libs/mumps             || exit 1
 
 export BATS_JUNIT_CLASS=MUMPS
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
     for mpi in $MPI_FAMILIES ; do
 
@@ -31,6 +27,7 @@ for compiler in $COMPILER_FAMILIES ; do
 	module load mumps     || exit 1
 	module load prun      || exit 1
 
+	./bootstrap           || exit 1
 	./configure           || exit 1
 	make clean            || exit 1
 	make -k check         || status=1

--- a/tests/libs/netcdf/ohpc-tests/netcdf_all_test_mpi_families
+++ b/tests/libs/netcdf/ohpc-tests/netcdf_all_test_mpi_families
@@ -12,10 +12,6 @@ source ./common/functions || exit 1
 
 cd libs/netcdf || exit 1
 export BATS_JUNIT_CLASS=NetCDF
-
-# bootstrap the local autotools project if necessary
-./bootstrap || exit 1
-
 if [ -n "${SIMPLE_CI}" ]; then
 	export OMPI_MCA_btl="self,tcp"
 fi
@@ -38,6 +34,7 @@ for compiler in ${COMPILER_FAMILIES}; do
 		module load netcdf-cxx || exit 1
 		module load netcdf-fortran || exit 1
 
+		./bootstrap || exit 1
 		./configure --enable-all || exit 1
 		make clean || exit 1
 		make -k check || status=1
@@ -65,6 +62,7 @@ for compiler in ${COMPILER_FAMILIES}; do
 	module load netcdf-cxx || exit 1
 	module load netcdf-fortran || exit 1
 
+	./bootstrap || exit 1
 	./configure --enable-all --disable-parallel || exit 1
 	make clean || exit 1
 	make -k check || status=1

--- a/tests/libs/netcdf/ohpc-tests/test_mpi_families
+++ b/tests/libs/netcdf/ohpc-tests/test_mpi_families
@@ -12,10 +12,6 @@ source ./common/functions || exit 1
 
 cd libs/netcdf || exit 1
 export BATS_JUNIT_CLASS=NetCDF
-
-# bootstrap the local autotools project if necessary
-./bootstrap || exit 1
-
 if [ -n "${SIMPLE_CI}" ]; then
 	export OMPI_MCA_btl="self,tcp"
 fi
@@ -36,6 +32,7 @@ for compiler in ${COMPILER_FAMILIES}; do
 		module load "${mpi}" || exit 1
 		module load netcdf || exit 1
 
+		./bootstrap || exit 1
 		./configure || exit 1
 		make clean || exit 1
 		make -k check || status=1
@@ -61,6 +58,7 @@ for compiler in ${COMPILER_FAMILIES}; do
 	module load "${compiler}" || exit 1
 	module load netcdf || exit 1
 
+	./bootstrap || exit 1
 	./configure --disable-parallel || exit 1
 	make clean || exit 1
 	make -k check || status=1

--- a/tests/libs/openblas/ohpc-tests/test_compiler_families
+++ b/tests/libs/openblas/ohpc-tests/test_compiler_families
@@ -11,10 +11,6 @@ cd libs/openblas || exit 1
 
 export BATS_JUNIT_CLASS=OPENBLAS
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in ${COMPILER_FAMILIES}; do
 
 	# gnu families only
@@ -31,6 +27,7 @@ for compiler in ${COMPILER_FAMILIES}; do
 	module load "${compiler}" || exit 1
 	module load openblas || exit 1
 
+	./bootstrap || exit 1
 	./configure || exit 1
 	make clean || exit 1
 	make -k check || status=1

--- a/tests/libs/opencoarrays/ohpc-tests/test_mpi_families
+++ b/tests/libs/opencoarrays/ohpc-tests/test_mpi_families
@@ -11,10 +11,6 @@ source ./common/functions || exit 1
 cd libs/opencoarrays || exit 1
 export BATS_JUNIT_CLASS=OpenCoarrays
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in gnu15 ; do
     for mpi in $MPI_FAMILIES ; do
 
@@ -30,6 +26,7 @@ for compiler in gnu15 ; do
 	module load $mpi         || exit 1
 	module load opencoarrays || exit 1
 
+	./bootstrap           || exit 1
 	./configure              || exit 1
 	make clean               || exit 1
 	make -k check            || status=1

--- a/tests/libs/petsc/ohpc-tests/test_mpi_families
+++ b/tests/libs/petsc/ohpc-tests/test_mpi_families
@@ -12,10 +12,6 @@ source ./common/functions || exit 1
 cd libs/petsc || exit 1
 export BATS_JUNIT_CLASS=PETSc
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for COMPILER in ${COMPILER_FAMILIES}; do
 	for MPI in ${MPI_FAMILIES}; do
 
@@ -31,6 +27,7 @@ for COMPILER in ${COMPILER_FAMILIES}; do
 		module load "${MPI}" || exit 1
 		module load petsc || exit 1
 
+		./bootstrap || exit 1
 		./configure || exit 1
 		make clean || exit 1
 		make -k check || status=1

--- a/tests/libs/phdf5/ohpc-tests/test_mpi_families
+++ b/tests/libs/phdf5/ohpc-tests/test_mpi_families
@@ -12,10 +12,6 @@ source ./common/functions || exit 1
 cd libs/phdf5 || exit 1
 export BATS_JUNIT_CLASS=PHDF5
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for COMPILER in ${COMPILER_FAMILIES}; do
 	for MPI in ${MPI_FAMILIES}; do
 
@@ -31,6 +27,7 @@ for COMPILER in ${COMPILER_FAMILIES}; do
 		module load "${MPI}" || exit 1
 		module load phdf5 || exit 1
 
+		./bootstrap || exit 1
 		./configure || exit 1
 		make clean || exit 1
 		make -k check || STATUS=1

--- a/tests/libs/plasma/ohpc-tests/test_compiler_families
+++ b/tests/libs/plasma/ohpc-tests/test_compiler_families
@@ -12,10 +12,6 @@ cd libs/plasma             || exit 1
 
 export BATS_JUNIT_CLASS=PLASMA
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
 
     if [ "$compiler" == "arm1" ]; then
@@ -32,6 +28,7 @@ for compiler in $COMPILER_FAMILIES ; do
     module load $compiler       || exit 1
     module load plasma          || exit 1
 
+    ./bootstrap           || exit 1
     ./configure                 || exit 1
     make clean                  || exit 1
     make -k check               || status=1

--- a/tests/libs/pnetcdf/ohpc-tests/test_mpi_families
+++ b/tests/libs/pnetcdf/ohpc-tests/test_mpi_families
@@ -11,10 +11,6 @@ source ./common/functions || exit 1
 cd libs/pnetcdf || exit 1
 export BATS_JUNIT_CLASS=PNETCDF
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
     for mpi in $MPI_FAMILIES ; do
 
@@ -30,6 +26,7 @@ for compiler in $COMPILER_FAMILIES ; do
 	module load $mpi      || exit 1
 	module load pnetcdf   || exit 1
 
+	./bootstrap           || exit 1
 	./configure           || exit 1
 	make clean            || exit 1
 	make -k check         || status=1

--- a/tests/libs/ptscotch/ohpc-tests/test_mpi_families
+++ b/tests/libs/ptscotch/ohpc-tests/test_mpi_families
@@ -11,10 +11,6 @@ cd libs/ptscotch || exit 1
 
 export BATS_JUNIT_CLASS=PTScotch
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES; do
 	for mpi in $MPI_FAMILIES; do
 
@@ -30,6 +26,7 @@ for compiler in $COMPILER_FAMILIES; do
 		module load "$mpi" || exit 1
 		module load ptscotch || exit 1
 
+		./bootstrap           || exit 1
 		./configure || exit 1
 		make clean || exit 1
 		make -k check || status=1

--- a/tests/libs/scalapack/ohpc-tests/test_mpi_families
+++ b/tests/libs/scalapack/ohpc-tests/test_mpi_families
@@ -12,10 +12,6 @@ source ./common/functions || exit 1
 cd libs/scalapack || exit 1
 export BATS_JUNIT_CLASS=scalapack
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for COMPILER in ${COMPILER_FAMILIES}; do
 
 	# gnu families only
@@ -35,6 +31,7 @@ for COMPILER in ${COMPILER_FAMILIES}; do
 		module load "${MPI}" || exit 1
 		module load scalapack || exit 1
 
+		./bootstrap || exit 1
 		./configure || exit 1
 		make clean || exit 1
 		make -k check || status=1

--- a/tests/libs/scotch/ohpc-tests/test_compiler_families
+++ b/tests/libs/scotch/ohpc-tests/test_compiler_families
@@ -11,10 +11,6 @@ cd libs/scotch || exit 1
 
 export BATS_JUNIT_CLASS=SCOTCH
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES; do
 
 	echo " "
@@ -28,6 +24,7 @@ for compiler in $COMPILER_FAMILIES; do
 	module load scotch || exit 1
 	module load prun || exit 1
 
+	./bootstrap           || exit 1
 	./configure || exit 1
 	make clean || exit 1
 	make -k check || status=1

--- a/tests/libs/slepc/configure.ac
+++ b/tests/libs/slepc/configure.ac
@@ -3,7 +3,7 @@
 #
 
 AC_PREREQ(2.59)
-AC_INIT(slepc, 3.7.4, [https://github.com/openhpc/ohpc])
+AC_INIT(slepc, 3.24.2, [https://github.com/openhpc/ohpc])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])

--- a/tests/libs/slepc/ohpc-tests/test_mpi_families
+++ b/tests/libs/slepc/ohpc-tests/test_mpi_families
@@ -11,10 +11,6 @@ source ./common/functions || exit 1
 cd libs/slepc || exit 1
 export BATS_JUNIT_CLASS=SLEPc
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
     for mpi in $MPI_FAMILIES ; do
 
@@ -30,6 +26,7 @@ for compiler in $COMPILER_FAMILIES ; do
 	module load $mpi      || exit 1
 	module load slepc     || exit 1
 
+	./bootstrap           || exit 1
 	./configure           || exit 1
 	make clean            || exit 1
 	make -k check         || status=1

--- a/tests/libs/slepc/tests/ex15.c
+++ b/tests/libs/slepc/tests/ex15.c
@@ -26,8 +26,6 @@ static char help[] = "Singular value decomposition of the Lauchli matrix.\n"
 
 #include <slepcsvd.h>
 
-#undef __FUNCT__
-#define __FUNCT__ "main"
 int main(int argc,char **argv)
 {
   Mat            A;               /* operator matrix */
@@ -36,37 +34,36 @@ int main(int argc,char **argv)
   SVDType        type;
   PetscReal      error,tol,sigma,mu=PETSC_SQRT_MACHINE_EPSILON;
   PetscInt       n=100,i,j,Istart,Iend,nsv,maxit,its,nconv;
-  PetscErrorCode ierr;
 
-  SlepcInitialize(&argc,&argv,(char*)0,help);
+  PetscCall(SlepcInitialize(&argc,&argv,(char*)0,help));
 
-  ierr = PetscOptionsGetInt(NULL,NULL,"-n",&n,NULL);CHKERRQ(ierr);
-  ierr = PetscOptionsGetReal(NULL,NULL,"-mu",&mu,NULL);CHKERRQ(ierr);
-  ierr = PetscPrintf(PETSC_COMM_WORLD,"\nLauchli singular value decomposition, (%D x %D) mu=%g\n\n",n+1,n,(double)mu);CHKERRQ(ierr);
+  PetscCall(PetscOptionsGetInt(NULL,NULL,"-n",&n,NULL));
+  PetscCall(PetscOptionsGetReal(NULL,NULL,"-mu",&mu,NULL));
+  PetscCall(PetscPrintf(PETSC_COMM_WORLD,"\nLauchli singular value decomposition, (%" PetscInt_FMT " x %" PetscInt_FMT ") mu=%g\n\n",n+1,n,(double)mu));
 
   /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
                           Build the Lauchli matrix
      - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-  ierr = MatCreate(PETSC_COMM_WORLD,&A);CHKERRQ(ierr);
-  ierr = MatSetSizes(A,PETSC_DECIDE,PETSC_DECIDE,n+1,n);CHKERRQ(ierr);
-  ierr = MatSetFromOptions(A);CHKERRQ(ierr);
-  ierr = MatSetUp(A);CHKERRQ(ierr);
+  PetscCall(MatCreate(PETSC_COMM_WORLD,&A));
+  PetscCall(MatSetSizes(A,PETSC_DECIDE,PETSC_DECIDE,n+1,n));
+  PetscCall(MatSetFromOptions(A));
+  PetscCall(MatSetUp(A));
 
-  ierr = MatGetOwnershipRange(A,&Istart,&Iend);CHKERRQ(ierr);
+  PetscCall(MatGetOwnershipRange(A,&Istart,&Iend));
   for (i=Istart;i<Iend;i++) {
     if (i == 0) {
       for (j=0;j<n;j++) {
-        ierr = MatSetValue(A,0,j,1.0,INSERT_VALUES);CHKERRQ(ierr);
+        PetscCall(MatSetValue(A,0,j,1.0,INSERT_VALUES));
       }
     } else {
-      ierr = MatSetValue(A,i,i-1,mu,INSERT_VALUES);CHKERRQ(ierr);
+      PetscCall(MatSetValue(A,i,i-1,mu,INSERT_VALUES));
     }
   }
 
-  ierr = MatAssemblyBegin(A,MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
-  ierr = MatAssemblyEnd(A,MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
-  ierr = MatCreateVecs(A,&v,&u);CHKERRQ(ierr);
+  PetscCall(MatAssemblyBegin(A,MAT_FINAL_ASSEMBLY));
+  PetscCall(MatAssemblyEnd(A,MAT_FINAL_ASSEMBLY));
+  PetscCall(MatCreateVecs(A,&v,&u));
 
   /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
           Create the singular value solver and set various options
@@ -75,40 +72,40 @@ int main(int argc,char **argv)
   /*
      Create singular value solver context
   */
-  ierr = SVDCreate(PETSC_COMM_WORLD,&svd);CHKERRQ(ierr);
+  PetscCall(SVDCreate(PETSC_COMM_WORLD,&svd));
 
   /*
-     Set operator
+     Set operators
   */
-  ierr = SVDSetOperator(svd,A);CHKERRQ(ierr);
+  PetscCall(SVDSetOperators(svd,A,NULL));
 
   /*
      Use thick-restart Lanczos as default solver
   */
-  ierr = SVDSetType(svd,SVDTRLANCZOS);CHKERRQ(ierr);
+  PetscCall(SVDSetType(svd,SVDTRLANCZOS));
 
   /*
      Set solver parameters at runtime
   */
-  ierr = SVDSetFromOptions(svd);CHKERRQ(ierr);
+  PetscCall(SVDSetFromOptions(svd));
 
   /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
                       Solve the singular value system
      - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-  ierr = SVDSolve(svd);CHKERRQ(ierr);
-  ierr = SVDGetIterationNumber(svd,&its);CHKERRQ(ierr);
-  ierr = PetscPrintf(PETSC_COMM_WORLD," Number of iterations of the method: %D\n",its);CHKERRQ(ierr);
+  PetscCall(SVDSolve(svd));
+  PetscCall(SVDGetIterationNumber(svd,&its));
+  PetscCall(PetscPrintf(PETSC_COMM_WORLD," Number of iterations of the method: %" PetscInt_FMT "\n",its));
 
   /*
      Optional: Get some information from the solver and display it
   */
-  ierr = SVDGetType(svd,&type);CHKERRQ(ierr);
-  ierr = PetscPrintf(PETSC_COMM_WORLD," Solution method: %s\n\n",type);CHKERRQ(ierr);
-  ierr = SVDGetDimensions(svd,&nsv,NULL,NULL);CHKERRQ(ierr);
-  ierr = PetscPrintf(PETSC_COMM_WORLD," Number of requested singular values: %D\n",nsv);CHKERRQ(ierr);
-  ierr = SVDGetTolerances(svd,&tol,&maxit);CHKERRQ(ierr);
-  ierr = PetscPrintf(PETSC_COMM_WORLD," Stopping condition: tol=%.4g, maxit=%D\n",(double)tol,maxit);CHKERRQ(ierr);
+  PetscCall(SVDGetType(svd,&type));
+  PetscCall(PetscPrintf(PETSC_COMM_WORLD," Solution method: %s\n\n",type));
+  PetscCall(SVDGetDimensions(svd,&nsv,NULL,NULL));
+  PetscCall(PetscPrintf(PETSC_COMM_WORLD," Number of requested singular values: %" PetscInt_FMT "\n",nsv));
+  PetscCall(SVDGetTolerances(svd,&tol,&maxit));
+  PetscCall(PetscPrintf(PETSC_COMM_WORLD," Stopping condition: tol=%.4g, maxit=%" PetscInt_FMT "\n",(double)tol,maxit));
 
   /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
                     Display solution and clean up
@@ -117,40 +114,40 @@ int main(int argc,char **argv)
   /*
      Get number of converged singular triplets
   */
-  ierr = SVDGetConverged(svd,&nconv);CHKERRQ(ierr);
-  ierr = PetscPrintf(PETSC_COMM_WORLD," Number of converged approximate singular triplets: %D\n\n",nconv);CHKERRQ(ierr);
+  PetscCall(SVDGetConverged(svd,&nconv));
+  PetscCall(PetscPrintf(PETSC_COMM_WORLD," Number of converged approximate singular triplets: %" PetscInt_FMT "\n\n",nconv));
 
   if (nconv>0) {
     /*
        Display singular values and relative errors
     */
-    ierr = PetscPrintf(PETSC_COMM_WORLD,
+    PetscCall(PetscPrintf(PETSC_COMM_WORLD,
          "          sigma           relative error\n"
-         "  --------------------- ------------------\n");CHKERRQ(ierr);
+         "  --------------------- ------------------\n"));
     for (i=0;i<nconv;i++) {
       /*
          Get converged singular triplets: i-th singular value is stored in sigma
       */
-      ierr = SVDGetSingularTriplet(svd,i,&sigma,u,v);CHKERRQ(ierr);
+      PetscCall(SVDGetSingularTriplet(svd,i,&sigma,u,v));
 
       /*
          Compute the error associated to each singular triplet
       */
-      ierr = SVDComputeError(svd,i,SVD_ERROR_RELATIVE,&error);CHKERRQ(ierr);
+      PetscCall(SVDComputeError(svd,i,SVD_ERROR_RELATIVE,&error));
 
-      ierr = PetscPrintf(PETSC_COMM_WORLD,"       % 6f      ",(double)sigma);CHKERRQ(ierr);
-      ierr = PetscPrintf(PETSC_COMM_WORLD," % 12g\n",(double)error);CHKERRQ(ierr);
+      PetscCall(PetscPrintf(PETSC_COMM_WORLD,"       % 6f      ",(double)sigma));
+      PetscCall(PetscPrintf(PETSC_COMM_WORLD," % 12g\n",(double)error));
     }
-    ierr = PetscPrintf(PETSC_COMM_WORLD,"\n");CHKERRQ(ierr);
+    PetscCall(PetscPrintf(PETSC_COMM_WORLD,"\n"));
   }
 
   /*
      Free work space
   */
-  ierr = SVDDestroy(&svd);CHKERRQ(ierr);
-  ierr = MatDestroy(&A);CHKERRQ(ierr);
-  ierr = VecDestroy(&u);CHKERRQ(ierr);
-  ierr = VecDestroy(&v);CHKERRQ(ierr);
-  ierr = SlepcFinalize();
-  return ierr;
+  PetscCall(SVDDestroy(&svd));
+  PetscCall(MatDestroy(&A));
+  PetscCall(VecDestroy(&u));
+  PetscCall(VecDestroy(&v));
+  PetscCall(SlepcFinalize());
+  return 0;
 }

--- a/tests/libs/slepc/tests/ex29.c
+++ b/tests/libs/slepc/tests/ex29.c
@@ -35,69 +35,67 @@ int main(int argc,char **argv)
   PetscBool          terse;
   PetscViewer        viewer;
   EPSConvergedReason reason;
-  PetscErrorCode     ierr;
+  PetscCall(SlepcInitialize(&argc,&argv,(char*)0,help));
 
-  ierr = SlepcInitialize(&argc,&argv,(char*)0,help);if (ierr) return ierr;
-
-  ierr = PetscOptionsGetInt(NULL,NULL,"-m",&m,NULL);CHKERRQ(ierr);
+  PetscCall(PetscOptionsGetInt(NULL,NULL,"-m",&m,NULL));
   N = m*(m+1)/2;
-  ierr = PetscPrintf(PETSC_COMM_WORLD,"\nMarkov Model, N=%D (m=%D)\n",N,m);CHKERRQ(ierr);
-  ierr = PetscOptionsGetReal(NULL,NULL,"-seconds",&seconds,NULL);CHKERRQ(ierr);
-  ierr = PetscPrintf(PETSC_COMM_WORLD,"Maximum time for computation is set to %g seconds.\n\n",(double)seconds);CHKERRQ(ierr);
+  PetscCall(PetscPrintf(PETSC_COMM_WORLD,"\nMarkov Model, N=%" PetscInt_FMT " (m=%" PetscInt_FMT ")\n",N,m));
+  PetscCall(PetscOptionsGetReal(NULL,NULL,"-seconds",&seconds,NULL));
+  PetscCall(PetscPrintf(PETSC_COMM_WORLD,"Maximum time for computation is set to %g seconds.\n\n",(double)seconds));
   deadline = seconds;
-  ierr = PetscTimeAdd(&deadline);CHKERRQ(ierr);
+  PetscCall(PetscTimeAdd(&deadline));
 
   /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
      Compute the operator matrix that defines the eigensystem, Ax=kx
      - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-  ierr = MatCreate(PETSC_COMM_WORLD,&A);CHKERRQ(ierr);
-  ierr = MatSetSizes(A,PETSC_DECIDE,PETSC_DECIDE,N,N);CHKERRQ(ierr);
-  ierr = MatSetFromOptions(A);CHKERRQ(ierr);
-  ierr = MatSetUp(A);CHKERRQ(ierr);
-  ierr = MatMarkovModel(m,A);CHKERRQ(ierr);
+  PetscCall(MatCreate(PETSC_COMM_WORLD,&A));
+  PetscCall(MatSetSizes(A,PETSC_DECIDE,PETSC_DECIDE,N,N));
+  PetscCall(MatSetFromOptions(A));
+  PetscCall(MatSetUp(A));
+  PetscCall(MatMarkovModel(m,A));
 
   /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
                 Create the eigensolver and set various options
      - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-  ierr = EPSCreate(PETSC_COMM_WORLD,&eps);CHKERRQ(ierr);
-  ierr = EPSSetOperators(eps,A,NULL);CHKERRQ(ierr);
-  ierr = EPSSetProblemType(eps,EPS_NHEP);CHKERRQ(ierr);
-  ierr = EPSSetStoppingTestFunction(eps,MyStoppingTest,&deadline,NULL);CHKERRQ(ierr);
-  ierr = EPSSetFromOptions(eps);CHKERRQ(ierr);
+  PetscCall(EPSCreate(PETSC_COMM_WORLD,&eps));
+  PetscCall(EPSSetOperators(eps,A,NULL));
+  PetscCall(EPSSetProblemType(eps,EPS_NHEP));
+  PetscCall(EPSSetStoppingTestFunction(eps,MyStoppingTest,&deadline,NULL));
+  PetscCall(EPSSetFromOptions(eps));
 
   /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
                       Solve the eigensystem
      - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-  ierr = EPSSolve(eps);CHKERRQ(ierr);
+  PetscCall(EPSSolve(eps));
 
   /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
                     Display solution and clean up
      - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
   /* show detailed info unless -terse option is given by user */
-  ierr = PetscOptionsHasName(NULL,NULL,"-terse",&terse);CHKERRQ(ierr);
+  PetscCall(PetscOptionsHasName(NULL,NULL,"-terse",&terse));
   if (terse) {
-    ierr = EPSErrorView(eps,EPS_ERROR_RELATIVE,NULL);CHKERRQ(ierr);
+    PetscCall(EPSErrorView(eps,EPS_ERROR_RELATIVE,NULL));
   } else {
-    ierr = PetscViewerASCIIGetStdout(PETSC_COMM_WORLD,&viewer);CHKERRQ(ierr);
-    ierr = PetscViewerPushFormat(viewer,PETSC_VIEWER_ASCII_INFO_DETAIL);CHKERRQ(ierr);
-    ierr = EPSGetConvergedReason(eps,&reason);CHKERRQ(ierr);
+    PetscCall(PetscViewerASCIIGetStdout(PETSC_COMM_WORLD,&viewer));
+    PetscCall(PetscViewerPushFormat(viewer,PETSC_VIEWER_ASCII_INFO_DETAIL));
+    PetscCall(EPSGetConvergedReason(eps,&reason));
     if (reason!=EPS_CONVERGED_USER) {
-      ierr = EPSConvergedReasonView(eps,viewer);CHKERRQ(ierr);
-      ierr = EPSErrorView(eps,EPS_ERROR_RELATIVE,viewer);CHKERRQ(ierr);
+      PetscCall(EPSConvergedReasonView(eps,viewer));
+      PetscCall(EPSErrorView(eps,EPS_ERROR_RELATIVE,viewer));
     } else {
-      ierr = EPSGetConverged(eps,&nconv);CHKERRQ(ierr);
-      ierr = PetscViewerASCIIPrintf(viewer,"Eigensolve finished with %D converged eigenpairs; reason=%s\n",nconv,EPSConvergedReasons[reason]);CHKERRQ(ierr);
+      PetscCall(EPSGetConverged(eps,&nconv));
+      PetscCall(PetscViewerASCIIPrintf(viewer,"Eigensolve finished with %" PetscInt_FMT " converged eigenpairs; reason=%s\n",nconv,EPSConvergedReasons[reason]));
     }
-    ierr = PetscViewerPopFormat(viewer);CHKERRQ(ierr);
+    PetscCall(PetscViewerPopFormat(viewer));
   }
-  ierr = EPSDestroy(&eps);CHKERRQ(ierr);
-  ierr = MatDestroy(&A);CHKERRQ(ierr);
-  ierr = SlepcFinalize();
-  return ierr;
+  PetscCall(EPSDestroy(&eps));
+  PetscCall(MatDestroy(&A));
+  PetscCall(SlepcFinalize());
+  return 0;
 }
 
 /*
@@ -124,10 +122,9 @@ PetscErrorCode MatMarkovModel(PetscInt m,Mat A)
   const PetscReal cst = 0.5/(PetscReal)(m-1);
   PetscReal       pd,pu;
   PetscInt        Istart,Iend,i,j,jmax,ix=0;
-  PetscErrorCode  ierr;
 
   PetscFunctionBeginUser;
-  ierr = MatGetOwnershipRange(A,&Istart,&Iend);CHKERRQ(ierr);
+  PetscCall(MatGetOwnershipRange(A,&Istart,&Iend));
   for (i=1;i<=m;i++) {
     jmax = m-i+1;
     for (j=1;j<=jmax;j++) {
@@ -137,31 +134,31 @@ PetscErrorCode MatMarkovModel(PetscInt m,Mat A)
         pd = cst*(PetscReal)(i+j-1);
         /* north */
         if (i==1) {
-          ierr = MatSetValue(A,ix-1,ix,2*pd,INSERT_VALUES);CHKERRQ(ierr);
+          PetscCall(MatSetValue(A,ix-1,ix,2*pd,INSERT_VALUES));
         } else {
-          ierr = MatSetValue(A,ix-1,ix,pd,INSERT_VALUES);CHKERRQ(ierr);
+          PetscCall(MatSetValue(A,ix-1,ix,pd,INSERT_VALUES));
         }
         /* east */
         if (j==1) {
-          ierr = MatSetValue(A,ix-1,ix+jmax-1,2*pd,INSERT_VALUES);CHKERRQ(ierr);
+          PetscCall(MatSetValue(A,ix-1,ix+jmax-1,2*pd,INSERT_VALUES));
         } else {
-          ierr = MatSetValue(A,ix-1,ix+jmax-1,pd,INSERT_VALUES);CHKERRQ(ierr);
+          PetscCall(MatSetValue(A,ix-1,ix+jmax-1,pd,INSERT_VALUES));
         }
       }
       /* south */
       pu = 0.5 - cst*(PetscReal)(i+j-3);
       if (j>1) {
-        ierr = MatSetValue(A,ix-1,ix-2,pu,INSERT_VALUES);CHKERRQ(ierr);
+        PetscCall(MatSetValue(A,ix-1,ix-2,pu,INSERT_VALUES));
       }
       /* west */
       if (i>1) {
-        ierr = MatSetValue(A,ix-1,ix-jmax-2,pu,INSERT_VALUES);CHKERRQ(ierr);
+        PetscCall(MatSetValue(A,ix-1,ix-jmax-2,pu,INSERT_VALUES));
       }
     }
   }
-  ierr = MatAssemblyBegin(A,MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
-  ierr = MatAssemblyEnd(A,MAT_FINAL_ASSEMBLY);CHKERRQ(ierr);
-  PetscFunctionReturn(0);
+  PetscCall(MatAssemblyBegin(A,MAT_FINAL_ASSEMBLY));
+  PetscCall(MatAssemblyEnd(A,MAT_FINAL_ASSEMBLY));
+  PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 /*
@@ -171,18 +168,17 @@ PetscErrorCode MatMarkovModel(PetscInt m,Mat A)
 */
 PetscErrorCode MyStoppingTest(EPS eps,PetscInt its,PetscInt max_it,PetscInt nconv,PetscInt nev,EPSConvergedReason *reason,void *ctx)
 {
-  PetscErrorCode ierr;
   PetscLogDouble now,deadline = *(PetscLogDouble*)ctx;
 
   PetscFunctionBeginUser;
   /* check if usual termination conditions are met */
-  ierr = EPSStoppingBasic(eps,its,max_it,nconv,nev,reason,NULL);CHKERRQ(ierr);
+  PetscCall(EPSStoppingBasic(eps,its,max_it,nconv,nev,reason,NULL));
   if (*reason==EPS_CONVERGED_ITERATING) {
     /* check if deadline has expired */
-    ierr = PetscTime(&now);CHKERRQ(ierr);
+    PetscCall(PetscTime(&now));
     if (now>deadline) *reason = EPS_CONVERGED_USER;
   }
-  PetscFunctionReturn(0);
+  PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 /*TEST

--- a/tests/libs/superlu/ohpc-tests/test_compiler_families
+++ b/tests/libs/superlu/ohpc-tests/test_compiler_families
@@ -11,10 +11,6 @@ cd libs/superlu || exit 1
 
 export BATS_JUNIT_CLASS=SUPERLU
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES; do
 
 	echo " "
@@ -28,6 +24,7 @@ for compiler in $COMPILER_FAMILIES; do
 	module load superlu || exit 1
 	module load prun || exit 1
 
+	./bootstrap || exit 1
 	./configure || exit 1
 	make clean || exit 1
 	make -k check || status=1

--- a/tests/libs/superlu_dist/ohpc-tests/test_mpi_families
+++ b/tests/libs/superlu_dist/ohpc-tests/test_mpi_families
@@ -11,10 +11,6 @@ source ./common/functions || exit 1
 cd libs/superlu_dist || exit 1
 export BATS_JUNIT_CLASS=superLU_dist
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
     for mpi in $MPI_FAMILIES ; do
 
@@ -37,6 +33,7 @@ for compiler in $COMPILER_FAMILIES ; do
 	
 	module load superlu_dist || exit 1
 
+	./bootstrap           || exit 1
 	./configure              || exit 1
 	make clean               || exit 1
 	make -k check            || status=1

--- a/tests/libs/trilinos/ohpc-tests/test_mpi_families
+++ b/tests/libs/trilinos/ohpc-tests/test_mpi_families
@@ -11,10 +11,6 @@ source ./common/functions || exit 1
 cd libs/trilinos || exit 1
 export BATS_JUNIT_CLASS=Trilinos
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
     if [ "$compiler" == "arm1" ]; then
 	continue
@@ -40,6 +36,7 @@ for compiler in $COMPILER_FAMILIES ; do
 	
 	module load trilinos  || exit 1
 
+	./bootstrap           || exit 1
 	./configure           || exit 1
 	make clean            || exit 1
 	make -k check         || status=1

--- a/tests/mpi/ohpc-tests/test_mpi_families
+++ b/tests/mpi/ohpc-tests/test_mpi_families
@@ -11,10 +11,6 @@ source ./common/functions || exit 1
 cd mpi || exit 1
 export BATS_JUNIT_CLASS=MPI
 
-# bootstrap the local autotools project
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
     for mpi in $MPI_FAMILIES ; do
 
@@ -29,6 +25,7 @@ for compiler in $COMPILER_FAMILIES ; do
 	module load $compiler || exit 1
 	module load $mpi      || exit 1
 
+	./bootstrap           || exit 1
 	./configure           || exit 1
 	make clean            || exit 1
 	make -k check         || status=1

--- a/tests/perf-tools/dimemas/ohpc-tests/test_mpi_families
+++ b/tests/perf-tools/dimemas/ohpc-tests/test_mpi_families
@@ -11,10 +11,6 @@ source ./common/functions || exit 1
 cd perf-tools/dimemas || exit 1
 export BATS_JUNIT_CLASS=Dimemas
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
     for mpi in $MPI_FAMILIES ; do
 
@@ -30,6 +26,7 @@ for compiler in $COMPILER_FAMILIES ; do
     module load $mpi      || exit 1
     module load dimemas   || exit 1
 
+    ./bootstrap           || exit 1
     ./configure           || exit 1
     make clean            || exit 1
     make -k check         || status=1

--- a/tests/perf-tools/dimemas/tests/test_module
+++ b/tests/perf-tools/dimemas/tests/test_module
@@ -8,40 +8,47 @@ if [ -s ./common/TEST_ENV ]; then
 	source ./common/TEST_ENV
 fi
 
-PKG=DIMEMAS
-export testname="Dimemas"
-module=dimemas
+setup_file() {
+	PKG=DIMEMAS
+	MODULE=dimemas
+	TESTNAME="perf-tools/Dimemas"
+
+	export PKG MODULE TESTNAME
+}
 
 setup() {
-	OUTPUT=$(mktemp)
+	OUTPUT="$(mktemp)"
+
+	export OUTPUT
 }
 
 teardown() {
 	rm -f "${OUTPUT}"
 }
 
-@test "[$testname] Verify $module module is loaded and matches rpm version ($LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
-	module list $module | grep "1) $module" >&"${OUTPUT}" || exit 1
-	run grep $module "${OUTPUT}"
+@test "[${TESTNAME}] Verify ${MODULE} module is loaded and matches rpm version (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	module list "${MODULE}" | grep "1) ${MODULE}" >&"${OUTPUT}" || exit 1
+	run grep "${MODULE}" "${OUTPUT}"
 	assert_success
 
 	# check version against rpm
 	local rpm
-	rpm=$(get_rpm_name ${module})
+	rpm=$(get_rpm_name "${MODULE}")
 	local version
-	version="$(rpm -q --queryformat='%{VERSION}\n' "$rpm")"
+	version="$(rpm -q --queryformat='%{VERSION}\n' "${rpm}")"
 	run cat "${OUTPUT}"
-	assert_output "  1) $module/$version"
+	assert_output "  1) ${MODULE}/${version}"
 }
 
-@test "[$testname] Verify module ${PKG}_DIR is defined and exists ($LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
-	DIR=${PKG}_DIR
-	if [ -z ${!DIR} ]; then
+@test "[${TESTNAME}] Verify ${PKG}_DIR is defined and exists (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	PKG_DIR="${PKG}_DIR"
+
+	if [ -z "${!PKG_DIR}" ]; then
 		flunk "${PKG}_DIR directory not defined"
 	fi
 
-	if [ ! -d ${!DIR} ] || [ -z "${!DIR}" ]; then
-		flunk "directory ${!DIR} does not exist"
+	if [ ! -d "${!PKG_DIR}" ]; then
+		flunk "directory ${!PKG_DIR} does not exist"
 	fi
 }
 
@@ -49,29 +56,30 @@ teardown() {
 # Binaries
 # ----------
 
-@test "[$testname] Verify module ${PKG}_BIN is defined and exists ($LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
-	BIN=${PKG}_BIN
-	if [ -z ${!BIN} ]; then
+@test "[${TESTNAME}] Verify ${PKG}_BIN is defined and exists (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	PKG_BIN="${PKG}_BIN"
+
+	if [ -z "${!PKG_BIN}" ]; then
 		flunk "${PKG}_BIN directory not defined"
 	fi
 
-	if [ ! -d ${!BIN} ] || [ -z "${!BIN}" ]; then
-		flunk "directory ${!BIN} does not exist"
+	if [ ! -d "${!PKG_BIN}" ]; then
+		flunk "directory ${!PKG_BIN} does not exist"
 	fi
 }
 
-@test "[$testname] Verify availability of prv2dim binary ($LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
-	run which prv2dim
+@test "[${TESTNAME}] Verify availability of prv2dim binary (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	run command -v prv2dim
 	assert_success
 }
 
-@test "[$testname] Verify availability of Dimemas binary ($LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
-	run which Dimemas
+@test "[${TESTNAME}] Verify availability of Dimemas binary (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	run command -v Dimemas
 	assert_success
 }
 
 # Run Dimemas
-@test "[$testname] Run Dimemas simulation ($LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
+@test "[${TESTNAME}] Run Dimemas simulation (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
 	rm -f prediction.prv ./*.dim ./*.pcf
 
 	# Convert Paraver trace file to Dimemas format

--- a/tests/perf-tools/extrae/ohpc-tests/test_mpi_families
+++ b/tests/perf-tools/extrae/ohpc-tests/test_mpi_families
@@ -11,10 +11,6 @@ source ./common/functions || exit 1
 cd perf-tools/extrae || exit 1
 export BATS_JUNIT_CLASS=Extrae
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
     for mpi in $MPI_FAMILIES ; do
 
@@ -30,6 +26,7 @@ for compiler in $COMPILER_FAMILIES ; do
     module load $mpi      || exit 1
     module load extrae    || exit 1
 
+    ./bootstrap           || exit 1
     ./configure           || exit 1
     make clean            || exit 1
     make -k check         || status=1

--- a/tests/perf-tools/extrae/tests/heat_mpi.c
+++ b/tests/perf-tools/extrae/tests/heat_mpi.c
@@ -1,20 +1,20 @@
-# include <stdlib.h>
-# include <stdio.h>
-# include <math.h>
-# include <time.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <time.h>
 
-# include "mpi.h"
+#include "mpi.h"
 
-int main ( int argc, char *argv[] );
-double boundary_condition ( double x, double time );
-double initial_condition ( double x, double time );
-double rhs ( double x, double time );
-void timestamp ( );
-void update ( int id, int p );
+int main(int argc, char *argv[]);
+double boundary_condition(double x, double time);
+double initial_condition(double x, double time);
+double rhs(double x, double time);
+void timestamp();
+void update(int id, int p);
 
 /******************************************************************************/
 
-int main ( int argc, char *argv[] )
+int main(int argc, char *argv[])
 
 /******************************************************************************/
 /*
@@ -54,62 +54,58 @@ int main ( int argc, char *argv[] )
      LC: QA76.642.M65.
 */
 {
-  int id;
-  int p;
-  double wtime;
+	int id;
+	int p;
+	double wtime;
 
-  MPI_Init ( &argc, &argv );
-  MPI_Comm_rank ( MPI_COMM_WORLD, &id );
-  MPI_Comm_size ( MPI_COMM_WORLD, &p );
+	MPI_Init(&argc, &argv);
+	MPI_Comm_rank(MPI_COMM_WORLD, &id);
+	MPI_Comm_size(MPI_COMM_WORLD, &p);
 
-  if ( id == 0 )
-  {
-    timestamp ( );
-    printf ( "\n" );
-    printf ( "HEAT_MPI:\n" );
-    printf ( "  C/MPI version\n" );
-    printf ( "  Solve the 1D time-dependent heat equation.\n" );
-  }
-/*
+	if (id == 0) {
+		timestamp();
+		printf("\n");
+		printf("HEAT_MPI:\n");
+		printf("  C/MPI version\n");
+		printf("  Solve the 1D time-dependent heat equation.\n");
+	}
+	/*
   Record the starting time.
 */
-  if ( id == 0 ) 
-  {
-    wtime = MPI_Wtime ( );
-  }
+	if (id == 0) {
+		wtime = MPI_Wtime();
+	}
 
-  update ( id, p );
-/*
+	update(id, p);
+	/*
   Record the final time.
 */
-  if ( id == 0 )
-  {
-    wtime = MPI_Wtime ( ) - wtime;
+	if (id == 0) {
+		wtime = MPI_Wtime() - wtime;
 
-    printf ( "\n");       
-    printf ( "  Wall clock elapsed seconds = %f\n", wtime );      
-  }
-/*
+		printf("\n");
+		printf("  Wall clock elapsed seconds = %f\n", wtime);
+	}
+	/*
   Terminate MPI.
 */
-  MPI_Finalize ( );
-/*
+	MPI_Finalize();
+	/*
   Terminate.
 */
-  if ( id == 0 )
-  {
-    printf ( "\n" );
-    printf ( "HEAT_MPI:\n" );
-    printf ( "  Normal end of execution.\n" );
-    printf ( "\n" );
-    timestamp ( );
-  }
+	if (id == 0) {
+		printf("\n");
+		printf("HEAT_MPI:\n");
+		printf("  Normal end of execution.\n");
+		printf("\n");
+		timestamp();
+	}
 
-  return 0;
+	return 0;
 }
 /******************************************************************************/
 
-void update ( int id, int p )
+void update(int id, int p)
 
 /******************************************************************************/
 /*
@@ -141,237 +137,221 @@ void update ( int id, int p )
     Input, int P, the number of processors.
 */
 {
-  double cfl;
+	double cfl;
 
-  double *h;
-  FILE *h_file;
-  double *h_new;
-  int i;
-  int j;
-  int j_min = 0;
-  int j_max = 400;
-  double k = 0.002;
-  int n = 11;
-  MPI_Status status;
-  int tag;
-  double time;
-  double time_delta;
-  double time_max = 10.0;
-  double time_min = 0.0;
-  double time_new;
-  double *x;
-  double x_delta;
-  FILE *x_file;
-  double x_max = 1.0;
-  double x_min = 0.0;
-/*
+	double *h;
+	FILE *h_file;
+	double *h_new;
+	int i;
+	int j;
+	int j_min = 0;
+	int j_max = 400;
+	double k = 0.002;
+	int n = 11;
+	MPI_Status status;
+	int tag;
+	double time;
+	double time_delta;
+	double time_max = 10.0;
+	double time_min = 0.0;
+	double time_new;
+	double *x;
+	double x_delta;
+	FILE *x_file;
+	double x_max = 1.0;
+	double x_min = 0.0;
+	/*
   Have process 0 print out some information.
 */
-  if ( id == 0 )
-  {
-    printf ( "\n" );
-    printf ( "  Compute an approximate solution to the time dependent\n" );
-    printf ( "  one dimensional heat equation:\n" );
-    printf ( "\n" );
-    printf ( "    dH/dt - K * d2H/dx2 = f(x,t)\n" );
-    printf ( "\n" );
-    printf ( "  for %f = x_min < x < x_max = %f\n", x_min, x_max );
-    printf ( "\n" );
-    printf ( "  and %f = time_min < t <= t_max = %f\n", time_min, time_max );
-    printf ( "\n" );
-    printf ( "  Boundary conditions are specified at x_min and x_max.\n" );
-    printf ( "  Initial conditions are specified at time_min.\n" );
-    printf ( "\n" );
-    printf ( "  The finite difference method is used to discretize the\n" );
-    printf ( "  differential equation.\n" );
-    printf ( "\n" );
-    printf ( "  This uses %d equally spaced points in X\n", p * n );
-    printf ( "  and %d equally spaced points in time.\n", j_max );
-    printf ( "\n" );
-    printf ( "  Parallel execution is done using %d processors.\n", p );
-    printf ( "  Domain decomposition is used.\n" );
-    printf ( "  Each processor works on %d nodes, \n", n );
-    printf ( "  and shares some information with its immediate neighbors.\n" );
-  }
-/*
+	if (id == 0) {
+		printf("\n");
+		printf("  Compute an approximate solution to the time dependent\n");
+		printf("  one dimensional heat equation:\n");
+		printf("\n");
+		printf("    dH/dt - K * d2H/dx2 = f(x,t)\n");
+		printf("\n");
+		printf("  for %f = x_min < x < x_max = %f\n", x_min, x_max);
+		printf("\n");
+		printf("  and %f = time_min < t <= t_max = %f\n", time_min,
+		       time_max);
+		printf("\n");
+		printf("  Boundary conditions are specified at x_min and x_max.\n");
+		printf("  Initial conditions are specified at time_min.\n");
+		printf("\n");
+		printf("  The finite difference method is used to discretize the\n");
+		printf("  differential equation.\n");
+		printf("\n");
+		printf("  This uses %d equally spaced points in X\n", p * n);
+		printf("  and %d equally spaced points in time.\n", j_max);
+		printf("\n");
+		printf("  Parallel execution is done using %d processors.\n",
+		       p);
+		printf("  Domain decomposition is used.\n");
+		printf("  Each processor works on %d nodes, \n", n);
+		printf("  and shares some information with its immediate neighbors.\n");
+	}
+	/*
   Set the X coordinates of the N nodes.
   We don't actually need ghost values of X but we'll throw them in
   as X[0] and X[N+1].
 */
-  x = ( double * ) malloc ( ( n + 2 ) * sizeof ( double ) );
+	x = (double *)malloc((n + 2) * sizeof(double));
 
-  for ( i = 0; i <= n + 1; i++ )
-  {
-    x[i] = ( ( double ) (         id * n + i - 1 ) * x_max
-           + ( double ) ( p * n - id * n - i     ) * x_min )
-           / ( double ) ( p * n              - 1 );
-  }
-/*
+	for (i = 0; i <= n + 1; i++) {
+		x[i] = ((double)(id * n + i - 1) * x_max +
+			(double)(p * n - id * n - i) * x_min) /
+		       (double)(p * n - 1);
+	}
+	/*
   In single processor mode, write out the X coordinates for display.
 */
-  if ( p == 1 )
-  {
-    x_file = fopen ( "x_data.txt", "w" );
-    for ( i = 1; i <= n; i++ )
-    {
-      fprintf ( x_file, "  %f", x[i] );
-    }
-    fprintf ( x_file, "\n" );
+	if (p == 1) {
+		x_file = fopen("x_data.txt", "w");
+		for (i = 1; i <= n; i++) {
+			fprintf(x_file, "  %f", x[i]);
+		}
+		fprintf(x_file, "\n");
 
-    fclose ( x_file );
-  }
-/*
+		fclose(x_file);
+	}
+	/*
   Set the values of H at the initial time.
 */
-  time = time_min;
-  h = ( double * ) malloc ( ( n + 2 ) * sizeof ( double ) );
-  h_new = ( double * ) malloc ( ( n + 2 ) * sizeof ( double ) );
-  h[0] = 0.0;
-  for ( i = 1; i <= n; i++ )
-  {
-    h[i] = initial_condition ( x[i], time );
-  }
-  h[n+1] = 0.0;
-  
-  time_delta = ( time_max - time_min ) / ( double ) ( j_max - j_min );
-  x_delta = ( x_max - x_min ) / ( double ) ( p * n - 1 );
-/*
+	time = time_min;
+	h = (double *)malloc((n + 2) * sizeof(double));
+	h_new = (double *)malloc((n + 2) * sizeof(double));
+	h[0] = 0.0;
+	for (i = 1; i <= n; i++) {
+		h[i] = initial_condition(x[i], time);
+	}
+	h[n + 1] = 0.0;
+
+	time_delta = (time_max - time_min) / (double)(j_max - j_min);
+	x_delta = (x_max - x_min) / (double)(p * n - 1);
+	/*
   Check the CFL condition, have processor 0 print out its value,
   and quit if it is too large.
 */
-  cfl = k * time_delta / x_delta / x_delta;
+	cfl = k * time_delta / x_delta / x_delta;
 
-  if ( id == 0 ) 
-  {
-    printf ( "\n" );
-    printf ( "UPDATE\n" );
-    printf ( "  CFL stability criterion value = %f\n", cfl );
-  }
+	if (id == 0) {
+		printf("\n");
+		printf("UPDATE\n");
+		printf("  CFL stability criterion value = %f\n", cfl);
+	}
 
-  if ( 0.5 <= cfl ) 
-  {
-    if ( id == 0 )
-    {
-      printf ( "\n" );
-      printf ( "UPDATE - Warning!\n" );
-      printf ( "  Computation cancelled!\n" );
-      printf ( "  CFL condition failed.\n" );
-      printf ( "  0.5 <= K * dT / dX / dX = %f\n", cfl );
-    }
-    return;
-  }
-/*
+	if (0.5 <= cfl) {
+		if (id == 0) {
+			printf("\n");
+			printf("UPDATE - Warning!\n");
+			printf("  Computation cancelled!\n");
+			printf("  CFL condition failed.\n");
+			printf("  0.5 <= K * dT / dX / dX = %f\n", cfl);
+		}
+		return;
+	}
+	/*
   In single processor mode, write out the values of H.
 */
-  if ( p == 1 )
-  {
-    h_file = fopen ( "h_data.txt", "w" );
+	if (p == 1) {
+		h_file = fopen("h_data.txt", "w");
 
-    for ( i = 1; i <= n; i++ )
-    {
-      fprintf ( h_file, "  %f", h[i] );
-    }
-    fprintf ( h_file, "\n" );
-  }
-/*
+		for (i = 1; i <= n; i++) {
+			fprintf(h_file, "  %f", h[i]);
+		}
+		fprintf(h_file, "\n");
+	}
+	/*
   Compute the values of H at the next time, based on current data.
 */
-  for ( j = 1; j <= j_max; j++ )
-  {
-
-    time_new = ( ( double ) (         j - j_min ) * time_max
-               + ( double ) ( j_max - j         ) * time_min )
-               / ( double ) ( j_max     - j_min );
-/*
+	for (j = 1; j <= j_max; j++) {
+		time_new = ((double)(j - j_min) * time_max +
+			    (double)(j_max - j) * time_min) /
+			   (double)(j_max - j_min);
+		/*
   Send H[1] to ID-1.
 */
-    if ( 0 < id )
-    {
-      tag = 1;
-      MPI_Send ( &h[1], 1, MPI_DOUBLE, id-1, tag, MPI_COMM_WORLD );
-    }
-/*
+		if (0 < id) {
+			tag = 1;
+			MPI_Send(&h[1], 1, MPI_DOUBLE, id - 1, tag,
+				 MPI_COMM_WORLD);
+		}
+		/*
   Receive H[N+1] from ID+1.
 */
-    if ( id < p-1 )
-    {
-      tag = 1;
-      MPI_Recv ( &h[n+1], 1,  MPI_DOUBLE, id+1, tag, MPI_COMM_WORLD, &status );
-    }
-/*
+		if (id < p - 1) {
+			tag = 1;
+			MPI_Recv(&h[n + 1], 1, MPI_DOUBLE, id + 1, tag,
+				 MPI_COMM_WORLD, &status);
+		}
+		/*
   Send H[N] to ID+1.
 */
-    if ( id < p-1 )
-    {
-      tag = 2;
-      MPI_Send ( &h[n], 1, MPI_DOUBLE, id+1, tag, MPI_COMM_WORLD );
-    }
-/*
+		if (id < p - 1) {
+			tag = 2;
+			MPI_Send(&h[n], 1, MPI_DOUBLE, id + 1, tag,
+				 MPI_COMM_WORLD);
+		}
+		/*
   Receive H[0] from ID-1.
 */
-    if ( 0 < id )
-    {
-      tag = 2;
-      MPI_Recv ( &h[0], 1, MPI_DOUBLE, id-1, tag, MPI_COMM_WORLD, &status );
-    }
-/*
+		if (0 < id) {
+			tag = 2;
+			MPI_Recv(&h[0], 1, MPI_DOUBLE, id - 1, tag,
+				 MPI_COMM_WORLD, &status);
+		}
+		/*
   Update the temperature based on the four point stencil.
 */
-    for ( i = 1; i <= n; i++ )
-    {
-      h_new[i] = h[i] 
-      + ( time_delta * k / x_delta / x_delta ) * ( h[i-1] - 2.0 * h[i] + h[i+1] ) 
-      + time_delta * rhs ( x[i], time );
-    }
-/*
+		for (i = 1; i <= n; i++) {
+			h_new[i] = h[i] +
+				   (time_delta * k / x_delta / x_delta) *
+					   (h[i - 1] - 2.0 * h[i] + h[i + 1]) +
+				   time_delta * rhs(x[i], time);
+		}
+		/*
   H at the extreme left and right boundaries was incorrectly computed
   using the differential equation.  Replace that calculation by
   the boundary conditions.
 */
-    if ( 0 == id )
-    {
-      h_new[1] = boundary_condition ( x[1], time_new );
-    }
-    if ( id == p - 1 )
-    {
-      h_new[n] = boundary_condition ( x[n], time_new );
-    }
-/*
+		if (0 == id) {
+			h_new[1] = boundary_condition(x[1], time_new);
+		}
+		if (id == p - 1) {
+			h_new[n] = boundary_condition(x[n], time_new);
+		}
+		/*
   Update time and temperature.
 */
-    time = time_new;
+		time = time_new;
 
-    for ( i = 1; i <= n; i++ )
-    {
-      h[i] = h_new[i];
-    }
-/*
+		for (i = 1; i <= n; i++) {
+			h[i] = h_new[i];
+		}
+		/*
   In single processor mode, add current solution data to output file.
 */
-    if ( p == 1 )
-    {
-      for ( i = 1; i <= n; i++ )
-      {
-        fprintf ( h_file, "  %f", h[i] );
-      }
-      fprintf ( h_file, "\n" );
-    }
-  }
+		if (p == 1) {
+			for (i = 1; i <= n; i++) {
+				fprintf(h_file, "  %f", h[i]);
+			}
+			fprintf(h_file, "\n");
+		}
+	}
 
-  if ( p == 1 )
-  {
-    fclose ( h_file );
-  }
+	if (p == 1) {
+		fclose(h_file);
+	}
 
-  free ( h );
-  free ( h_new );
-  free ( x );
+	free(h);
+	free(h_new);
+	free(x);
 
-  return;
+	return;
 }
 /******************************************************************************/
 
-double boundary_condition ( double x, double time )
+double boundary_condition(double x, double time)
 
 /******************************************************************************/
 /*
@@ -398,24 +378,21 @@ double boundary_condition ( double x, double time )
     Output, double BOUNDARY_CONDITION, the value of the boundary condition.
 */
 {
-  double value;
-/*
+	double value;
+	/*
   Left condition:
 */
-  if ( x < 0.5 )
-  {
-    value = 100.0 + 10.0 * sin ( time );
-  }
-  else
-  {
-    value = 75.0;
-  }
+	if (x < 0.5) {
+		value = 100.0 + 10.0 * sin(time);
+	} else {
+		value = 75.0;
+	}
 
-  return value;
+	return value;
 }
 /******************************************************************************/
 
-double initial_condition ( double x, double time )
+double initial_condition(double x, double time)
 
 /******************************************************************************/
 /*
@@ -442,15 +419,15 @@ double initial_condition ( double x, double time )
     Output, double INITIAL_CONDITION, the value of the initial condition.
 */
 {
-  double value;
+	double value;
 
-  value = 95.0;
+	value = 95.0;
 
-  return value;
+	return value;
 }
 /******************************************************************************/
 
-double rhs ( double x, double time )
+double rhs(double x, double time)
 
 /******************************************************************************/
 /*
@@ -477,15 +454,15 @@ double rhs ( double x, double time )
     Output, double RHS, the value of the right hand side function.
 */
 {
-  double value;
+	double value;
 
-  value = 0.0;
+	value = 0.0;
 
-  return value;
+	return value;
 }
 /******************************************************************************/
 
-void timestamp ( )
+void timestamp()
 
 /******************************************************************************/
 /*
@@ -514,19 +491,19 @@ void timestamp ( )
     None
 */
 {
-# define TIME_SIZE 40
+#define TIME_SIZE 40
 
-  static char time_buffer[TIME_SIZE];
-  const struct tm *tm;
-  time_t now;
+	static char time_buffer[TIME_SIZE];
+	const struct tm *tm;
+	time_t now;
 
-  now = time ( NULL );
-  tm = localtime ( &now );
+	now = time(NULL);
+	tm = localtime(&now);
 
-  strftime ( time_buffer, TIME_SIZE, "%d %B %Y %I:%M:%S %p", tm );
+	strftime(time_buffer, TIME_SIZE, "%d %B %Y %I:%M:%S %p", tm);
 
-  printf ( "%s\n", time_buffer );
+	printf("%s\n", time_buffer);
 
-  return;
-# undef TIME_SIZE
+	return;
+#undef TIME_SIZE
 }

--- a/tests/perf-tools/extrae/tests/rm_execution
+++ b/tests/perf-tools/extrae/tests/rm_execution
@@ -4,91 +4,90 @@
 load ./common/test_helper_functions || exit 1
 source ./common/functions || exit 1
 
-if [ -s ./common/TEST_ENV ];then
-    source ./common/TEST_ENV
+if [ -s ./common/TEST_ENV ]; then
+	source ./common/TEST_ENV
 fi
 
-check_rms
-rm=$RESOURCE_MANAGER
+setup_file() {
+	TESTNAME="perf-tools/Extrae"
+	NODES=2
+	TASKS=$(tasks_count 8)
+	ARGS=8
+	TIMEOUT="00:10:00"
 
-NODES=2
-TASKS=`tasks_count 8`
-ARGS=8
+	check_rms
+	unset OMP_NUM_THREADS
 
-unset OMP_NUM_THREADS
+	mkdir -p .tmp.extrae
+	MPI2PRV_TMP_DIR=.tmp.extrae
 
-
-@test "[Extrae] MPI C trace under resource manager ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
-    [ "${LMOD_FAMILY_COMPILER}" == "acfl" ] && skip "Test segfaults with acfl compiler"
-    if [ ! -s heat_mpi ];then
-	flunk "heat_mpi binary does not exist"
-    fi
-
-    rm -f TRACE.mpits
-    rm -f heat_mpi.prv
-    rm -rf set-0
-    mkdir set-0
-
-    mkdir -p .tmp.extrae
-    export MPI2PRV_TMP_DIR=.tmp.extrae
-
-    # Extrae's LD_PRELOAD interception can cause a spurious MPI_Abort
-    # during finalization with OpenMPI 5.x, making mpirun exit non-zero
-    # even though tracing succeeded.  Tolerate the exit code and validate
-    # the actual trace output below.
-    run_mpi_binary "./tracec.sh ./heat_mpi" "" $NODES $TASKS || true
-
-    # allow for some job output lag from pbs
-    for i in `seq 1 10`; do
-	if [ -s TRACE.mpits ];then
-	    break
-	else
-	    sleep 0.2
-	fi
-    done
-
-    run mpi2prv -f TRACE.mpits
-
-    run ls heat_mpi.prv
-    assert_success
-
+	export TESTNAME NODES TASKS ARGS TIMEOUT MPI2PRV_TMP_DIR
 }
 
-@test "[Extrae] Parallel trace merge runs under resource manager ($rm/$LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
+@test "[${TESTNAME}] MPI C trace under resource manager (${RESOURCE_MANAGER}/${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	[ "${LMOD_FAMILY_COMPILER}" == "acfl" ] && skip "Test segfaults with acfl compiler"
 
-    [ "${LMOD_FAMILY_COMPILER}" == "acfl" ] && skip "Test segfaults with acfl compiler"
-    run ls TRACE.mpits
-    assert_success
-
-    rm -f job.out
-
-    mkdir -p .tmp.extrae
-    export MPI2PRV_TMP_DIR=.tmp.extrae
-
-    run_mpi_binary -o "job.out" "mpimpi2prv -syn -f TRACE.mpits -o trace.prv" "" $NODES $TASKS
-    assert_success
-
-    run ls trace.prv
-    assert_success
-
-    # allow for some job output lag from pbs
-    for i in `seq 1 10`; do
-	if [ -s job.out ];then
-	    break
-	else
-	    sleep 0.2
+	if [ ! -s heat_mpi ]; then
+		flunk "heat_mpi binary does not exist"
 	fi
-    done
 
-    run ls job.out
-    assert_success
+	rm -f TRACE.mpits
+	rm -f heat_mpi.prv
+	rm -rf set-0
+	mkdir set-0
 
-    run tail -1 job.out
-    assert_output "mpi2prv: Congratulations! trace.prv has been generated."
+	# Extrae's LD_PRELOAD interception can cause a spurious MPI_Abort
+	# during finalization with OpenMPI 5.x, making mpirun exit non-zero
+	# even though tracing succeeded.  Tolerate the exit code and validate
+	# the actual trace output below.
+	run_mpi_binary -t "${TIMEOUT}" "./tracec.sh ./heat_mpi" "" "${NODES}" "${TASKS}" || true
 
-    rm -rf profile*
-    rm -f pingtmp?
-    rm -rf *prv *row *pcf TRACE.*
-    rm -rf $MPI2PRV_TMP_DIR
-#    rm -rf set-0
+	# allow for some job output lag from pbs
+	for _ in $(seq 1 10); do
+		if [ -s TRACE.mpits ]; then
+			break
+		else
+			sleep 0.2
+		fi
+	done
+
+	run mpi2prv -f TRACE.mpits
+
+	run ls heat_mpi.prv
+	assert_success
+}
+
+@test "[${TESTNAME}] Parallel trace merge runs under resource manager (${RESOURCE_MANAGER}/${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	[ "${LMOD_FAMILY_COMPILER}" == "acfl" ] && skip "Test segfaults with acfl compiler"
+
+	run ls TRACE.mpits
+	assert_success
+
+	rm -f job.out
+
+	run_mpi_binary -t "${TIMEOUT}" -o "job.out" "mpimpi2prv -syn -f TRACE.mpits -o trace.prv" "" "${NODES}" "${TASKS}"
+	assert_success
+
+	run ls trace.prv
+	assert_success
+
+	# allow for some job output lag from pbs
+	for _ in $(seq 1 10); do
+		if [ -s job.out ]; then
+			break
+		else
+			sleep 0.2
+		fi
+	done
+
+	run ls job.out
+	assert_success
+
+	run tail -1 job.out
+	assert_output "mpi2prv: Congratulations! trace.prv has been generated."
+
+	rm -rf profile*
+	rm -f pingtmp?
+	rm -rf ./*prv ./*row ./*pcf TRACE.*
+	rm -rf "${MPI2PRV_TMP_DIR}"
 }

--- a/tests/perf-tools/extrae/tests/test_module
+++ b/tests/perf-tools/extrae/tests/test_module
@@ -8,41 +8,48 @@ if [ -s ./common/TEST_ENV ]; then
 	source ./common/TEST_ENV
 fi
 
-PKG=EXTRAE
-export testname="Extrae"
-module=extrae
-library=libmpitrace
+setup_file() {
+	PKG=EXTRAE
+	MODULE=extrae
+	TESTNAME="perf-tools/Extrae"
+	LIBRARY=libmpitrace
+
+	export PKG MODULE TESTNAME LIBRARY
+}
 
 setup() {
-	OUTPUT=$(mktemp)
+	OUTPUT="$(mktemp)"
+
+	export OUTPUT
 }
 
 teardown() {
 	rm -f "${OUTPUT}"
 }
 
-@test "[$testname] Verify $module module is loaded and matches rpm version ($LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
-	module list $module | grep "1) $module" >&"${OUTPUT}" || exit 1
-	run grep $module "${OUTPUT}"
+@test "[${TESTNAME}] Verify ${MODULE} module is loaded and matches rpm version (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	module list "${MODULE}" | grep "1) ${MODULE}" >&"${OUTPUT}" || exit 1
+	run grep "${MODULE}" "${OUTPUT}"
 	assert_success
 
 	# check version against rpm
 	local rpm
-	rpm=$(get_rpm_name ${module})
+	rpm=$(get_rpm_name "${MODULE}")
 	local version
-	version="$(rpm -q --queryformat='%{VERSION}\n' "$rpm")"
+	version="$(rpm -q --queryformat='%{VERSION}\n' "${rpm}")"
 	run cat "${OUTPUT}"
-	assert_output "  1) $module/$version"
+	assert_output "  1) ${MODULE}/${version}"
 }
 
-@test "[$testname] Verify module ${PKG}_DIR is defined and exists ($LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
-	DIR=${PKG}_DIR
-	if [ -z ${!DIR} ]; then
+@test "[${TESTNAME}] Verify ${PKG}_DIR is defined and exists (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	PKG_DIR="${PKG}_DIR"
+
+	if [ -z "${!PKG_DIR}" ]; then
 		flunk "${PKG}_DIR directory not defined"
 	fi
 
-	if [ ! -d ${!DIR} ] || [ -z "${!DIR}" ]; then
-		flunk "directory ${!DIR} does not exist"
+	if [ ! -d "${!PKG_DIR}" ]; then
+		flunk "directory ${!PKG_DIR} does not exist"
 	fi
 }
 
@@ -50,24 +57,25 @@ teardown() {
 # Binaries
 # ----------
 
-@test "[$testname] Verify module ${PKG}_BIN is defined and exists ($LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
-	BIN=${PKG}_BIN
-	if [ -z ${!BIN} ]; then
+@test "[${TESTNAME}] Verify ${PKG}_BIN is defined and exists (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	PKG_BIN="${PKG}_BIN"
+
+	if [ -z "${!PKG_BIN}" ]; then
 		flunk "${PKG}_BIN directory not defined"
 	fi
 
-	if [ ! -d ${!BIN} ] || [ -z "${!BIN}" ]; then
-		flunk "directory ${!BIN} does not exist"
+	if [ ! -d "${!PKG_BIN}" ]; then
+		flunk "directory ${!PKG_BIN} does not exist"
 	fi
 }
 
-@test "[$testname] Verify availability of mpi2prv binary ($LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
-	run which mpi2prv
+@test "[${TESTNAME}] Verify availability of mpi2prv binary (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	run command -v mpi2prv
 	assert_success
 }
 
-@test "[$testname] Verify availability of extrae-cmd binary ($LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
-	run which extrae-cmd
+@test "[${TESTNAME}] Verify availability of extrae-cmd binary (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	run command -v extrae-cmd
 	assert_success
 }
 
@@ -75,26 +83,26 @@ teardown() {
 # Lib Tests
 # ----------
 
-@test "[$testname] Verify module ${PKG}_LIB is defined and exists ($LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
-	LIB=${PKG}_LIB
+@test "[${TESTNAME}] Verify ${PKG}_LIB is defined and exists (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	LIB="${PKG}_LIB"
 
-	if [ -z ${!LIB} ]; then
+	if [ -z "${!LIB}" ]; then
 		flunk "${PKG}_LIB directory not defined"
 	fi
 
-	if [ ! -d ${!LIB} ]; then
+	if [ ! -d "${!LIB}" ]; then
 		flunk "directory ${!LIB} does not exist"
 	fi
 }
 
-@test "[$testname] Verify dynamic library available in ${PKG}_LIB ($LMOD_FAMILY_COMPILER/$LMOD_FAMILY_MPI)" {
-	LIB=${PKG}_LIB
+@test "[${TESTNAME}] Verify dynamic library available in ${PKG}_LIB (${LMOD_FAMILY_COMPILER}/${LMOD_FAMILY_MPI})" {
+	LIB="${PKG}_LIB"
 
-	if [ -z ${!LIB} ]; then
+	if [ -z "${!LIB}" ]; then
 		flunk "${PKG}_LIB directory not defined"
 	fi
 
-	if [ ! -s ${!LIB}/${library}.so ]; then
-		flunk "${library}.so does not exist"
+	if [ ! -s "${!LIB}/${LIBRARY}.so" ]; then
+		flunk "${LIBRARY}.so does not exist"
 	fi
 }

--- a/tests/perf-tools/extrae/tests/tracec.sh
+++ b/tests/perf-tools/extrae/tests/tracec.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
 
-source ${EXTRAE_DIR}/etc/extrae.sh
+source "${EXTRAE_DIR}/etc/extrae.sh"
 
-arch=`uname -m`
+arch=$(uname -m)
 
-if [ "$arch" == "aarch64" ] || [ -n "$SIMPLE_CI" ];then
-    export EXTRAE_CONFIG_FILE=./extrae-nopapi.xml
+if [ "${arch}" == "aarch64" ] || [ -n "${SIMPLE_CI}" ]; then
+	export EXTRAE_CONFIG_FILE=./extrae-nopapi.xml
 else
-    export EXTRAE_CONFIG_FILE=./extrae.xml
+	export EXTRAE_CONFIG_FILE=./extrae.xml
 fi
 
-export LD_PRELOAD=${EXTRAE_HOME}/lib/libmpitrace.so
+export LD_PRELOAD="${EXTRAE_HOME}/lib/libmpitrace.so"
 
 # Run the desired program
-$*
-
+"$@"

--- a/tests/perf-tools/extrae/tests/tracef.sh
+++ b/tests/perf-tools/extrae/tests/tracef.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
 
-source ${EXTRAE_DIR}/etc/extrae.sh
+source "${EXTRAE_DIR}/etc/extrae.sh"
 
-arch=`uname -m`
+arch=$(uname -m)
 
-if [ "$arch" == "aarch64" ];then
-    export EXTRAE_CONFIG_FILE=./extrae-nopapi.xml
+if [ "${arch}" == "aarch64" ] || [ -n "${SIMPLE_CI}" ]; then
+	export EXTRAE_CONFIG_FILE=./extrae-nopapi.xml
 else
-    export EXTRAE_CONFIG_FILE=./extrae.xml
+	export EXTRAE_CONFIG_FILE=./extrae.xml
 fi
 
-export LD_PRELOAD=${EXTRAE_HOME}/lib/libmpitracef.so
+export LD_PRELOAD="${EXTRAE_HOME}/lib/libmpitracef.so"
 
 # Run the desired program
-$*
-
+"$@"

--- a/tests/perf-tools/geopm/ohpc-tests/test_mpi_families
+++ b/tests/perf-tools/geopm/ohpc-tests/test_mpi_families
@@ -29,10 +29,6 @@ export -f srun
 cd perf-tools/geopm || exit 1
 
 export BATS_JUNIT_CLASS=GEOPM
-
-# bootstrap the local autotools project if necessary
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
 	for mpi in $MPI_FAMILIES ; do
 		echo " "
@@ -51,6 +47,7 @@ for compiler in $COMPILER_FAMILIES ; do
 		GEOPM_MPIRUN=$(which mpirun || echo 'false')
 		GEOPM_SRUN=$(which srun || echo 'false')
 
+		./bootstrap           || exit 1
 		./configure           || exit 1
 		make clean            || exit 1
 		make -k check         || status=1

--- a/tests/perf-tools/imb/ohpc-tests/test_mpi_families
+++ b/tests/perf-tools/imb/ohpc-tests/test_mpi_families
@@ -12,10 +12,6 @@ cd perf-tools/imb               || exit 1
 
 export BATS_JUNIT_CLASS=IMB
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
     for mpi in $MPI_FAMILIES ; do
 
@@ -31,6 +27,7 @@ for compiler in $COMPILER_FAMILIES ; do
 	module load $mpi      || exit 1
 	module load imb       || exit 1
 
+	./bootstrap           || exit 1
 	./configure           || exit 1
 	make clean            || exit 1
 	make -k check         || status=1

--- a/tests/perf-tools/likwid/ohpc-tests/test_compiler_families
+++ b/tests/perf-tools/likwid/ohpc-tests/test_compiler_families
@@ -11,10 +11,6 @@ source ./common/functions || exit 1
 cd perf-tools/likwid || exit 1
 export BATS_JUNIT_CLASS=LIKWID
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
 
     echo " "
@@ -27,6 +23,7 @@ for compiler in $COMPILER_FAMILIES ; do
     module load $compiler       || exit 1
     module load likwid          || exit 1
 
+    ./bootstrap           || exit 1
     ./configure                 || exit 1
     make clean                  || exit 1
     make -k check               || status=1

--- a/tests/perf-tools/omb/ohpc-tests/test_mpi_families
+++ b/tests/perf-tools/omb/ohpc-tests/test_mpi_families
@@ -11,10 +11,6 @@ cd perf-tools/omb || exit 1
 
 export BATS_JUNIT_CLASS=omb
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for COMPILER in $COMPILER_FAMILIES; do
 	for MPI in $MPI_FAMILIES; do
 
@@ -30,6 +26,7 @@ for COMPILER in $COMPILER_FAMILIES; do
 		module load "${MPI}" || exit 1
 		module load omb || exit 1
 
+		./bootstrap || exit 1
 		./configure || exit 1
 		make clean || exit 1
 		make -k check || status=1

--- a/tests/perf-tools/papi/ohpc-tests/test_compiler_families
+++ b/tests/perf-tools/papi/ohpc-tests/test_compiler_families
@@ -11,10 +11,6 @@ cd perf-tools/papi || exit 1
 
 export BATS_JUNIT_CLASS=PAPI
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in ${COMPILER_FAMILIES}; do
 
 	echo " "
@@ -27,6 +23,7 @@ for compiler in ${COMPILER_FAMILIES}; do
 	module load "${compiler}" || exit 1
 	module load papi || exit 1
 
+	./bootstrap || exit 1
 	./configure || exit 1
 	make clean || exit 1
 	make -k check || status=1

--- a/tests/perf-tools/scalasca/ohpc-tests/test_mpi_families
+++ b/tests/perf-tools/scalasca/ohpc-tests/test_mpi_families
@@ -12,10 +12,6 @@ cd perf-tools/scalasca || exit 1
 export BATS_JUNIT_CLASS=Scalasca
 export SCAN_MPI_LAUNCHER=prun
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
     if [ "$compiler" == "arm1" ]; then
 	continue
@@ -34,6 +30,7 @@ for compiler in $COMPILER_FAMILIES ; do
 	module load $mpi      || exit 1
 	module load scalasca  || exit 1
 
+	./bootstrap           || exit 1
 	./configure           || exit 1
 	make clean            || exit 1
 	make -k check         || status=1

--- a/tests/perf-tools/scorep/ohpc-tests/test_mpi_families
+++ b/tests/perf-tools/scorep/ohpc-tests/test_mpi_families
@@ -12,9 +12,6 @@ cd perf-tools/scorep || exit 1
 export BATS_JUNIT_CLASS=Score-P
 export SCAN_MPI_LAUNCHER=prun
 
-# bootstrap the local autotools project if necessary
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
     if [ "$compiler" == "arm1" ]; then
 	continue
@@ -33,6 +30,7 @@ for compiler in $COMPILER_FAMILIES ; do
 	module load $mpi      || exit 1
 	module load scorep    || exit 1
 
+	./bootstrap           || exit 1
 	./configure           || exit 1
 	make clean            || exit 1
 	make -k check         || status=1

--- a/tests/perf-tools/tau/ohpc-tests/test_mpi_families
+++ b/tests/perf-tools/tau/ohpc-tests/test_mpi_families
@@ -11,10 +11,6 @@ source ./common/functions || exit 1
 cd perf-tools/tau || exit 1
 export BATS_JUNIT_CLASS=TAU
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
     if [ "$compiler" == "arm1" ]; then
 	continue
@@ -33,6 +29,7 @@ for compiler in $COMPILER_FAMILIES ; do
 	module load $mpi      || exit 1
 	module load tau       || exit 1
 
+	./bootstrap           || exit 1
 	./configure           || exit 1
 	make clean            || exit 1
 	make -k check         || status=1

--- a/tests/rms-harness/ohpc-tests/test_mpi_families
+++ b/tests/rms-harness/ohpc-tests/test_mpi_families
@@ -11,10 +11,6 @@ cd rms-harness || exit 1
 
 export BATS_JUNIT_CLASS=rms-harness
 
-# bootstrap the local autotools project
-
-./bootstrap || exit 1
-
 for compiler in ${COMPILER_FAMILIES}; do
 	for mpi in ${MPI_FAMILIES}; do
 
@@ -29,6 +25,7 @@ for compiler in ${COMPILER_FAMILIES}; do
 		module load "${compiler}" || exit 1
 		module load "${mpi}" || exit 1
 
+		./bootstrap || exit 1
 		./configure || exit 1
 		make -k check || status=1
 

--- a/tests/user-env-oom/ohpc-tests/test_compiler_families
+++ b/tests/user-env-oom/ohpc-tests/test_compiler_families
@@ -8,10 +8,6 @@ status=0
 source ./common/TEST_ENV || exit 1
 cd user-env-oom          || exit 1
 
-# bootstrap the local autotools project if necessary
-
-./bootstrap || exit 1
-
 for compiler in $COMPILER_FAMILIES ; do
 
     echo " "
@@ -24,6 +20,7 @@ for compiler in $COMPILER_FAMILIES ; do
     module load $compiler       || exit 1
     module load metis           || exit 1
 
+    ./bootstrap           || exit 1
     ./configure                 || exit 1
     make clean                  || exit 1
     make -k check               || status=1


### PR DESCRIPTION
Apply BEST_PRACTICES.md conventions to extrae and dimemas test suites:

- add setup_file() for one-time initialization (TESTNAME, NODES, TASKS, TIMEOUT, check_rms)
- add setup()/teardown() with exported OUTPUT tempfile
- replace backticks with $(...) command substitution
- replace 'which' with 'command -v'
- quote all variables with curly braces: "${VARIABLE}"
- use "${RESOURCE_MANAGER}" instead of local $rm alias
- add -t "${TIMEOUT}" to run_mpi_binary calls
- use "$@" instead of $*  in tracec.sh and tracef.sh
- add SIMPLE_CI check to tracef.sh for nopapi config
- tolerate Extrae MPI finalization abort with OpenMPI 5.x
- apply clang-format to heat_mpi.c
- add extrae rm_execution, tracec.sh, tracef.sh, and heat_mpi.c to CI lint targets

Generated with Claude Code (https://claude.ai/code)

[TESTS:ALL]