### PR TITLE
Add package install for the nfs-server service

### DIFF
--- a/docs/install/templates/base-os/nfs.md.j2
+++ b/docs/install/templates/base-os/nfs.md.j2
@@ -8,7 +8,8 @@ example configuration.
 <!-- ohpc_begin -->
 <!-- ohpc_comment Setup NFS Server -->
 ```bash
-# Start NFS server
+# Install and Start NFS server
+{{ pkg_install }} nfs-utils
 systemctl start nfs-server.service
 
 # Create OpenHPC public packages directory


### PR DESCRIPTION
Fixed the case where nfs-utils was not installed on base install.

Tested on AlmaLinux and RockyLinux for confluent on x86_64 on Jetstream2 - removing nfs-utils from image before testing.