### PR TITLE
ci: reduce GitHub Actions cache usage

### DIFF
--- a/.github/actions/oneapi-cache/action.yml
+++ b/.github/actions/oneapi-cache/action.yml
@@ -13,10 +13,11 @@ runs:
   steps:
     - name: Restore oneAPI package cache
       if: inputs.mode == 'restore'
+      id: restore-oneapi
       uses: actions/cache/restore@v4
       with:
         path: /var/cache/dnf/oneAPI-*/packages
-        key: dnf-oneapi-rhel-${{ github.sha }}
+        key: dnf-oneapi-rhel
         restore-keys: |
           dnf-oneapi-rhel-
     - name: Clean oneAPI package cache
@@ -29,9 +30,19 @@ runs:
           oldest=$(find /var/cache/dnf/oneAPI-*/packages -type f -printf '%T+ %p\n' 2>/dev/null | sort | head -1 | cut -d' ' -f2-)
           [ -n "$oldest" ] && rm -f "$oldest" || break
         done
+    - name: Delete previous oneAPI package cache
+      if: inputs.mode == 'save'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        gh cache list --key dnf-oneapi-rhel- --json id,key --jq '.[].id' | while read -r id; do
+          gh cache delete "$id" || true
+        done
     - name: Save oneAPI package cache
       if: inputs.mode == 'save'
       uses: actions/cache/save@v4
       with:
         path: /var/cache/dnf/oneAPI-*/packages
-        key: dnf-oneapi-rhel-${{ github.sha }}
+        key: dnf-oneapi-rhel-${{ github.run_id }}

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -67,8 +67,6 @@ jobs:
           build-args: |
             ARCH=${{ matrix.arch }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Export digest
         id: export

--- a/.github/workflows/build-ohpc-analysis-container.yml
+++ b/.github/workflows/build-ohpc-analysis-container.yml
@@ -49,8 +49,6 @@ jobs:
           platforms: linux/amd64
           provenance: false # Disable provenance to avoid unknown/unknown
           sbom: false       # Disable sbom to avoid unknown/unknown
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Output image details
         run: |

--- a/.github/workflows/build-ohpc-lint-container.yml
+++ b/.github/workflows/build-ohpc-lint-container.yml
@@ -49,8 +49,6 @@ jobs:
           platforms: linux/amd64
           provenance: false # Disable provenance to avoid unknown/unknown
           sbom: false       # Disable sbom to avoid unknown/unknown
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Output image details
         run: |

--- a/.github/workflows/build-ohpc-validate-container.yml
+++ b/.github/workflows/build-ohpc-validate-container.yml
@@ -62,8 +62,6 @@ jobs:
           provenance: false
           sbom: false
           outputs: type=image,name=${{ env.REGISTRY }}/openhpc/ohpc-validate-${{ matrix.distro }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Export digest
         id: export

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,6 +9,7 @@ on:
       - 4.x
 
 permissions:
+  actions: write
   contents: read
 
 env:


### PR DESCRIPTION
- Disable Docker BuildKit layer caching (cache-from/cache-to) in all container build workflows to free cache space
- Keep only one oneAPI package cache entry by deleting previous entries before saving, reducing ~6GB to ~1GB
- Add actions: write permission to validate workflow for cache deletion

Generated with Claude Code (https://claude.ai/code)