### PR TITLE
fix package filter to prefer exact name match

### DIFF
--- a/misc/check_for_package_updates.py
+++ b/misc/check_for_package_updates.py
@@ -1671,9 +1671,17 @@ def main(argv=None):
 
     if config.package:
         needle = config.package.lower()
-        filtered = [s for s in spec_files if needle in s.lower()]
+        # Try exact match on base name (without extension) first
+        filtered = [
+            s
+            for s in spec_files
+            if needle == os.path.splitext(os.path.basename(s))[0].lower()
+        ]
         if not filtered:
-            # Try matching against the base name without extension
+            # Fall back to substring match on the full path
+            filtered = [s for s in spec_files if needle in s.lower()]
+        if not filtered:
+            # Try substring match against the base name without extension
             filtered = [
                 s
                 for s in spec_files


### PR DESCRIPTION
When filtering by package name, try an exact match on the spec file base name before falling back to substring matching. This prevents short names like "R" from matching every spec file whose path contains that letter.

Generated with Claude Code (https://claude.ai/code)