### PR TITLE
Test infrastructure updates

### DIFF
--- a/docs/install/config/provisioner/openchami.yaml
+++ b/docs/install/config/provisioner/openchami.yaml
@@ -6,4 +6,4 @@ is_openchami: true
 
 # OpenCHAMI component versions
 openchami_version: "0.1.2"
-ochami_version: "0.6.1"
+ochami_version: "0.7.0"

--- a/docs/install/input.local.template
+++ b/docs/install/input.local.template
@@ -58,6 +58,7 @@ initialize_options="${initialize_options:-usklpta}"
 deployment_protocols="${deployment_protocols:-firmware}"
 dns_domain="${dns_domain:-local}"
 iso_path="${iso_path:-}"
+iso_url="${iso_url:-}"
 
 # Flags for optional installation/configuration
 enable_ib="${enable_ib:-0}"

--- a/docs/install/recipes/rocky10-aarch64-confluent-slurm.yaml
+++ b/docs/install/recipes/rocky10-aarch64-confluent-slurm.yaml
@@ -1,2 +1,2 @@
 distro_id: "rocky-10.1-aarch64-default"
-distro_iso_image: "Rocky-10.1-aarch64-dvd.iso"
+distro_iso_image: "Rocky-10.1-aarch64-dvd1.iso"

--- a/docs/install/templates/base-os/ssh-key.md.j2
+++ b/docs/install/templates/base-os/ssh-key.md.j2
@@ -1,0 +1,20 @@
+## Generate SSH Key Pair
+
+An SSH key pair on the *head node* enables passwordless access to compute nodes
+and is useful for automating cluster configuration tasks.
+{% if is_confluent %}
+It is also required by the Confluent provisioner for node deployment.
+{% endif %}
+If an ed25519 key does not already exist, generate one:
+
+<!-- ohpc_begin -->
+```bash
+[[ -f ~/.ssh/id_ed25519 ]] || ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -N ''
+```
+<!-- ohpc_end -->
+
+::: {.tip}
+**Note:** The key is generated without a passphrase (`-N ''`) to allow
+unattended use in scripts and automated workflows. Ensure that access to the
+head node is appropriately restricted.
+:::

--- a/docs/install/templates/chapters/base-os.md.j2
+++ b/docs/install/templates/chapters/base-os.md.j2
@@ -20,6 +20,10 @@
 {% include "base-os/time.md.j2" %}
 
 {% if not is_warewulf %}
+{% include "base-os/ssh-key.md.j2" %}
+{% endif %}
+
+{% if not is_warewulf %}
 {% include "base-os/nfs.md.j2" %}
 {% endif %}
 

--- a/docs/install/templates/chapters/ohpc.md.j2
+++ b/docs/install/templates/chapters/ohpc.md.j2
@@ -1,6 +1,5 @@
 {# OpenHPC Aggregator #}
 # Install OpenHPC Components
 
-{% include "ohpc/ohpc-repo-validation.md.j2" %}
 {% include "ohpc/enable-ohpc-repo.md.j2" %}
 {% include "ohpc/install-ohpc-base.md.j2"%}

--- a/docs/install/templates/chapters/provisioner-confluent.md.j2
+++ b/docs/install/templates/chapters/provisioner-confluent.md.j2
@@ -6,6 +6,7 @@
 {% include "provisioner/confluent/intro.md.j2" %}
 {% include "provisioner/confluent/confluent-install.md.j2" %}
 {% include "provisioner/confluent/confluent-setup.md.j2" %}
+{% include "provisioner/confluent/download-iso.md.j2" %}
 {% include "provisioner/confluent/init-os-images.md.j2" %}
 {% include "provisioner/confluent/add-nodes.md.j2" %}
 

--- a/docs/install/templates/distro/el/repos.md.j2
+++ b/docs/install/templates/distro/el/repos.md.j2
@@ -25,7 +25,10 @@ with {{ distro_full_name }} and is typically enabled by default.  In contrast,
 the CRB repository is typically disabled in a standard install, but can be
 enabled from EPEL as follows:
 
+<!-- ohpc_begin -->
+<!-- ohpc_comment Install EPEL and enable CRB-->
 ```bash
 dnf -y install epel-release dnf-plugins-core
 dnf config-manager --set-enabled crb
 ```
+<!-- ohpc_end -->

--- a/docs/install/templates/intro/inputs.md.j2
+++ b/docs/install/templates/intro/inputs.md.j2
@@ -45,7 +45,8 @@ Required variables:
 * `initialize_options` - `usklpta`
 * `deployment_protocols` - `firmware`
 * `${dns_domain}` - DNS domain name for cluster (e.g. `local`)
-* `iso_path` - location of compute node base os dvd iso
+* `iso_path` - location of compute node base os dvd iso (default: `{{ distro_iso_image }}`)
+* `iso_url` - ISO download base URL (optional; overrides default upstream location)
 {% endif %}
 
 {% if is_x86_64 %}

--- a/docs/install/templates/ohpc/enable-ohpc-repo.md.j2
+++ b/docs/install/templates/ohpc/enable-ohpc-repo.md.j2
@@ -13,9 +13,11 @@ package signing and enabling the repository. The example which follows
 illustrates installation of the `ohpc-release` package directly from the OpenHPC
 build server.
 
+<!-- ohpc_begin -->
+<!-- ohpc_comment Install OpenHPC ohpc-release -->
 {% if uses_dnf %}
 ```bash
-dnf install {{ ohpc_repo_server }}/OpenHPC/{{ ohpc_version_tree }}/{{ ostree }}/{{ arch }}/\
+{{ pkg_install }} {{ ohpc_repo_server }}/OpenHPC/{{ ohpc_version_tree }}/{{ ostree }}/{{ arch }}/\
 ohpc-release-{{ ohpc_version_tree }}-1.{{ distro_tag }}.{{ arch }}.rpm
 ```
 {% else %}
@@ -24,6 +26,7 @@ rpm -ivh {{ ohpc_repo_server }}/OpenHPC/{{ ohpc_version_tree }}/{{ ostree }}/{{ 
 ohpc-release-{{ ohpc_version_tree }}-1.{{ distro_tag }}.{{ arch }}.rpm
 ```
 {% endif %}
+<!-- ohpc_end -->
 
 ::: {.tip}
 **Note:** Many sites may find it useful or necessary to maintain a local copy of

--- a/docs/install/templates/ohpc/ohpc-repo-validation.md.j2
+++ b/docs/install/templates/ohpc/ohpc-repo-validation.md.j2
@@ -1,7 +1,0 @@
-<!-- ohpc_begin -->
-<!-- ohpc_comment Verify OpenHPC repository has been enabled before proceeding -->
-<!-- ohpc_if ! dnf repolist | grep -q OpenHPC -->
-<!-- ohpc_command    echo "Error: OpenHPC repository must be enabled locally" -->
-<!-- ohpc_command    exit 1 -->
-<!-- ohpc_fi -->
-<!-- ohpc_end -->

--- a/docs/install/templates/provisioner/confluent/confluent-install.md.j2
+++ b/docs/install/templates/provisioner/confluent/confluent-install.md.j2
@@ -21,6 +21,7 @@ provisioning service on the *head node*:
 # Install Confluent and required packages
 {{ pkg_install }} lenovo-confluent
 {{ pkg_install }} tftp-server nfs-utils policycoreutils-python-utils yq jq
+{{ pkg_install }} confluent_ipxe-aarch64
 
 # Enable Confluent and its tools for use in current shell
 systemctl enable --now confluent

--- a/docs/install/templates/provisioner/confluent/download-iso.md.j2
+++ b/docs/install/templates/provisioner/confluent/download-iso.md.j2
@@ -1,0 +1,14 @@
+## Download ISO Image for Compute Node Deployment
+
+The `osdeploy import` command (below) requires a local copy of the
+{{ distro_full_name }} ISO image (`{{ distro_iso_image }}`), available from the
+{{ distro_full_name }} [download]({{ distro_download_page }}) page. If the ISO
+is not already present locally, download it:
+
+<!-- ohpc_begin -->
+```bash
+iso_file="{{ distro_iso_image }}"
+iso_url="${iso_url:={{ distro_base_url }}{{ distro_version }}/isos/{{ arch }}}"
+[[ -f "${iso_file}" ]] || curl -fO "${iso_url}/${iso_file}"
+```
+<!-- ohpc_end -->


### PR DESCRIPTION
Test infrastructure:
* Move installing epel-release, CRB, and ohpc-release into recipe.sh
* Move root ssh key generation for Confluent into recipe.sh
* Move Confluent ISO download into recipe.sh

Provisioner updates:
* Bump OpenCHAMI to 0.7.0
* Add confluent_ipxe to Confluent for initial aarch64 support (broken)

Mostly tested on AlmaLinux, RockyLinux, Confluent, Warewulf, OpenCHAMI, x86_64.

New support for Confluent on aarch64 is incomplete, Confluent installs but nodes crash on boot.
OpenCHAMI is the remaining provisioner not supported on aarch64.