### PR TITLE
dev-tools: update python-mpi4py to 4.1.1

### DIFF
--- a/components/dev-tools/mpi4py/SPECS/python-mpi4py.spec
+++ b/components/dev-tools/mpi4py/SPECS/python-mpi4py.spec
@@ -23,7 +23,7 @@
 %define pname mpi4py
 
 Name:           %{python_prefix}-%{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-Version:        3.1.5
+Version:        4.1.1
 Release:        1%{?dist}
 Summary:        Python bindings for the Message Passing Interface (MPI) standard.
 License:        BSD-3-Clause
@@ -31,6 +31,7 @@ Group:          %{PROJ_NAME}/dev-tools
 Url:            https://github.com/mpi4py/mpi4py
 Source0:        https://github.com/mpi4py/mpi4py/releases/download/%{version}/mpi4py-%{version}.tar.gz
 Requires:       lmod%{PROJ_DELIM} >= 7.6.1
+BuildRequires:  %{python_prefix}-Cython%{PROJ_DELIM}
 
 # Default library install path
 %define install_path %{OHPC_LIBS}/%{compiler_family}/%{mpi_family}/%{pname}/%version


### PR DESCRIPTION
- python3-mpi4py: 3.1.5 -> 4.1.1
  upstream: mpi4py/mpi4py

Command: `misc/check_for_package_updates.py -v -o markdown mpi4py
  --update`