### PR TITLE
docs: fix glob expansion in OpenCHAMI compute_echo macro

### DIFF
--- a/docs/install/templates/macros.j2
+++ b/docs/install/templates/macros.j2
@@ -81,7 +81,7 @@ C="sed -i '{{ regex }}' {{ file }}" \
 {%- endmacro -%}
 
 {%- macro compute_echo(string, file, append=true) -%}
-C="echo {{ string }} {{ ">>" if append else ">" }} {{ file }}" \
+C="echo '{{ string }}' {{ ">>" if append else ">" }} {{ file }}" \
   yq -i '.cmds += [{"cmd": strenv(C)}]' /opt/ohpc/admin/images/compute-prod.yaml
 {%- endmacro -%}
 


### PR DESCRIPTION
Add single quotes around the string argument in the OpenCHAMI compute_echo Jinja2 macro to prevent shell glob expansion. Without quotes, arguments containing '*' (e.g. memlock settings) were expanded to directory listings when the stored command was executed. This resulted in incorrect limits.conf content on compute nodes:
```
  afs bin boot dev etc home lib ... soft memlock unlimited
  afs bin boot dev etc home lib ... hard memlock unlimited
```
instead of the expected:
```
  * soft memlock unlimited
  * hard memlock unlimited
```
The Warewulf and Confluent variants already quoted this argument.

Generated with Claude Code (https://claude.ai/code)

CC: @middelkoopt 