### PR TITLE
dev-tools: update valgrind to 3.26.0

### DIFF
--- a/components/dev-tools/valgrind/SPECS/valgrind.spec
+++ b/components/dev-tools/valgrind/SPECS/valgrind.spec
@@ -14,7 +14,7 @@
 
 Summary:   Valgrind Memory Debugger
 Name:      %{pname}%{PROJ_DELIM}
-Version:   3.25.1
+Version:   3.26.0
 Release:   1%{?dist}
 License:   GPL
 URL:       http://www.valgrind.org/


### PR DESCRIPTION
- valgrind: 3.25.1 -> 3.26.0
  upstream: release-monitoring.org/13639

Command: `misc/check_for_package_updates.py -v -o markdown valgrind
  --update`