### PR TITLE
warewulf: openEuler support fixes

### DIFF
--- a/components/provisioning/warewulf/SPECS/warewulf.spec
+++ b/components/provisioning/warewulf/SPECS/warewulf.spec
@@ -90,7 +90,7 @@ BuildRequires: systemd
 BuildRequires: golang >= 1.22
 BuildRequires: firewalld-filesystem
 Requires: nfs-utils
-%if 0%{?rhel} < 8
+%if 0%{?rhel} < 8 || 0%{?openEuler}
 Requires: ipxe-bootimgs
 %else
 Requires: ipxe-bootimgs-x86

--- a/docs/install/mkdoc.py
+++ b/docs/install/mkdoc.py
@@ -199,12 +199,13 @@ def extract_recipe_script(content: str) -> str:
       <!-- ohpc_if_set VAR -->      if [[ ${VAR} -eq 1 ]];then
       <!-- ohpc_if CONDITION -->    if CONDITION;then
       <!-- ohpc_else -->            else
-      <!-- ohpc_fi -->           fi
+      <!-- ohpc_fi -->              fi
     Blank lines inside ohpc_begin/ohpc_end blocks pass through.
     """
     lines = []
     in_run_block = False
     in_code_block = False
+    current_section = None
 
     for line in content.split("\n"):
         # Pass through section markers
@@ -212,11 +213,15 @@ def extract_recipe_script(content: str) -> str:
         if match:
             where, section = match.groups()
             lines.append(f"# --- {where}section: {section} ---")
+            if where == "+":
+                current_section = section
             continue
 
         # Track run blocks
         if "<!-- ohpc_begin -->" in line:
             in_run_block = True
+            if current_section:
+                lines.append(f"echo '=== section: {current_section} ==='")
             continue
         if "<!-- ohpc_end -->" in line:
             in_run_block = False

--- a/docs/install/templates/distro/openeuler/repos.md.j2
+++ b/docs/install/templates/distro/openeuler/repos.md.j2
@@ -6,13 +6,16 @@ Everything, and EPOL main repositories are typically enabled by default. To
 enable the EPOL update repository on {{ distro_full_name }}, you can run the
 following command:
 
+<!-- ohpc_begin -->
+<!-- ohpc_comment Install EPOL -->
+
 ```bash
-ohpc_repo="{{ openeuler_ohpc_repo_server }}"
-ohpc_repo+="/{{ openeuler_ohpc_repo_dir }}"
-ohpc_repo+="/{{ openeuler_ohpc_repo_file }}"
-{{ pkg_add_repo }} ${ohpc_repo}
+{{ pkg_add_repo }} {{ openeuler_ohpc_repo_server }}\
+/{{ openeuler_ohpc_repo_dir }}\
+/{{ openeuler_ohpc_repo_file }}
 {{ pkg_install }} openeuler-extra-repos
 ```
+<!-- ohpc_end -->
 
 By default all repositories use
 [http://repo.openeuler.org](http://repo.openeuler.org). For better network speed

--- a/docs/install/templates/provisioner/warewulf/compute-create-image.md.j2
+++ b/docs/install/templates/provisioner/warewulf/compute-create-image.md.j2
@@ -28,7 +28,7 @@ export CHROOT
 <!-- ohpc_command #<<< ohpc_proxy:compute >>># -->
 ```bash
 # Enable OpenHPC inside image and update image.
-#Disable image build on exit, rebuild later.
+# Disable image build on exit, rebuild later.
 wwctl image exec --build=false {{ baseos }} -- /bin/bash -ex <<- EOF
   dnf -y install dnf-utils
   dnf -y install {{ ohpc_repo_server }}/OpenHPC/{{ ohpc_version_tree }}/{{ ostree }}/\

--- a/docs/install/templates/provisioner/warewulf/compute-install-ohpc.md.j2
+++ b/docs/install/templates/provisioner/warewulf/compute-install-ohpc.md.j2
@@ -21,10 +21,9 @@ wwctl image exec --build=false {{ baseos }} -- /bin/bash -ex <<- EOF
 {% if is_el %}
   dnf -y install epel-release
 {% elif is_openeuler %}
-  ohpc_repo="{{ openeuler_ohpc_repo_server }}"
-  ohpc_repo+="/{{ openeuler_ohpc_repo_dir }}"
-  ohpc_repo+="/{{ openeuler_ohpc_repo_file }}"
-  dnf -y config-manager --add-repo ${ohpc_repo}
+  dnf -y config-manager --add-repo {{ openeuler_ohpc_repo_server }}\
+/{{ openeuler_ohpc_repo_dir }}\
+/{{ openeuler_ohpc_repo_file }}
   dnf -y install openeuler-extra-repos
 {% endif %}
   dnf -y install ohpc-base-compute

--- a/docs/install/templates/provisioner/warewulf/finalize-provisioning.md.j2
+++ b/docs/install/templates/provisioner/warewulf/finalize-provisioning.md.j2
@@ -22,7 +22,7 @@ it is helpful to add `rd.shell` to the kernel arguments.
 ```bash
 ## Add rd.shell to kernel arguments in the "default" profile.
 yq -i '.nodeprofiles.default.kernel.args += ["rd.shell"]' \
-	/etc/warewulf/nodes.conf
+  /etc/warewulf/nodes.conf
 ```
 <!-- ohpc_end -->
 
@@ -32,17 +32,13 @@ yq -i '.nodeprofiles.default.kernel.args += ["rd.shell"]' \
 ```bash
 ## Install Dracut in the image
 wwctl image exec --build=false {{ baseos }} -- /usr/bin/dnf install -y \
-	warewulf-ohpc-dracut ignition gdisk
+  warewulf-ohpc-dracut
 
 ## Configure Dracut. Note the leading and trailing spaces
 # in the quotes in "add_dracutmodules"
 echo 'hostonly="no"' > "$CHROOT"/etc/dracut.conf.d/wwinit.conf
-echo 'add_dracutmodules+=" wwinit ignition "' \
-	>> "$CHROOT"/etc/dracut.conf.d/wwinit.conf
-
-## Build the Dracut initramfs
-wwctl image exec --build=false {{ baseos }} -- /usr/bin/dracut --force \
-	--regenerate-all
+echo 'add_dracutmodules+=" wwinit "' \
+  >> "$CHROOT"/etc/dracut.conf.d/wwinit.conf
 
 ## Enable Dracut boot for compute nodes that use the "nodes" profile
 wwctl profile set --yes nodes --tagadd IPXEMenuEntry=dracut
@@ -58,6 +54,14 @@ provisioning (previous step) must also be enabled.  The compute node will use,
 <!-- ohpc_if [[ ${enable_dracut} -eq 1 && ${enable_todisk} -eq 1 ]] -->
 <!-- ohpc_comment Configure two-stage provision-to-disk -->
 ```bash
+## Install disk tools
+wwctl image exec --build=false {{ baseos }} -- /usr/bin/dnf install -y \
+  ignition gdisk
+
+## Add ignition Dracut module.
+echo 'add_dracutmodules+=" ignition "' \
+  >> "$CHROOT"/etc/dracut.conf.d/wwinit.conf
+
 ## Create the target "rootfs" partition and filesystem
 wwctl profile set --yes nodes \
   --diskname "${node_disk}" --diskwipe \
@@ -74,9 +78,18 @@ wwctl profile set nodes --yes --root=/dev/disk/by-partlabel/rootfs
 
 The bootstrap image includes the runtime kernel and associated modules, as well
 as some simple scripts to complete the provisioning process.  We explicitly
-rebuild the image at the end because rebuilding the image is disabled in earlier
-steps. It is good practice to rebuild the overlays when after configuration
-changes.
+rebuild Dracut and the image at the end because rebuilding the image is disabled
+in earlier steps. It is good practice to rebuild the overlays when after
+configuration changes.
+
+<!-- ohpc_begin -->
+<!-- ohpc_comment Build Dracut -->
+```bash
+## Build the Dracut initramfs
+wwctl image exec --build=false {{ baseos }} -- /usr/bin/dracut --force \
+  --regenerate-all
+```
+<!-- ohpc_end -->
 
 <!-- ohpc_begin -->
 <!-- ohpc_comment Assemble bootstrap image -->
@@ -86,4 +99,3 @@ wwctl image build {{ baseos }}
 wwctl overlay build
 ```
 <!-- ohpc_end -->
-

--- a/docs/install/templates/provisioner/warewulf/warewulf-install.md.j2
+++ b/docs/install/templates/provisioner/warewulf/warewulf-install.md.j2
@@ -20,10 +20,18 @@ configuring Warewulf `yaml` files.
 
 # Create the tftpboot directory (not created by dnsmasq)
 install -d -m 0755 /var/lib/tftpboot
+```
+<!-- ohpc_end -->
 
+If SELinux is enabled, configure the appropriate file context for the `tftpboot` directory:
+
+<!-- ohpc_begin -->
+<!-- ohpc_if [[ "$(getenforce 2>/dev/null)" != "Disabled" ]] -->
+```bash
 # Add public_content_t type to tftpboot directory and contents
 {{ pkg_install }} policycoreutils-python-utils
 semanage fcontext -a -t public_content_t "/var/lib/tftpboot(/.*)?"
 restorecon -R -v /var/lib/tftpboot
 ```
+<!-- ohpc_fi -->
 <!-- ohpc_end -->


### PR DESCRIPTION
- openEuler Warewulf recipe work — Fixed the openEuler repo URL construction (dropped intermediate shell variable, used line-continuation syntax instead) in both the head node and compute image install paths. Added ipxe-bootimgs RPM dep for openEuler in the warewulf spec.
- Dracut/ignition decoupling — Separated ignition and gdisk from the base dracut install; they're now only installed and configured when enable_todisk=1. This avoids pulling in disk tools on nodes that don't use provision-to-disk.
- Conditional SELinux setup — Wrapped the semanage/restorecon block in warewulf-install.md.j2 with a runtime getenforce check so it's a no-op on systems with SELinux disabled (relevant for openEuler, which may not have SELinux enforcing).
- Recipe script section echo — Added runtime echo '=== section: ... ===' output to mkdoc.py so the generated recipe.sh prints progress as each section begins executing to aid in finding the template.

Replaces https://github.com/openhpc/ohpc/pull/2420

OpenEuler 24.03-SP2 is EOL so that will need to be updated.  

Two stage to ram works.  Provision to disk is missing ignition.  Hard to fully test, mirrors are flakey and US mirror does not fully mirror SP2.  

