### PR TITLE
Default to use dnf over yum

### DIFF
--- a/components/admin/meta-packages/SPECS/meta-packages.spec
+++ b/components/admin/meta-packages/SPECS/meta-packages.spec
@@ -71,7 +71,7 @@ Requires:  man-db
 Requires:  NetworkManager
 %endif
 %if 0%{?rhel}
-Requires:  yum-utils
+Requires:  dnf-utils
 %endif
 %if 0%{?suse_version}
 Requires:  glibc-locale

--- a/docs/install/config/base.yaml
+++ b/docs/install/config/base.yaml
@@ -34,7 +34,7 @@ is_confluent: false
 is_slurm: false
 
 ## Capabilities
-uses_dnf: false
+uses_dnf: true
 
 ## Feature flags
 enable_infiniband: false

--- a/docs/install/config/distro/el10.yaml
+++ b/docs/install/config/distro/el10.yaml
@@ -4,7 +4,6 @@
 distro_family: "el"
 distro_version: "10"
 is_el: true
-uses_dnf: true
 
 # Computed values (derived from distro_family + distro_version)
 ostree: "EL_10"

--- a/docs/install/config/distro/openeuler.yaml
+++ b/docs/install/config/distro/openeuler.yaml
@@ -2,7 +2,6 @@
 
 distro: "openeuler"
 is_openeuler: true
-uses_dnf: true
 
 distro_family: "openeuler"
 distro_version: "24.03"

--- a/docs/install/templates/base-os/time.md.j2
+++ b/docs/install/templates/base-os/time.md.j2
@@ -8,6 +8,7 @@ to serve as a local time server for the cluster, issue the following:
 <!-- ohpc_begin -->
 <!-- ohpc_comment Enable NTP services on head node -->
 ```bash
+{{ pkg_install }} chrony
 systemctl enable chronyd.service
 echo "local stratum 10" >> /etc/chrony.conf
 echo "server ${ntp_server}" >> /etc/chrony.conf


### PR DESCRIPTION
* All distributions use dnf now, so install dnf-utils instead of yum-utils.
* set `uses_dnf=true` as default.
* Leave yum code in for now.

This cleanup/refactor is to simplify testing of OpenEuler. 