### PR TITLE
tests: fix double free in mfem ex1p_perf test

### DIFF
--- a/tests/libs/mfem/tests/parallel/ex1p_perf.cpp
+++ b/tests/libs/mfem/tests/parallel/ex1p_perf.cpp
@@ -329,7 +329,7 @@ int ex1_t<dim>::run(Mesh *mesh, int ser_ref_levels, int par_ref_levels,
 		}
 		delete fespace;
 		delete fec;
-		delete mesh;
+		delete pmesh;
 		return 5;
 	}
 


### PR DESCRIPTION
The early-return path at line 332 deleted `mesh`, but `mesh` was already freed at line 276 after creating the ParMesh. Replace with `delete pmesh` to properly clean up the allocated ParMesh and avoid the double free