### PR TITLE
Add proxy and node reset placeholder markers

### DIFF
--- a/docs/install/DESIGN.md
+++ b/docs/install/DESIGN.md
@@ -303,6 +303,187 @@ shell conditionals evaluated at install time (controlled by `input.local`
 variables). Jinja2 `{% if ... %}` controls what appears in the document
 at build time (controlled by recipe YAML flags). Use both as appropriate.
 
+### Site Pre-processing Placeholders
+
+Some configuration is too site-specific or environment-specific to be encoded
+in the generic recipe templates. For these, `ohpc_command` markers emit
+**placeholder lines** that a site's pre-processing step expands before running
+the script. Placeholders always appear in the generated `recipe.sh` regardless
+of the install environment — they are valid shell comments when left unexpanded.
+
+The placeholder convention:
+
+```bash
+#<<< ohpc_type:SUBTYPE >>>#
+```
+
+The `#` delimiters make the line a no-op shell comment. The `<<<`/`>>>` delimiters
+are distinct enough to grep reliably without false positives. The `SUBTYPE` field
+allows a pre-processor to distinguish contexts within the same type.
+
+#### Proxy Placeholders
+
+Proxy and mirror configuration is the primary user of this mechanism. Proxy
+setup is site-specific because:
+
+- CA certificate paths and trust store locations differ by OS and site policy
+- Repo file names and whether to use metalink, mirrorlist, or baseurl vary
+- Some environments use different proxies for different resource types
+- A local container registry (e.g., OpenCHAMI's `${sms_name}:5000`) must bypass
+  the proxy via `NO_PROXY`, requiring knowledge of site-specific addresses
+
+Three proxy placeholder types appear in each recipe, each once, in script order:
+
+| Placeholder | Location | Context |
+| --- | --- | --- |
+| `#<<< ohpc_proxy:head >>>#` | Near top, before first `dnf` | Head node setup (CA cert, dnf.conf, profile.d) |
+| `#<<< ohpc_proxy:compute >>>#` | Compute image/node setup | Warewulf chroot or Confluent nodeshell commands |
+| `#<<< ohpc_proxy:image >>>#` | OpenCHAMI image build only | Image-builder config (local registry must bypass proxy) |
+
+**Finding placeholders in a generated script:**
+
+```bash
+grep -n '^#<<< ohpc_proxy:' recipe.sh
+```
+
+**Example Python pre-processor:**
+
+```python
+import re, sys
+
+PROXY_SETUP = {
+    "head": """\
+cp /path/to/proxy-ca-cert.pem /etc/pki/ca-trust/source/anchors/proxy-ca-cert.pem
+update-ca-trust
+echo "proxy=http://proxy.site.example:3128" >> /etc/dnf/dnf.conf
+printf 'export HTTPS_PROXY=http://proxy.site.example:3128\\n' \\
+    > /etc/profile.d/proxy.sh
+printf 'export NO_PROXY=${sms_name},localhost,127.0.0.1\\n' \\
+    >> /etc/profile.d/proxy.sh
+source /etc/profile.d/proxy.sh
+""",
+    "compute": """\
+nodeshell compute "cp /var/lib/confluent/.../proxy-ca-cert.pem ..."
+nodeshell compute "update-ca-trust"
+nodeshell compute "echo proxy=http://proxy.site.example:3128 >> /etc/dnf/dnf.conf"
+""",
+    "image": """\
+export HTTPS_PROXY=http://proxy.site.example:3128
+export NO_PROXY=${sms_name}:5000,localhost
+""",
+}
+
+script = open("recipe.sh").read()
+for subtype, commands in PROXY_SETUP.items():
+    placeholder = f"#<<< ohpc_proxy:{subtype} >>>#"
+    script = script.replace(placeholder, commands.rstrip())
+open("recipe.sh", "w").write(script)
+```
+
+Leave a placeholder line unchanged (or replace it with an empty string) for
+environments that do not require that type of proxy setup. A site with a proxy
+only on the head node would expand `head` and leave `compute` and `image` as
+no-op comments.
+
+**Template source locations for proxy placeholders:**
+
+- `templates/base-os/proxy.md.j2` — `head` placeholder
+- `templates/provisioner/warewulf/compute-create-image.md.j2` — `compute` placeholder
+- `templates/provisioner/confluent/compute-setup.md.j2` — `compute` placeholder
+- `templates/provisioner/openchami/compute-image-build.md.j2` — `image` placeholder
+
+#### Node Reset Placeholders
+
+In environments without IPMI (e.g., VMs on a hypervisor), compute nodes cannot
+be reset via `ipmitool`. The `has_ipmi` flag in `input.local` selects between
+the two paths in `boot-computes.md.j2`:
+
+- `has_ipmi=1` — uses `ipmitool chassis power reset` (real BMC)
+- `has_ipmi=0` — emits `ohpc_reset` placeholder lines to stdout at runtime
+
+Unlike proxy placeholders (which are pre-processed into the script before
+execution), reset placeholders are **runtime-emitted**. The script prints them
+to stdout via `echo`, and an external monitoring process wrapping the script
+intercepts them and triggers a hypervisor-level VM reset:
+
+```bash
+for ((i=0; i<num_computes; i++)) ; do
+  echo "#<<< ohpc_reset:$i,${c_name[$i]},${c_bmc[$i]} >>>#"
+done
+```
+
+Fields are comma-delimited (not `:`) so that IPv6 BMC addresses do not
+conflict with the field separator. Each output line carries three fields:
+index, node name, and BMC address:
+
+```text
+#<<< ohpc_reset:0,c1,192.168.1.101 >>>#
+#<<< ohpc_reset:1,c2,192.168.1.102 >>>#
+```
+
+**Example monitoring wrapper:**
+
+```bash
+#!/bin/bash
+# Run recipe.sh and intercept ohpc_reset lines to trigger VM resets
+bash recipe.sh 2>&1 | while IFS= read -r line; do
+  printf '%s\n' "$line"
+  pat='^#<<<[[:space:]]ohpc_reset:([0-9]+),([^,]+),(.+)[[:space:]]>>>#$'
+  if [[ "$line" =~ $pat ]]; then
+    idx="${BASH_REMATCH[1]}"
+    node_name="${BASH_REMATCH[2]}"
+    bmc_addr="${BASH_REMATCH[3]}"
+    echo ">>> Triggering reset for ${node_name} [${idx}] (${bmc_addr})" >&2
+    # Use node name (e.g. OpenStack server name matches c_name):
+    openstack server reboot --hard "${node_name}"
+    # Or use BMC address (e.g. hypervisor API keyed by IP):
+    # curl -X POST "http://hypervisor/api/vms/${bmc_addr}/reset"
+  fi
+done
+```
+
+All three fields come from `input.local` arrays. The index `$i` (0-based)
+identifies position in the `c_name`/`c_bmc` arrays. `c_name` holds the
+hostname (e.g. `c1`, `c2`); `c_bmc` holds the BMC/management address —
+the same value used by `ipmitool` in the IPMI path. IPv6 BMC addresses
+are safe because fields are comma-separated rather than colon-separated.
+
+**Template source:** `templates/boot/boot-computes.md.j2` (inside the
+`ohpc_else` branch of the `ohpc_if_set has_ipmi` conditional).
+
+#### Adding New Placeholder Types
+
+Two patterns exist, depending on whether expansion happens before or during
+script execution:
+
+**Static (pre-processed before execution)** — like `ohpc_proxy`. The
+placeholder is a fixed comment line in the script; a pre-processor replaces
+it before the script runs. Use this when the expansion produces commands
+that execute as part of the normal script flow.
+
+1. Choose a type prefix (e.g., `ohpc_auth`, `ohpc_storage`).
+2. Add an `ohpc_comment` + `ohpc_command` inside an `ohpc_begin`/`ohpc_end`
+   block. No `ohpc_if` wrapper — the placeholder should always be present:
+
+   ```markdown
+   <!-- ohpc_begin -->
+   <!-- ohpc_comment Configure site authentication (site-specific) -->
+   <!-- ohpc_command #<<< ohpc_auth:head >>># -->
+   <!-- ohpc_end -->
+   ```
+
+**Runtime-emitted (printed to stdout during execution)** — like `ohpc_reset`.
+The script prints placeholder lines via `echo` at runtime; a monitoring
+process wrapping the script intercepts them and acts out-of-band. Use this
+when the action must happen asynchronously from outside the script (e.g.,
+triggering a hypervisor reset while the script waits for the node to come up).
+
+   ```markdown
+   <!-- ohpc_command echo "#<<< ohpc_action:$var >>>#" -->
+   ```
+
+For both patterns, document the new type in this section.
+
 ## Directory Structure
 
 ```text

--- a/docs/install/templates/base-os/proxy.md.j2
+++ b/docs/install/templates/base-os/proxy.md.j2
@@ -1,0 +1,10 @@
+## Configure HTTPS Proxy (Optional)
+
+If your environment requires an HTTPS caching proxy for external network access,
+configure it here before installing any packages. The placeholder below marks
+where site-specific proxy setup should be injected by a pre-processing step.
+
+<!-- ohpc_begin -->
+<!-- ohpc_comment Configure HTTPS proxy for head node (site-specific) -->
+<!-- ohpc_command #<<< ohpc_proxy:head >>># -->
+<!-- ohpc_end -->

--- a/docs/install/templates/boot/boot-computes.md.j2
+++ b/docs/install/templates/boot/boot-computes.md.j2
@@ -18,10 +18,10 @@ for ((i=0; i<num_computes; i++)) ; do
 done
 ```
 <!-- ohpc_else -->
-<!-- ohpc_command # In-band communication to reset nodes   -->
-<!-- ohpc_command for ((i=0; i<num_computes; i++)) ; do    -->
-<!-- ohpc_command   echo "<<< ipmi-reset:${c_bmc[$i]} >>>" -->
-<!-- ohpc_command done                                     -->
+<!-- ohpc_command # In-band communication to reset nodes     -->
+<!-- ohpc_command for ((i=0; i<num_computes; i++)) ; do      -->
+<!-- ohpc_command   echo "#<<< ohpc_reset:$i,${c_name[$i]},${c_bmc[$i]} >>>#" -->
+<!-- ohpc_command done                                       -->
 <!-- ohpc_fi -->
 <!-- ohpc_end -->
 

--- a/docs/install/templates/chapters/base-os.md.j2
+++ b/docs/install/templates/chapters/base-os.md.j2
@@ -3,6 +3,8 @@
 
 {% include "base-os/install.md.j2" %}
 
+{% include "base-os/proxy.md.j2" %}
+
 {% if is_el %}
 {% include "distro/el/repos.md.j2" %}
 {% elif is_openeuler %}

--- a/docs/install/templates/provisioner/confluent/compute-setup.md.j2
+++ b/docs/install/templates/provisioner/confluent/compute-setup.md.j2
@@ -5,6 +5,11 @@ We now need to configure the compute nodes. We leverage the Confluent-provided
 
 We first disable the firewall on the compute nodes.
 <!-- ohpc_begin -->
+<!-- ohpc_comment Configure HTTPS proxy for compute nodes (site-specific) -->
+<!-- ohpc_command #<<< ohpc_proxy:compute >>># -->
+<!-- ohpc_end -->
+
+<!-- ohpc_begin -->
 <!-- ohpc_comment Disable firewall -->
 ```bash
 # Disable firewall for computes

--- a/docs/install/templates/provisioner/openchami/compute-image-build.md.j2
+++ b/docs/install/templates/provisioner/openchami/compute-image-build.md.j2
@@ -47,6 +47,11 @@ EOF
 ```
 <!-- ohpc_end -->
 
+<!-- ohpc_begin -->
+<!-- ohpc_comment Configure HTTPS proxy for image build (site-specific) -->
+<!-- ohpc_command #<<< ohpc_proxy:image >>># -->
+<!-- ohpc_end -->
+
 Build this first layer:
 
 <!-- ohpc_begin -->

--- a/docs/install/templates/provisioner/warewulf/compute-create-image.md.j2
+++ b/docs/install/templates/provisioner/warewulf/compute-create-image.md.j2
@@ -23,7 +23,10 @@ wwctl image import docker://ghcr.io/warewulf/warewulf-{{ distro_container_image 
 # Define chroot location
 CHROOT=$(wwctl image show {{ baseos }})
 export CHROOT
-
+```
+<!-- ohpc_comment Configure HTTPS proxy for compute image (site-specific) -->
+<!-- ohpc_command #<<< ohpc_proxy:compute >>># -->
+```bash
 # Enable OpenHPC inside image and update image.
 #Disable image build on exit, rebuild later.
 wwctl image exec --build=false {{ baseos }} -- /bin/bash -ex <<- EOF


### PR DESCRIPTION
Add `#<<< ohpc_proxy:TYPE >>>#` placeholder comments to all three provisioners and the head node setup. These are extension points for sites that need HTTPS proxy support: a site pre-processor replaces the markers in-place before running recipe.sh; left unexpanded they are no-op shell comments.

Three proxy placeholders per recipe, in script order:
- ohpc_proxy:head   — head node, before first dnf (base-os/proxy.md.j2)
- ohpc_proxy:compute — compute image/node (Warewulf chroot, Confluent
                       nodeshell)
- ohpc_proxy:image  — OpenCHAMI image-build (local registry context)

Update boot-computes.md.j2 node-reset placeholder to the consistent `#<<< ohpc_reset:$i,${c_name[$i]},${c_bmc[$i]} >>>#` format — ohpc_ prefix, comma-delimited fields (IPv6-safe), index + name + BMC address. Unlike proxy placeholders, reset placeholders are runtime-emitted to stdout for interception by a monitoring wrapper.

Document both placeholder patterns in DESIGN.md under a new "Site Pre-processing Placeholders" section with usage examples.