### PR TITLE
Patch for OpennCHAMI support on aarch64

### DIFF
--- a/docs/install/templates/provisioner/openchami/install.md.j2
+++ b/docs/install/templates/provisioner/openchami/install.md.j2
@@ -18,6 +18,23 @@ v{{ openchami_version }}/openchami-{{ openchami_version }}.rpm
 ```
 <!-- ohpc_end -->
 
+{% if is_aarch64 %}
+<!-- ohpc_begin -->
+```bash
+# FIXME: Patch to use versions that support aarch64 and fix step-ca regression
+sed -i 's|ghcr.io/openchami/opaal:v0.3.10|ghcr.io/openchami/opaal:v0.3.12|g' \
+	/etc/containers/systemd/opaal.container \
+	/etc/containers/systemd/opaal-idp.container
+sed -i 's|ghcr.io/openchami/local-ca:v0.2.2|ghcr.io/openchami/local-ca:v0.2.3|g' \
+	/etc/containers/systemd/step-ca.container
+sed -i '\|^Image=ghcr.io/openchami/local-ca|a '\
+'Exec=/usr/bin/step-ca --password-file /home/step/secrets/password '\
+'/home/step/config/ca.json' \
+	/etc/containers/systemd/step-ca.container
+```
+<!-- ohpc_end -->
+{% endif %}
+
 <!-- ohpc_begin -->
 <!-- ohpc_comment Source /etc/profile.d/openchami.sh -->
 ```bash


### PR DESCRIPTION
Patch during installation to use containers that have aarch64 and fix a regression that was introduced in the new version.

Tested on aarch64 and x86_64