### PR TITLE
parallel-libs: fix trilinos tests for 17.0.0

### DIFF
--- a/tests/libs/trilinos/configure.ac
+++ b/tests/libs/trilinos/configure.ac
@@ -2,8 +2,8 @@
 # Process this file with autoconf to produce a configure script.
 #
 
-AC_PREREQ(2.59)
-AC_INIT(trilinos, 12.4.2, [https://github.com/openhpc/ohpc])
+AC_PREREQ([2.71])
+AC_INIT([trilinos],[12.4.2],[https://github.com/openhpc/ohpc])
 AM_INIT_AUTOMAKE([foreign])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_SUBST([LOG_DRIVER],['$(SHELL) $(top_srcdir)/../../test-driver-ohpc'])
@@ -13,7 +13,7 @@ AC_MSG_CHECKING([for TRILINOS_DIR environment variable])
 if test "x$TRILINOS_DIR" = "x"; then
    AC_MSG_RESULT([no])
    echo
-   AC_ERROR([TRILINOS_DIR not defined - please load trilinos environment.])
+   AC_MSG_ERROR(TRILINOS_DIR not defined - please load trilinos environment.)
 else
    AC_MSG_RESULT([yes])
 fi
@@ -24,7 +24,7 @@ AC_MSG_CHECKING([for OPENBLAS environment variable])
 if test "x$OPENBLAS_DIR" = "x"; then
    AC_MSG_RESULT([no])
    echo
-   AC_ERROR([OPENBLAS_DIR not defined - please load openblas environment.])
+   AC_MSG_ERROR(OPENBLAS_DIR not defined - please load openblas environment.)
 else
    AC_MSG_RESULT([yes])
 fi
@@ -33,7 +33,7 @@ AC_MSG_CHECKING([for Parallel HDF5 environment variable])
 if test "x$HDF5_DIR" = "x"; then
    AC_MSG_RESULT([no])
    echo
-   AC_ERROR([HDF5_DIR not defined - please load phdf5 environment.])
+   AC_MSG_ERROR(HDF5_DIR not defined - please load phdf5 environment.)
 else
    AC_MSG_RESULT([yes])
 fi
@@ -42,7 +42,7 @@ AC_MSG_CHECKING([for NETCDF environment variable])
 if test "x$NETCDF_DIR" = "x"; then
    AC_MSG_RESULT([no])
    echo
-   AC_ERROR([NETCDF_DIR not defined - please load netcdf environment.])
+   AC_MSG_ERROR(NETCDF_DIR not defined - please load netcdf environment.)
 else
    AC_MSG_RESULT([yes])
 fi
@@ -62,7 +62,7 @@ AC_PROG_CXX
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
 
-CXXFLAGS="-I${TRILINOS_INC} -I${TRILINOS_INC}/kokkos ${USER_CXX_FLAGS} -fopenmp ${CFLAGS} -Wno-unused-but-set-variable"
+CXXFLAGS="-I${TRILINOS_INC} -I${TRILINOS_INC}/kokkos ${USER_CXX_FLAGS} -std=c++20 -fopenmp ${CFLAGS} -Wno-unused-but-set-variable"
 LDFLAGS="-L${TRILINOS_LIB} -lkokkoscontainers -ltpetra -lteuchoskokkoscomm"
 LDFLAGS="${LDFLAGS} -lteuchoskokkoscompat -lteuchosremainder -lteuchosnumerics"
 LDFLAGS="${LDFLAGS} -lteuchoscomm -lteuchosparameterlist -lteuchosparser -lteuchoscore -lkokkoscore"
@@ -71,7 +71,7 @@ LDFLAGS="${LDFLAGS} -lteuchoscomm -lteuchosparameterlist -lteuchosparser -lteuch
 AC_CONFIG_FILES(Makefile tests/Makefile)
 
 # Configure
-AC_OUTPUT()
+AC_OUTPUT
 
 echo
 echo '-------------------------------------------------- SUMMARY --------------------------------------------------'

--- a/tests/libs/trilinos/tests/lesson_kokkos_memspace.cpp
+++ b/tests/libs/trilinos/tests/lesson_kokkos_memspace.cpp
@@ -64,7 +64,7 @@ typedef Kokkos::View<double *[3]> view_type;
 // performance penalties then it is its own host_mirror_space. This is
 // the case for HostSpace, CudaUVMSpace and CudaHostPinnedSpace.
 
-typedef view_type::HostMirror host_view_type;
+typedef view_type::host_mirror_type host_view_type;
 
 struct ReduceFunctor {
 	view_type a;


### PR DESCRIPTION
Trilinos 17.0.0 bundles Kokkos 4.x which requires C++20. Add -std=c++20 to CXXFLAGS in configure.ac and replace deprecated view_type::HostMirror with view_type::host_mirror_type in the kokkos memspace test.