### PR TITLE
ci: add docs/install Python scripts to ruff lint targets

### DIFF
--- a/docs/install/generate_manifest.py
+++ b/docs/install/generate_manifest.py
@@ -37,25 +37,27 @@ from pathlib import Path
 # Configuration Loading
 # ---------------------------------------------------------------------------
 
+
 def load_config() -> dict:
     """Load configuration from manifests/config.yaml."""
     config_path = Path(__file__).parent / "manifests" / "config.yaml"
-    with open(config_path, 'r', encoding='utf-8') as f:
+    with open(config_path, "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
 
 
 _CONFIG = load_config()
 
 # Load configuration into module-level constants
-COMPILER_FAMILIES = _CONFIG['compiler_families']
-MPI_FAMILIES = _CONFIG['mpi_families']
-EXCLUDE_PACKAGES = set(_CONFIG['exclude_packages'])
-CATEGORY_ORDER = list(_CONFIG['categories'].items())
+COMPILER_FAMILIES = _CONFIG["compiler_families"]
+MPI_FAMILIES = _CONFIG["mpi_families"]
+EXCLUDE_PACKAGES = set(_CONFIG["exclude_packages"])
+CATEGORY_ORDER = list(_CONFIG["categories"].items())
 
 
 # ---------------------------------------------------------------------------
 # Data Structures
 # ---------------------------------------------------------------------------
+
 
 @dataclass
 class Package:
@@ -78,6 +80,7 @@ class PackageGroup:
 # Parsing
 # ---------------------------------------------------------------------------
 
+
 def parse_pkg_ohpc(filepath: Path) -> list[Package]:
     """Parse pkg-ohpc.all into a list of Package objects.
 
@@ -90,9 +93,7 @@ def parse_pkg_ohpc(filepath: Path) -> list[Package]:
             line = line.strip()
             if not line:
                 continue
-            match = re.match(
-                r"^(\S+)\s+(\S+)\s+(\S+)\s+(ohpc/\S+)\s+(.+)$", line
-            )
+            match = re.match(r"^(\S+)\s+(\S+)\s+(\S+)\s+(ohpc/\S+)\s+(.+)$", line)
             if not match:
                 continue
             name, version, url, category_full, summary = match.groups()
@@ -121,6 +122,7 @@ def parse_meta_ohpc(filepath: Path) -> list[tuple[str, str]]:
 # ---------------------------------------------------------------------------
 # Package Family Classification and Grouping
 # ---------------------------------------------------------------------------
+
 
 def classify_package(name: str) -> tuple[str, bool]:
     """Determine if a package is a compiler/MPI family variant.
@@ -166,9 +168,14 @@ def group_packages(packages: list[Package]) -> list[PackageGroup]:
         base, is_family = classify_package(pkg.name)
 
         if not is_family:
-            groups.append(PackageGroup(
-                [pkg.name], pkg.version, pkg.url, pkg.summary,
-            ))
+            groups.append(
+                PackageGroup(
+                    [pkg.name],
+                    pkg.version,
+                    pkg.url,
+                    pkg.summary,
+                )
+            )
             i += 1
             continue
 
@@ -188,12 +195,16 @@ def group_packages(packages: list[Package]) -> list[PackageGroup]:
                 break
 
         variant_names = [
-            p.name for p in packages[i:end]
-            if p.name not in EXCLUDE_PACKAGES
+            p.name for p in packages[i:end] if p.name not in EXCLUDE_PACKAGES
         ]
-        groups.append(PackageGroup(
-            variant_names, pkg.version, pkg.url, pkg.summary,
-        ))
+        groups.append(
+            PackageGroup(
+                variant_names,
+                pkg.version,
+                pkg.url,
+                pkg.summary,
+            )
+        )
         i = end
 
     return groups
@@ -202,6 +213,7 @@ def group_packages(packages: list[Package]) -> list[PackageGroup]:
 # ---------------------------------------------------------------------------
 # Table Formatting
 # ---------------------------------------------------------------------------
+
 
 def format_summary(summary: str) -> str:
     """Ensure summary ends with a period."""
@@ -260,6 +272,7 @@ def generate_meta_table(patterns: list[tuple[str, str]]) -> str:
 # Document Assembly
 # ---------------------------------------------------------------------------
 
+
 def generate_meta_md(meta_path: Path) -> str:
     """Generate meta-package table markdown from meta-ohpc.all."""
     meta_patterns = parse_meta_ohpc(meta_path)
@@ -309,6 +322,7 @@ def generate_pkg_md(pkg_path: Path) -> str:
 # .all File Generation (queries system package manager)
 # ---------------------------------------------------------------------------
 
+
 def parse_manifest_dir(manifest_dir: Path) -> tuple[str, str]:
     """Extract distro prefix and architecture from manifest directory name.
 
@@ -319,7 +333,10 @@ def parse_manifest_dir(manifest_dir: Path) -> tuple[str, str]:
         if name.endswith(f"-{arch}"):
             prefix = name[: -len(f"-{arch}")]
             return prefix, arch
-    print(f"Error: Cannot detect architecture from directory name: {name}", file=sys.stderr)
+    print(
+        f"Error: Cannot detect architecture from directory name: {name}",
+        file=sys.stderr,
+    )
     print("Expected format: <distro>-<arch> (e.g., el10-x86_64)", file=sys.stderr)
     sys.exit(1)
 
@@ -344,7 +361,8 @@ def build_repo_args(version: str, baseos: str) -> list[str]:
     if minor > 0:
         update_url = f"{repo_base_url}/{major}/update.{version}/{baseos}"
         args += [
-            "--latest-limit", "1",
+            "--latest-limit",
+            "1",
             f"--repofrompath=ohpc-update,{update_url}",
             "--repoid=ohpc-update",
         ]
@@ -352,33 +370,46 @@ def build_repo_args(version: str, baseos: str) -> list[str]:
     return args
 
 
-def dnf_repoquery(query_format: str, pattern: str, version: str,
-                   baseos: str, arch: str) -> str:
+def dnf_repoquery(
+    query_format: str, pattern: str, version: str, baseos: str, arch: str
+) -> str:
     """Run dnf repoquery with proper repo pinning and arch filtering.
 
     Raises SystemExit on failure.
     """
     arch_query = f"{arch},noarch"
     cmd = [
-        "dnf", "repoquery",
+        "dnf",
+        "repoquery",
         f"--arch={arch_query}",
         *build_repo_args(version, baseos),
         f"--queryformat={query_format}",
         pattern,
     ]
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, check=True,
-                                env={**__import__('os').environ, "LC_COLLATE": "C"})
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=True,
+            env={**__import__("os").environ, "LC_COLLATE": "C"},
+        )
         return result.stdout
     except subprocess.CalledProcessError as e:
-        print(f"Error: dnf repoquery failed", file=sys.stderr)
+        print("Error: dnf repoquery failed", file=sys.stderr)
         print(f"Command: {' '.join(cmd)}", file=sys.stderr)
         if e.stderr:
             print(f"Error output: {e.stderr}", file=sys.stderr)
         sys.exit(1)
     except FileNotFoundError:
-        print("Error: dnf not found. Must run on a system with dnf installed.", file=sys.stderr)
-        print("For macOS with Lima: lima python3 generate_manifest.py ... --generate-all", file=sys.stderr)
+        print(
+            "Error: dnf not found. Must run on a system with dnf installed.",
+            file=sys.stderr,
+        )
+        print(
+            "For macOS with Lima: lima python3 generate_manifest.py ... --generate-all",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
 
@@ -408,15 +439,22 @@ def generate_all_files(manifest_dir: Path, version: str) -> None:
 
     # Build aarch64 skip pattern
     skip_patterns = _CONFIG.get("aarch64_skip_patterns", [])
-    skip_re = re.compile("|".join(skip_patterns)) if arch == "aarch64" and skip_patterns else None
+    skip_re = (
+        re.compile("|".join(skip_patterns))
+        if arch == "aarch64" and skip_patterns
+        else None
+    )
     if skip_re:
         print(f"  Excluding aarch64-incompatible packages: {', '.join(skip_patterns)}")
 
     # --- Generate pkg-ohpc.all ---
     print("Querying packages...")
     raw = dnf_repoquery(
-        "%{Name} %{Version} %{URL} %{Group} %{Summary}\\n", "*",
-        version, baseos, arch,
+        "%{Name} %{Version} %{URL} %{Group} %{Summary}\\n",
+        "*",
+        version,
+        baseos,
+        arch,
     )
 
     # Filter: only *-ohpc packages, apply skip patterns, sort
@@ -431,8 +469,11 @@ def generate_all_files(manifest_dir: Path, version: str) -> None:
 
     # Also include ohpc-release
     release_raw = dnf_repoquery(
-        "%{Name} %{Version} %{URL} %{Group} %{Summary}\\n", "ohpc-release",
-        version, baseos, arch,
+        "%{Name} %{Version} %{URL} %{Group} %{Summary}\\n",
+        "ohpc-release",
+        version,
+        baseos,
+        arch,
     )
     for line in release_raw.splitlines():
         line = line.strip()
@@ -449,8 +490,11 @@ def generate_all_files(manifest_dir: Path, version: str) -> None:
     # --- Generate meta-ohpc.all ---
     print("Querying meta-packages...")
     raw = dnf_repoquery(
-        "%{Name} %{Group} %{Description}\\n", "ohpc*",
-        version, baseos, arch,
+        "%{Name} %{Group} %{Description}\\n",
+        "ohpc*",
+        version,
+        baseos,
+        arch,
     )
 
     # Filter: ohpc/meta-package group, extract name + description
@@ -474,6 +518,7 @@ def generate_all_files(manifest_dir: Path, version: str) -> None:
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
+
 
 def main():
     parser = argparse.ArgumentParser(

--- a/docs/install/mkdoc.py
+++ b/docs/install/mkdoc.py
@@ -21,7 +21,14 @@ import traceback
 from pathlib import Path
 
 import yaml
-from jinja2 import Environment, FileSystemLoader, StrictUndefined, TemplateSyntaxError, TemplateRuntimeError, UndefinedError
+from jinja2 import (
+    Environment,
+    FileSystemLoader,
+    StrictUndefined,
+    TemplateSyntaxError,
+    TemplateRuntimeError,
+    UndefinedError,
+)
 from jinja2.ext import Extension
 
 BASE_DIR = Path(__file__).resolve().parent
@@ -30,6 +37,7 @@ BASE_DIR = Path(__file__).resolve().parent
 # ---------------------------------------------------------------------------
 # Configuration Loading
 # ---------------------------------------------------------------------------
+
 
 def load_yaml(path: Path) -> dict:
     """Load a YAML file."""
@@ -43,6 +51,7 @@ def load_yaml(path: Path) -> dict:
 # ---------------------------------------------------------------------------
 # Template Rendering
 # ---------------------------------------------------------------------------
+
 
 class SectionCommentExtension(Extension):
     """Inject <!-- +section: path --> ... <!-- -section --> comments around every {% include %}."""
@@ -98,7 +107,7 @@ def render_template(
         if tb:
             # Find the first frame in a template file (not in mkdoc.py)
             for frame in reversed(tb):
-                if frame.filename.endswith('.j2') or 'template' in frame.filename:
+                if frame.filename.endswith(".j2") or "template" in frame.filename:
                     print(f"Error in {frame.filename}", file=sys.stderr)
                     print(f"  Line {frame.lineno}: {str(e)}", file=sys.stderr)
                     break
@@ -125,7 +134,7 @@ def check_line_lengths(content: str, max_length: int = 87) -> int:
         stripped = line.rstrip()
 
         # Track current section from comment markers
-        match = re.match(r'<!-- [+-]section: (.+?) -->', stripped)
+        match = re.match(r"<!-- [+-]section: (.+?) -->", stripped)
         if match:
             current_section = match.group(1)
             section_start_lineno = lineno
@@ -209,7 +218,7 @@ def extract_recipe_script(content: str) -> str:
 
     for line in content.split("\n"):
         # Pass through section markers
-        match = re.search(r'<!-- ([+-])section: (.+) -->', line)
+        match = re.search(r"<!-- ([+-])section: (.+) -->", line)
         if match:
             where, section = match.groups()
             lines.append(f"# --- {where}section: {section} ---")
@@ -242,17 +251,20 @@ def extract_recipe_script(content: str) -> str:
         else:
             # Warn if an ohpc_ directive is missing its closing -->
             if line.startswith("<!-- ohpc_") and line[-3:] != "-->":
-                print(f"Error: ohpc directive missing closing -->: {line}", file=sys.stderr)
+                print(
+                    f"Error: ohpc directive missing closing -->: {line}",
+                    file=sys.stderr,
+                )
                 sys.exit(1)
             # ohpc_if_set: shorthand for enable_* boolean flags (check before ohpc_if)
-            match = re.search(r'<!-- ohpc_if_set (\S+) -->', line)
+            match = re.search(r"<!-- ohpc_if_set (\S+) -->", line)
             if match:
                 lines.append(f'if [[ "${{{match.group(1)}}}" -eq 1 ]];then')
                 continue
             # ohpc_if: general condition
-            match = re.search(r'<!-- ohpc_if (.+) -->', line)
+            match = re.search(r"<!-- ohpc_if (.+) -->", line)
             if match:
-                lines.append(f'if {match.group(1)};then')
+                lines.append(f"if {match.group(1)};then")
                 continue
             if "<!-- ohpc_else -->" in line:
                 lines.append("else")
@@ -261,12 +273,12 @@ def extract_recipe_script(content: str) -> str:
                 lines.append("fi")
                 continue
             # ohpc_command: raw shell line
-            match = re.search(r'<!-- ohpc_command (.+) -->', line)
+            match = re.search(r"<!-- ohpc_command (.+) -->", line)
             if match:
                 lines.append(match.group(1).rstrip())
                 continue
             # ohpc_comment: shell comment line
-            match = re.search(r'<!-- ohpc_comment (.+) -->', line)
+            match = re.search(r"<!-- ohpc_comment (.+) -->", line)
             if match:
                 comment = match.group(1).replace("'", "'\\''")
                 lines.append(f"echo '--- {comment}'")
@@ -289,7 +301,10 @@ def extract_recipe_script(content: str) -> str:
 # Main Build Function
 # ---------------------------------------------------------------------------
 
-def resolve_output(flag, suffix: str, config_path: Path, build_dir: Path) -> Path | None:
+
+def resolve_output(
+    flag, suffix: str, config_path: Path, build_dir: Path
+) -> Path | None:
     """Resolve an output flag: True -> default path, Path -> as-is, None -> skip."""
     if flag is True:
         build_dir.mkdir(exist_ok=True)
@@ -381,8 +396,10 @@ def parse_output_flag(args, with_name: str, path_name: str) -> Path | bool | Non
     with_flag = getattr(args, with_name)
     path_flag = getattr(args, path_name)
     if with_flag and path_flag:
-        print(f"Error: --{with_name.replace('_', '-')} and --{path_name} are mutually exclusive",
-              file=sys.stderr)
+        print(
+            f"Error: --{with_name.replace('_', '-')} and --{path_name} are mutually exclusive",
+            file=sys.stderr,
+        )
         sys.exit(1)
     if with_flag:
         return True  # sentinel: use default path in build/
@@ -438,7 +455,7 @@ Examples:
     config_path = Path(args.config).resolve()
     markdown_output = Path(args.markdown) if args.markdown else None
 
-    print(f'=== mkdoc.py {args.config} ===')
+    print(f"=== mkdoc.py {args.config} ===")
     build(
         config_path=config_path,
         markdown_output=markdown_output,

--- a/docs/install/wraptext.py
+++ b/docs/install/wraptext.py
@@ -16,39 +16,43 @@ import textwrap
 from pathlib import Path
 
 WIDTH = 80
-LIST_RE = re.compile(r'^(\s*)([-*+]|\d+\.)\s+')
+LIST_RE = re.compile(r"^(\s*)([-*+]|\d+\.)\s+")
 
 
 def is_verbatim(line: str) -> bool:
     """Return True for lines that must be output as-is (not accumulated)."""
     s = line.strip()
     return (
-        not s                          # empty (handled separately)
-        or s.startswith('```')
-        or s.startswith('<!--')
-        or s.startswith('{%')
-        or s.startswith('{#')
-        or s.startswith('|')
-        or s.startswith('#')
-        or s.startswith('\\')
-        or s.startswith(':::')
+        not s  # empty (handled separately)
+        or s.startswith("```")
+        or s.startswith("<!--")
+        or s.startswith("{%")
+        or s.startswith("{#")
+        or s.startswith("|")
+        or s.startswith("#")
+        or s.startswith("\\")
+        or s.startswith(":::")
     )
 
 
 def wrap_block(lines: list[str], prefix: str | None) -> str:
     """Join accumulated lines and re-wrap to WIDTH."""
-    text = ' '.join(line.strip() for line in lines if line.strip())
+    text = " ".join(line.strip() for line in lines if line.strip())
     if prefix is None:
         return textwrap.fill(
-            text, width=WIDTH,
-            break_long_words=False, break_on_hyphens=False,
+            text,
+            width=WIDTH,
+            break_long_words=False,
+            break_on_hyphens=False,
         )
-    subsequent = ' ' * len(prefix)
+    subsequent = " " * len(prefix)
     return textwrap.fill(
-        text, width=WIDTH,
+        text,
+        width=WIDTH,
         initial_indent=prefix,
         subsequent_indent=subsequent,
-        break_long_words=False, break_on_hyphens=False,
+        break_long_words=False,
+        break_on_hyphens=False,
     )
 
 
@@ -57,31 +61,31 @@ def process(content: str) -> str:
     in_code = False
     in_comment = False
 
-    buf: list[str] = []       # accumulated lines for current block
+    buf: list[str] = []  # accumulated lines for current block
     prefix: str | None = None  # None = paragraph, str = list item prefix
 
     def flush():
         nonlocal buf, prefix
         if buf:
-            result.append(wrap_block(buf, prefix) + '\n')
+            result.append(wrap_block(buf, prefix) + "\n")
         buf = []
         prefix = None
 
     for raw in content.splitlines(keepends=True):
-        line = raw.rstrip('\n')
+        line = raw.rstrip("\n")
         stripped = line.strip()
 
         # --- Inside fenced code block ---
         if in_code:
             result.append(raw)
-            if stripped.startswith('```'):
+            if stripped.startswith("```"):
                 in_code = False
             continue
 
         # --- Inside multi-line HTML comment ---
         if in_comment:
             result.append(raw)
-            if '-->' in line:
+            if "-->" in line:
                 in_comment = False
             continue
 
@@ -92,17 +96,17 @@ def process(content: str) -> str:
             continue
 
         # --- Code fence open ---
-        if stripped.startswith('```'):
+        if stripped.startswith("```"):
             flush()
             in_code = True
             result.append(raw)
             continue
 
         # --- HTML comment open ---
-        if stripped.startswith('<!--'):
+        if stripped.startswith("<!--"):
             flush()
             result.append(raw)
-            if '-->' not in line:
+            if "-->" not in line:
                 in_comment = True
             continue
 
@@ -116,14 +120,14 @@ def process(content: str) -> str:
         m = LIST_RE.match(line)
         if m:
             flush()
-            item_prefix = m.group(0)   # e.g. "* " or "  1. "
-            text = line[len(item_prefix):]
+            item_prefix = m.group(0)  # e.g. "* " or "  1. "
+            text = line[len(item_prefix) :]
             buf = [text]
             prefix = item_prefix
             continue
 
         # --- Continuation of list item (indented, not a new marker) ---
-        if prefix is not None and line.startswith(' ' * len(prefix)):
+        if prefix is not None and line.startswith(" " * len(prefix)):
             if not LIST_RE.match(line):
                 buf.append(line)
                 continue
@@ -131,7 +135,7 @@ def process(content: str) -> str:
             flush()
             m2 = LIST_RE.match(line)
             item_prefix = m2.group(0)
-            buf = [line[len(item_prefix):]]
+            buf = [line[len(item_prefix) :]]
             prefix = item_prefix
             continue
 
@@ -141,15 +145,15 @@ def process(content: str) -> str:
         buf.append(line)
 
     flush()
-    return ''.join(result)
+    return "".join(result)
 
 
 def main() -> None:
-    check_only = '--check' in sys.argv
-    paths = [a for a in sys.argv[1:] if not a.startswith('--')]
+    check_only = "--check" in sys.argv
+    paths = [a for a in sys.argv[1:] if not a.startswith("--")]
 
     if not paths:
-        print(f'Usage: {sys.argv[0]} <file.md.j2> [--check]', file=sys.stderr)
+        print(f"Usage: {sys.argv[0]} <file.md.j2> [--check]", file=sys.stderr)
         sys.exit(1)
 
     changed = False
@@ -160,14 +164,14 @@ def main() -> None:
         if wrapped != original:
             changed = True
             if check_only:
-                print(f'would change: {path}')
+                print(f"would change: {path}")
             else:
                 path.write_text(wrapped)
-                print(f'wrapped: {path}')
+                print(f"wrapped: {path}")
 
     if check_only and changed:
         sys.exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tests/ci/Makefile
+++ b/tests/ci/Makefile
@@ -119,7 +119,10 @@ ruff-check-lint:
 		../../misc/build_order.py \
 		../../misc/check_for_package_updates.py \
 		../../tests/ci/spec_to_test_mapping.py \
-		../../tests/dev-tools/numpy/tests/MM.py
+		../../tests/dev-tools/numpy/tests/MM.py \
+		../../docs/install/generate_manifest.py \
+		../../docs/install/mkdoc.py \
+		../../docs/install/wraptext.py
 
 ruff-format-lint:
 	@echo "Running 'ruff format' on selected Python files"
@@ -130,7 +133,10 @@ ruff-format-lint:
 		../../misc/build_order.py \
 		../../misc/check_for_package_updates.py \
 		../../tests/ci/spec_to_test_mapping.py \
-		../../tests/dev-tools/numpy/tests/MM.py
+		../../tests/dev-tools/numpy/tests/MM.py \
+		../../docs/install/generate_manifest.py \
+		../../docs/install/mkdoc.py \
+		../../docs/install/wraptext.py
 
 whitespace-lint:
 	@echo "Checking spec files for trailing whitespaces"


### PR DESCRIPTION
Add generate_manifest.py, mkdoc.py, and wraptext.py to the ruff-check-lint and ruff-format-lint targets in tests/ci/Makefile. Fix ruff F541 (f-string without placeholders) in
generate_manifest.py and apply ruff formatting to all three files.

Generated with Claude Code (https://claude.ai/code)