### PR TITLE
docs: escape "$" to not resolve variable too early

### DIFF
--- a/docs/install/templates/provisioner/warewulf/compute-install-ohpc.md.j2
+++ b/docs/install/templates/provisioner/warewulf/compute-install-ohpc.md.j2
@@ -24,7 +24,7 @@ wwctl image exec --build=false {{ baseos }} -- /bin/bash -ex <<- EOF
   ohpc_repo="{{ openeuler_ohpc_repo_server }}"
   ohpc_repo+="/{{ openeuler_ohpc_repo_dir }}"
   ohpc_repo+="/{{ openeuler_ohpc_repo_file }}"
-  dnf -y config-manager --add-repo ${ohpc_repo}
+  dnf -y config-manager --add-repo \${ohpc_repo}
   dnf -y install openeuler-extra-repos
 {% endif %}
   dnf -y install ohpc-base-compute


### PR DESCRIPTION
@middelkoopt Does that make sense? Without a change like this variable is not correctly resolved. Do you have a preferred way how to do this?