### PR TITLE
Update petsc and slepc to 3.25.0 and support multi-spec CI builds

### DIFF
--- a/components/parallel-libs/petsc/SPECS/petsc.spec
+++ b/components/parallel-libs/petsc/SPECS/petsc.spec
@@ -25,7 +25,7 @@ Name:           %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Summary:        Portable Extensible Toolkit for Scientific Computation
 License:        2-clause BSD
 Group:          %{PROJ_NAME}/parallel-libs
-Version:        3.24.4
+Version:        3.25.0
 Release:        1%{?dist}
 Source0:        https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-%{version}.tar.gz
 Url:            http://www.mcs.anl.gov/petsc/

--- a/components/parallel-libs/slepc/SPECS/slepc.spec
+++ b/components/parallel-libs/slepc/SPECS/slepc.spec
@@ -21,7 +21,7 @@
 %define pname slepc
 
 Name:           %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-Version:        3.24.3
+Version:        3.25.0
 Release:        1
 Summary:        A library for solving large scale sparse eigenvalue problems
 License:        LGPL-3.0

--- a/tests/ci/run_build.py
+++ b/tests/ci/run_build.py
@@ -79,6 +79,11 @@ for root, dirs, files in os.walk(ccache_dir):
     for f in files:
         os.chown(os.path.join(root, f), uid, gid)
 
+rpmbuild_rpms_dir = os.path.join(
+    pwd.getpwnam(build_user).pw_dir, "rpmbuild", "RPMS"
+)
+local_repo_configured = False
+
 
 def run_command(command):
     logging.info("About to run command %s" % " ".join(command))
@@ -138,6 +143,122 @@ def loop_command(command, max_attempts=5):
 
         logging.info("Retrying attempt '%i'" % attempt_counter)
         time.sleep(attempt_counter)
+
+
+def get_build_order(specfiles):
+    """Use misc/build_order.sh to determine the correct build order
+    for the given spec files."""
+    logging.info("Determining build order using misc/build_order.sh")
+
+    # Ensure RPM build environment is set up (build_order.sh requires
+    # OHPC_macros in the RPM source directory)
+    sourcedir = subprocess.check_output(
+        ["rpm", "--eval", "%{_sourcedir}"], text=True
+    ).strip()
+    topdir = subprocess.check_output(
+        ["rpm", "--eval", "%{_topdir}"], text=True
+    ).strip()
+    for subdir in ["BUILD", "BUILDROOT", "RPMS", "SOURCES", "SPECS", "SRPMS"]:
+        os.makedirs(os.path.join(topdir, subdir), exist_ok=True)
+    macros_dest = os.path.join(sourcedir, "OHPC_macros")
+    if not os.path.exists(macros_dest):
+        macros_src = "components/OHPC_macros"
+        if os.path.exists(macros_src):
+            shutil.copy2(macros_src, macros_dest)
+            logging.info("Copied OHPC_macros to %s" % macros_dest)
+        else:
+            logging.warning("components/OHPC_macros not found")
+
+    success, output = run_command(["misc/build_order.sh"])
+    if not success:
+        logging.warning(
+            "misc/build_order.sh failed, using original spec file order"
+        )
+        return specfiles
+
+    # build_order.sh prints all spec paths in order on one line
+    ordered = output.strip().split()
+
+    # Normalize paths: strip leading "./" for consistent comparison
+    def normalize(p):
+        while p.startswith("./"):
+            p = p[2:]
+        return p
+
+    ordered_normalized = [normalize(p) for p in ordered]
+
+    # Build a position map from the full build order
+    position = {}
+    for idx, path in enumerate(ordered_normalized):
+        position[path] = idx
+        # Also index by basename for fallback matching
+        position[os.path.basename(path)] = idx
+
+    def sort_key(spec_path):
+        norm = normalize(spec_path)
+        if norm in position:
+            return position[norm]
+        base = os.path.basename(norm)
+        if base in position:
+            return position[base]
+        # Specs not found in build order go to the end
+        return len(ordered)
+
+    sorted_specs = sorted(specfiles, key=sort_key)
+    logging.info(
+        "Build order: %s"
+        % " ".join([os.path.basename(s) for s in sorted_specs])
+    )
+    return sorted_specs
+
+
+def setup_local_repo():
+    """Run createrepo_c on the rpmbuild RPMS directory and configure
+    it as a local repository so that subsequent builds can use
+    previously built RPMs as dependencies."""
+    global local_repo_configured
+
+    os.makedirs(rpmbuild_rpms_dir, exist_ok=True)
+
+    logging.info(
+        "Running createrepo_c on %s" % rpmbuild_rpms_dir
+    )
+    success, _ = run_command(["createrepo_c", rpmbuild_rpms_dir])
+    if not success:
+        logging.error("createrepo_c failed on %s" % rpmbuild_rpms_dir)
+        return False
+
+    if not local_repo_configured:
+        if dnf_based:
+            repo_file = "/etc/yum.repos.d/local-ohpc-ci.repo"
+            with open(repo_file, "w") as f:
+                f.write("[local-ohpc-ci]\n")
+                f.write("name=Local OpenHPC CI builds\n")
+                f.write(
+                    "baseurl=file://%s\n" % rpmbuild_rpms_dir
+                )
+                f.write("enabled=1\n")
+                f.write("gpgcheck=0\n")
+            logging.info(
+                "Configured local DNF repository at %s" % repo_file
+            )
+        else:
+            success, _ = run_command([
+                "zypper",
+                "ar",
+                "-G",
+                "-f",
+                rpmbuild_rpms_dir,
+                "local-ohpc-ci",
+            ])
+            if not success:
+                logging.error("Failed to add local zypper repository")
+                return False
+            logging.info("Configured local zypper repository")
+
+        local_repo_configured = True
+
+    return True
 
 
 def build_srpm_and_rpm(
@@ -250,7 +371,25 @@ rebuild_success = []
 total = 0
 docs_spec_executed = False
 
-for spec in args.specfiles:
+# Determine the number of actual spec files to build
+specfiles = args.specfiles
+spec_count = sum(
+    1 for s in specfiles
+    if s.endswith(".spec")
+    or "components/admin/docs/SPECS/docs.spec" == s
+    or "docs/recipes/install/" in s
+    or "components/admin/docs/SOURCES/" in s
+)
+multiple_specs = spec_count > 1
+build_order_used = None
+
+if multiple_specs:
+    specfiles = get_build_order(specfiles)
+    build_order_used = [
+        os.path.basename(s) for s in specfiles if s.endswith(".spec")
+    ]
+
+for spec in specfiles:
     # if more than one docs related file are modified then
     # build the docs.spec just once
     # START OF LOGIC FOR DOCS
@@ -346,11 +485,19 @@ for spec in args.specfiles:
         else:
             rebuild_success.append(just_spec)
 
+    # When building multiple specs, update the local repo after each
+    # spec so that subsequent builds can use the just-built RPMs
+    # as dependencies.
+    if multiple_specs:
+        setup_local_repo()
+
 
 if not spec_found:
     logging.info("SKIP. Commit without changes to a SPEC file.")
 
 logging.info("Found %d spec file(s)" % total)
+if build_order_used:
+    logging.info("--> Build order: %s" % " -> ".join(build_order_used))
 logging.info("--> %d rebuild successfully" % len(rebuild_success))
 for success in rebuild_success:
     logging.info("----> %s" % success)

--- a/tests/libs/slepc/tests/test4f.F
+++ b/tests/libs/slepc/tests/test4f.F
@@ -149,10 +149,10 @@
      &                   PETSC_VIEWER_DEFAULT,vf,ierr)
       call SVDMonitorSet(svd,SVDMONITORFIRST,vf,                        &
      &                   PetscViewerAndFormatDestroy,ierr)
-      call SVDMonitorConvergedCreate(PETSC_VIEWER_STDOUT_WORLD,         &
-     &                   PETSC_VIEWER_DEFAULT,PETSC_NULL_VEC,vf,ierr)
+      call PetscViewerAndFormatCreate(PETSC_VIEWER_STDOUT_WORLD,        &
+     &                   PETSC_VIEWER_DEFAULT,vf,ierr)
       call SVDMonitorSet(svd,SVDMONITORCONVERGED,vf,                    &
-     &                   SVDMonitorConvergedDestroy,ierr)
+     &                   PetscViewerAndFormatDestroy,ierr)
       call SVDMonitorCancel(svd,ierr)
 
 !     ** call the solver


### PR DESCRIPTION
   - Update PETSc from 3.24.4 to 3.25.0                                                                                                                                                                                                        
  - Update SLEPc from 3.24.3 to 3.25.0                                                                                                                                                                                                        
  - Extend tests/ci/run_build.py to support building multiple spec files in the correct dependency order, with a local RPM repository for inter-package dependencies                                                                          
                                                                                                                                                                                                                                                                                                                                                                                                                                                                      
