### PR TITLE
rms: upgrade slurm to 24.11.7

### DIFF
--- a/components/rms/slurm/SPECS/slurm.spec
+++ b/components/rms/slurm/SPECS/slurm.spec
@@ -30,7 +30,7 @@
 # $Id$
 #
 Name:		%{pname}%{PROJ_DELIM}
-Version:	24.11.5
+Version:	24.11.7
 %global rel	1
 Release:	%{?dist}.1
 Summary:	Slurm Workload Manager


### PR DESCRIPTION
To benefit from 24.11.6 and 24.11.7 bug fixes
See https://github.com/SchedMD/slurm/blob/slurm-24.11/CHANGELOG/slurm-24.11.md

Fixes #2428