### PR TITLE
tests/pdsh: create SSH key pair if one does not exist

### DIFF
--- a/tests/user-env/pdsh
+++ b/tests/user-env/pdsh
@@ -13,6 +13,15 @@ setup_file() {
 
 	TESTNAME="pdsh"
 
+	# Create SSH key pair if it does not exist and authorize it
+	if [[ ! -f "${HOME}/.ssh/id_ed25519" ]]; then
+		mkdir -p "${HOME}/.ssh"
+		chmod 700 "${HOME}/.ssh"
+		ssh-keygen -t ed25519 -N "" -f "${HOME}/.ssh/id_ed25519"
+		cat "${HOME}/.ssh/id_ed25519.pub" >> "${HOME}/.ssh/authorized_keys"
+		chmod 600 "${HOME}/.ssh/authorized_keys"
+	fi
+
 	export TESTNAME
 }
 


### PR DESCRIPTION
Generate an Ed25519 SSH key pair and add the public key to authorized_keys during test setup so pdsh tests can run without requiring pre-existing SSH credentials.

Generated with Claude Code (https://claude.ai/code)