### PR TITLE
admin: add paraver to perf-tools meta-packages

### DIFF
--- a/components/admin/meta-packages/SPECS/meta-packages.spec
+++ b/components/admin/meta-packages/SPECS/meta-packages.spec
@@ -266,6 +266,7 @@ Requires:  imb-%{compiler_family}-mpich%{PROJ_DELIM}
 Requires:  imb-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  omb-%{compiler_family}-mpich%{PROJ_DELIM}
 Requires:  omb-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  paraver%{PROJ_DELIM}
 Requires:  tau-%{compiler_family}-mpich%{PROJ_DELIM}
 Requires:  tau-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  scalasca-%{compiler_family}-mpich%{PROJ_DELIM}
@@ -292,6 +293,7 @@ Requires:  dimemas-%{compiler_family}-mpich%{PROJ_DELIM}
 Requires:  extrae-%{compiler_family}-mpich%{PROJ_DELIM}
 Requires:  imb-%{compiler_family}-mpich%{PROJ_DELIM}
 Requires:  omb-%{compiler_family}-mpich%{PROJ_DELIM}
+Requires:  paraver%{PROJ_DELIM}
 Requires:  tau-%{compiler_family}-mpich%{PROJ_DELIM}
 Requires:  scalasca-%{compiler_family}-mpich%{PROJ_DELIM}
 Requires:  scorep-%{compiler_family}-mpich%{PROJ_DELIM}
@@ -306,6 +308,7 @@ Requires:  extrae-%{compiler_family}-mvapich2%{PROJ_DELIM}
 Requires:  imb-%{compiler_family}-mvapich2%{PROJ_DELIM}
 Requires:  likwid-%{compiler_family}%{PROJ_DELIM}
 Requires:  omb-%{compiler_family}-mvapich2%{PROJ_DELIM}
+Requires:  paraver%{PROJ_DELIM}
 Requires:  tau-%{compiler_family}-mvapich2%{PROJ_DELIM}
 Requires:  scalasca-%{compiler_family}-mvapich2%{PROJ_DELIM}
 Requires:  scorep-%{compiler_family}-mvapich2%{PROJ_DELIM}
@@ -320,6 +323,7 @@ Requires:  extrae-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  imb-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  likwid-%{compiler_family}%{PROJ_DELIM}
 Requires:  omb-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  paraver%{PROJ_DELIM}
 Requires:  tau-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  scalasca-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  scorep-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
@@ -597,6 +601,7 @@ Requires:  extrae-intel-impi%{PROJ_DELIM}
 Requires:  extrae-intel-mpich%{PROJ_DELIM}
 Requires:  extrae-intel-mvapich2%{PROJ_DELIM}
 Requires:  extrae-intel-%{mpi_family}%{PROJ_DELIM}
+Requires:  paraver%{PROJ_DELIM}
 Requires:  imb-%{compiler_family}-impi%{PROJ_DELIM}
 Requires:  imb-intel-impi%{PROJ_DELIM}
 Requires:  imb-intel-mpich%{PROJ_DELIM}
@@ -742,6 +747,7 @@ Requires:  dimemas-arm1-mpich%{PROJ_DELIM}
 Requires:  dimemas-arm1-%{mpi_family}%{PROJ_DELIM}
 Requires:  extrae-arm1-mpich%{PROJ_DELIM}
 Requires:  extrae-arm1-%{mpi_family}%{PROJ_DELIM}
+Requires:  paraver%{PROJ_DELIM}
 Requires:  imb-arm1-mpich%{PROJ_DELIM}
 Requires:  imb-arm1-%{mpi_family}%{PROJ_DELIM}
 ### Requires:  likwid-arm1%{PROJ_DELIM}


### PR DESCRIPTION
Add paraver as a dependency to all perf-tools meta-packages that include extrae and dimemas. Paraver is a compiler-independent performance visualization tool, so it uses the base package name (paraver-ohpc) without compiler or MPI family suffixes.