### PR TITLE
io-libs: enable zlib support in hdf5 cmake build

### DIFF
--- a/components/io-libs/hdf5/SPECS/hdf5.spec
+++ b/components/io-libs/hdf5/SPECS/hdf5.spec
@@ -78,6 +78,7 @@ cmake -DCMAKE_INSTALL_PREFIX=%{install_path} \
       -DBUILD_SHARED_LIBS=ON                 \
       -DBUILD_STATIC_LIBS=OFF                \
       -DHDF5_BUILD_FORTRAN=ON                \
+      -DHDF5_ENABLE_Z_LIB_SUPPORT=ON         \
 %if "%{?OHPC_USE_CCACHE}" == "yes"
       -DCMAKE_C_COMPILER_LAUNCHER=ccache     \
       -DCMAKE_CXX_COMPILER_LAUNCHER=ccache   \


### PR DESCRIPTION
HDF5 2.0.0 switched from autotools to cmake. The cmake build does not enable zlib by default, unlike the old autotools build. This causes netcdf to fail with "HDF5 was not built with zlib".

Generated with Claude Code (https://claude.ai/code)