### PR TITLE
parallel-libs: update slepc to 3.24.3

### DIFF
--- a/components/parallel-libs/slepc/SPECS/slepc.spec
+++ b/components/parallel-libs/slepc/SPECS/slepc.spec
@@ -21,7 +21,7 @@
 %define pname slepc
 
 Name:           %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-Version:        3.24.2
+Version:        3.24.3
 Release:        1
 Summary:        A library for solving large scale sparse eigenvalue problems
 License:        LGPL-3.0


### PR DESCRIPTION
- slepc: 3.24.2 -> 3.24.3
  upstream: release-monitoring.org/slepc

Command: `misc/check_for_package_updates.py -v -o markdown slepc
  --update`