### PR TITLE
docs: improve package manifest table formatting

### DIFF
--- a/docs/install/generate_manifest.py
+++ b/docs/install/generate_manifest.py
@@ -50,6 +50,7 @@ _CONFIG = load_config()
 # Load configuration into module-level constants
 COMPILER_FAMILIES = _CONFIG["compiler_families"]
 MPI_FAMILIES = _CONFIG["mpi_families"]
+BUILD_VARIANTS = _CONFIG.get("build_variants", [])
 EXCLUDE_PACKAGES = set(_CONFIG["exclude_packages"])
 CATEGORY_ORDER = list(_CONFIG["categories"].items())
 
@@ -71,6 +72,7 @@ class Package:
 @dataclass
 class PackageGroup:
     names: list[str]
+    base_name: str
     version: str
     url: str
     summary: str
@@ -171,6 +173,7 @@ def group_packages(packages: list[Package]) -> list[PackageGroup]:
             groups.append(
                 PackageGroup(
                     [pkg.name],
+                    pkg.name,
                     pkg.version,
                     pkg.url,
                     pkg.summary,
@@ -200,6 +203,7 @@ def group_packages(packages: list[Package]) -> list[PackageGroup]:
         groups.append(
             PackageGroup(
                 variant_names,
+                base,
                 pkg.version,
                 pkg.url,
                 pkg.summary,
@@ -231,22 +235,61 @@ def format_url(url: str) -> str:
     return f"[{url}]({url})"
 
 
+def strip_ohpc_suffix(name: str) -> str:
+    """Remove the -ohpc suffix from a package name, if present."""
+    if name.endswith("-ohpc"):
+        return name[: -len("-ohpc")]
+    return name
+
+
+def display_name(group: PackageGroup) -> str:
+    """Compute the display name for a package group.
+
+    For family groups (multiple variants), strips the -ohpc suffix and
+    any build variant infixes (ofi, ucx, pmix) from the base name.
+    For single packages, just strips the -ohpc suffix.
+    """
+    name = strip_ohpc_suffix(group.base_name)
+    for variant in BUILD_VARIANTS:
+        suffix = f"-{variant}"
+        if name.endswith(suffix):
+            name = name[: -len(suffix)]
+    return name
+
+
+def merge_groups(groups: list[PackageGroup]) -> list[PackageGroup]:
+    """Merge consecutive groups that share the same display name and version."""
+    if not groups:
+        return []
+    merged: list[PackageGroup] = [groups[0]]
+    for group in groups[1:]:
+        prev = merged[-1]
+        if display_name(group) == display_name(prev) and group.version == prev.version:
+            # Merge into previous group, keeping its metadata
+            prev.names.extend(group.names)
+        else:
+            merged.append(group)
+    return merged
+
+
 def generate_package_table(groups: list[PackageGroup]) -> str:
     """Generate a markdown table from PackageGroups."""
     if not groups:
         return ""
 
+    groups = merge_groups(groups)
+
     lines = [
         "| **RPM Package Name** | **Version** | **Info/URL** |",
-        "|----------------------|-------------|--------------|",
+        "|------|--|------------|",
     ]
 
     for group in groups:
-        names_cell = "<br>".join(group.names)
+        name = display_name(group)
         summary = format_summary(group.summary)
         url = format_url(group.url)
         info = f"{summary} {url}".rstrip()
-        lines.append(f"| {names_cell} | {group.version} | {info} |")
+        lines.append(f"| {name} | {group.version} | {info} |")
 
     return "\n".join(lines)
 
@@ -258,7 +301,7 @@ def generate_meta_table(patterns: list[tuple[str, str]]) -> str:
 
     lines = [
         "| **Group Name** | **Description** |",
-        "|----------------|----------------|",
+        "|-------|-------------|",
     ]
 
     for name, description in patterns:

--- a/docs/install/manifests/config.yaml
+++ b/docs/install/manifests/config.yaml
@@ -38,6 +38,12 @@ mpi_families:
   - impi
   - mpich
 
+# Build variant infixes stripped from display names (e.g. mpich-ofi -> mpich)
+build_variants:
+  - ofi
+  - ucx
+  - pmix
+
 # Packages to exclude from manifest generation
 exclude_packages:
   - slurm-sjstat-ohpc

--- a/docs/install/manifests/el10-aarch64/meta-ohpc.md
+++ b/docs/install/manifests/el10-aarch64/meta-ohpc.md
@@ -1,5 +1,5 @@
 | **Group Name** | **Description** |
-|----------------|----------------|
+|-------|-------------|
 | ohpc-arm1-io-libs | Collection of IO library builds for use with the Arm Compiler for Linux toolchain. |
 | ohpc-arm1-mpich-parallel-libs | Collection of parallel library builds for use with the Arm Compiler for Linux and the MPICH runtime. |
 | ohpc-arm1-openmpi5-parallel-libs | Collection of parallel library builds for use with the Arm Compiler for Linux and the openmpi5 runtime. |

--- a/docs/install/manifests/el10-aarch64/pkg-ohpc.md.j2
+++ b/docs/install/manifests/el10-aarch64/pkg-ohpc.md.j2
@@ -2,20 +2,21 @@
 ### Administrative Tools
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| conman-ohpc | 0.3.1 | ConMan: The Console Manager. [http://dun.github.io/conman](http://dun.github.io/conman) |
-| docs-ohpc | 4.0.0 | OpenHPC documentation. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| examples-ohpc | 2.0 | Example source code and templates for use within OpenHPC environment. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| genders-ohpc | 1.32 | Static cluster configuration database. [https://github.com/chaos/genders](https://github.com/chaos/genders) |
-| hpc-workspace-ohpc | 1.5.0 | Temporary workspace management. [https://github.com/holgerBerger/hpc-workspace](https://github.com/holgerBerger/hpc-workspace) |
-| lmod-defaults-gnu15-mpich-ohpc<br>lmod-defaults-gnu15-openmpi5-ohpc | 2.0 | OpenHPC default login environments. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| lmod-ohpc | 8.7.64 | Lua based Modules (lmod). [https://github.com/TACC/Lmod](https://github.com/TACC/Lmod) |
-| losf-ohpc | 0.56.0 | A Linux operating system framework for managing HPC clusters. [https://github.com/hpcsi/losf](https://github.com/hpcsi/losf) |
-| nhc-ohpc | 1.4.3 | LBNL Node Health Check. [https://github.com/mej/nhc](https://github.com/mej/nhc) |
+|------|--|------------|
+| conman | 0.3.1 | ConMan: The Console Manager. [http://dun.github.io/conman](http://dun.github.io/conman) |
+| docs | 4.0.0 | OpenHPC documentation. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| examples | 2.0 | Example source code and templates for use within OpenHPC environment. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| genders | 1.32 | Static cluster configuration database. [https://github.com/chaos/genders](https://github.com/chaos/genders) |
+| hpc-workspace | 1.5.0 | Temporary workspace management. [https://github.com/holgerBerger/hpc-workspace](https://github.com/holgerBerger/hpc-workspace) |
+| lmod-defaults | 2.0 | OpenHPC default login environments. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| lmod | 9.2 | Lua based Modules (lmod). [https://github.com/TACC/Lmod](https://github.com/TACC/Lmod) |
+| losf | 0.56.0 | A Linux operating system framework for managing HPC clusters. [https://github.com/hpcsi/losf](https://github.com/hpcsi/losf) |
+| mdtoc | 1.4.0 | Markdown table-of-contents generator. [https://github.com/kubernetes-sigs/mdtoc](https://github.com/kubernetes-sigs/mdtoc) |
+| nhc | 1.4.3 | LBNL Node Health Check. [https://github.com/mej/nhc](https://github.com/mej/nhc) |
 | ohpc-release | 4 | OpenHPC release files. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| pdsh-ohpc | 2.35 | Parallel remote shell program. [https://github.com/chaos/pdsh](https://github.com/chaos/pdsh) |
-| prun-ohpc | 2.2 | Convenience utility for parallel job launch. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| test-suite-ohpc | 4.0.0 | Integration test suite for OpenHPC. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| pdsh | 2.36 | Parallel remote shell program. [https://github.com/chaos/pdsh](https://github.com/chaos/pdsh) |
+| prun | 2.2 | Convenience utility for parallel job launch. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| test-suite | 4.0.0 | Integration test suite for OpenHPC. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
 
 {% endif %}
 
@@ -23,10 +24,10 @@
 ### Provisioning
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| warewulf-ohpc | 4.6.4 | A provisioning system for large clusters of bare metal and/or virtual systems. [https://github.com/warewulf/warewulf](https://github.com/warewulf/warewulf) |
-| warewulf-ohpc-dracut | 4.6.4 | dracut module for loading a Warewulf image. [https://github.com/warewulf/warewulf](https://github.com/warewulf/warewulf) |
-| warewulf-ohpc-sos | 4.6.4 | sos plugin for Warewulf. [https://github.com/warewulf/warewulf](https://github.com/warewulf/warewulf) |
+|------|--|------------|
+| warewulf | 4.6.5 | A provisioning system for large clusters of bare metal and/or virtual systems. [https://github.com/warewulf/warewulf](https://github.com/warewulf/warewulf) |
+| warewulf-ohpc-dracut | 4.6.5 | dracut module for loading a Warewulf image. [https://github.com/warewulf/warewulf](https://github.com/warewulf/warewulf) |
+| warewulf-ohpc-sos | 4.6.5 | sos plugin for Warewulf. [https://github.com/warewulf/warewulf](https://github.com/warewulf/warewulf) |
 
 {% endif %}
 
@@ -34,26 +35,26 @@
 ### Resource Management
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| magpie-ohpc | 3.0 | Scripts for running Big Data software in HPC environments. [https://github.com/LLNL/magpie](https://github.com/LLNL/magpie) |
-| openpbs-client-ohpc | 23.06.06 | OpenPBS for a client host. [http://www.openpbs.org](http://www.openpbs.org) |
-| openpbs-execution-ohpc | 23.06.06 | OpenPBS for an execution host. [http://www.openpbs.org](http://www.openpbs.org) |
-| openpbs-server-ohpc | 23.06.06 | OpenPBS for a server host. [http://www.openpbs.org](http://www.openpbs.org) |
-| pmix-ohpc | 4.2.9 | An extended/exascale implementation of PMI. [https://pmix.github.io/pmix](https://pmix.github.io/pmix) |
-| slurm-contribs-ohpc | 25.05.3 | Perl tool to print Slurm job state information. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-devel-ohpc | 25.05.3 | Development package for Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-example-configs-ohpc | 25.05.3 | Example config files for Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-libpmi-ohpc | 25.05.3 | Slurm\'s implementation of the pmi libraries. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-ohpc | 25.05.3 | Slurm Workload Manager. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-openlava-ohpc | 25.05.3 | openlava/LSF wrappers for transition from OpenLava/LSF to Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-pam_slurm-ohpc | 25.05.3 | PAM module for restricting access to compute nodes via Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-perlapi-ohpc | 25.05.3 | Perl API to Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-sackd-ohpc | 25.05.3 | Slurm authentication daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-slurmctld-ohpc | 25.05.3 | Slurm controller daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-slurmd-ohpc | 25.05.3 | Slurm compute node daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-slurmdbd-ohpc | 25.05.3 | Slurm database daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-sview-ohpc | 25.05.3 | Graphical user interface to view and modify Slurm state. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-torque-ohpc | 25.05.3 | Torque/PBS wrappers for transition from Torque/PBS to Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+|------|--|------------|
+| magpie | 3.2 | Scripts for running Big Data software in HPC environments. [https://github.com/LLNL/magpie](https://github.com/LLNL/magpie) |
+| openpbs-client | 23.06.06 | OpenPBS for a client host. [http://www.openpbs.org](http://www.openpbs.org) |
+| openpbs-execution | 23.06.06 | OpenPBS for an execution host. [http://www.openpbs.org](http://www.openpbs.org) |
+| openpbs-server | 23.06.06 | OpenPBS for a server host. [http://www.openpbs.org](http://www.openpbs.org) |
+| pmix | 4.2.9 | An extended/exascale implementation of PMI. [https://pmix.org](https://pmix.org) |
+| slurm-contribs | 25.05.7 | Perl tool to print Slurm job state information. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-devel | 25.05.7 | Development package for Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-example-configs | 25.05.7 | Example config files for Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-libpmi | 25.05.7 | Slurm\'s implementation of the pmi libraries. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm | 25.05.7 | Slurm Workload Manager. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-openlava | 25.05.7 | openlava/LSF wrappers for transition from OpenLava/LSF to Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-pam_slurm | 25.05.7 | PAM module for restricting access to compute nodes via Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-perlapi | 25.05.7 | Perl API to Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-sackd | 25.05.7 | Slurm authentication daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-slurmctld | 25.05.7 | Slurm controller daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-slurmd | 25.05.7 | Slurm compute node daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-slurmdbd | 25.05.7 | Slurm database daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-sview | 25.05.7 | Graphical user interface to view and modify Slurm state. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-torque | 25.05.7 | Torque/PBS wrappers for transition from Torque/PBS to Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
 
 {% endif %}
 
@@ -61,8 +62,8 @@
 ### Compiler Families
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| gnu15-compilers-ohpc | 15.1.0 | The GNU C Compiler and Support Files. [http://gcc.gnu.org](http://gcc.gnu.org) |
+|------|--|------------|
+| gnu15-compilers | 15.2.0 | The GNU C Compiler and Support Files. [http://gcc.gnu.org](http://gcc.gnu.org) |
 
 {% endif %}
 
@@ -70,11 +71,10 @@
 ### MPI Families / Communication Libraries
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| mpich-ofi-gnu15-ohpc | 3.4.3 | MPICH MPI implementation. [http://www.mpich.org](http://www.mpich.org) |
-| mpich-ucx-gnu15-ohpc | 3.4.3 | MPICH MPI implementation. [http://www.mpich.org](http://www.mpich.org) |
-| openmpi5-gnu15-ohpc<br>openmpi5-pmix-gnu15-ohpc | 5.0.8 | A powerful implementation of MPI/SHMEM. [http://www.open-mpi.org](http://www.open-mpi.org) |
-| ucx-ohpc | 1.18.0 | UCX is a communication library implementing high-performance messaging. [http://www.openucx.org](http://www.openucx.org) |
+|------|--|------------|
+| mpich | 5.0.1 | MPICH MPI implementation. [http://www.mpich.org](http://www.mpich.org) |
+| openmpi5 | 5.0.10 | A powerful implementation of MPI/SHMEM. [http://www.open-mpi.org](http://www.open-mpi.org) |
+| ucx | 1.20.0 | UCX is a communication library implementing high-performance messaging. [http://www.openucx.org](http://www.openucx.org) |
 
 {% endif %}
 
@@ -82,17 +82,17 @@
 ### Development Tools
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| EasyBuild-ohpc | 5.1.2 | Software build and installation framework. [https://easybuilders.github.io/easybuild](https://easybuilders.github.io/easybuild) |
-| autoconf-ohpc | 2.71 | A GNU tool for automatically configuring source code. [http://www.gnu.org/software/autoconf](http://www.gnu.org/software/autoconf) |
-| automake-ohpc | 1.16.5 | A GNU tool for automatically creating Makefiles. [http://www.gnu.org/software/automake](http://www.gnu.org/software/automake) |
-| cmake-ohpc | 4.1.2 | CMake is an open-source, cross-platform family of tools designed to build, test and package software. [https://cmake.org](https://cmake.org) |
-| hwloc-ohpc | 2.12.1 | Portable Hardware Locality. [http://www.open-mpi.org/projects/hwloc](http://www.open-mpi.org/projects/hwloc) |
-| libtool-ohpc | 2.4.6 | The GNU Portable Library Tool. [http://www.gnu.org/software/libtool](http://www.gnu.org/software/libtool) |
-| python3-mpi4py-gnu15-mpich-ohpc<br>python3-mpi4py-gnu15-openmpi5-ohpc | 3.1.5 | Python bindings for the Message Passing Interface (MPI) standard. [https://github.com/mpi4py/mpi4py](https://github.com/mpi4py/mpi4py) |
-| python3-numpy-gnu15-ohpc | 1.26.4 | NumPy array processing for numbers, strings, records and objects. [https://github.com/numpy/numpy](https://github.com/numpy/numpy) |
-| spack-ohpc | 1.0.1 | HPC software package management. [https://github.com/spack/spack](https://github.com/spack/spack) |
-| valgrind-ohpc | 3.25.1 | Valgrind Memory Debugger. [http://www.valgrind.org](http://www.valgrind.org) |
+|------|--|------------|
+| EasyBuild | 5.3.0 | Software build and installation framework. [https://easybuilders.github.io/easybuild](https://easybuilders.github.io/easybuild) |
+| autoconf | 2.71 | A GNU tool for automatically configuring source code. [http://www.gnu.org/software/autoconf](http://www.gnu.org/software/autoconf) |
+| automake | 1.16.5 | A GNU tool for automatically creating Makefiles. [http://www.gnu.org/software/automake](http://www.gnu.org/software/automake) |
+| cmake | 4.3.1 | CMake is an open-source, cross-platform family of tools designed to build, test and package software. [https://cmake.org](https://cmake.org) |
+| hwloc | 2.13.0 | Portable Hardware Locality. [http://www.open-mpi.org/projects/hwloc](http://www.open-mpi.org/projects/hwloc) |
+| libtool | 2.4.6 | The GNU Portable Library Tool. [http://www.gnu.org/software/libtool](http://www.gnu.org/software/libtool) |
+| python3-mpi4py | 4.1.1 | Python bindings for the Message Passing Interface (MPI) standard. [https://github.com/mpi4py/mpi4py](https://github.com/mpi4py/mpi4py) |
+| python3-numpy | 2.4.4 | NumPy array processing for numbers, strings, records and objects. [https://github.com/numpy/numpy](https://github.com/numpy/numpy) |
+| spack | 1.1.1 | HPC software package management. [https://github.com/spack/spack](https://github.com/spack/spack) |
+| valgrind | 3.26.0 | Valgrind Memory Debugger. [http://www.valgrind.org](http://www.valgrind.org) |
 
 {% endif %}
 
@@ -100,16 +100,18 @@
 ### Performance Analysis Tools
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| dimemas-gnu15-mpich-ohpc<br>dimemas-gnu15-openmpi5-ohpc | 5.4.2 | Dimemas tool. [https://tools.bsc.es](https://tools.bsc.es) |
-| extrae-gnu15-mpich-ohpc<br>extrae-gnu15-openmpi5-ohpc | 3.8.3 | Extrae tool. [https://tools.bsc.es](https://tools.bsc.es) |
-| imb-gnu15-mpich-ohpc<br>imb-gnu15-openmpi5-ohpc | 2021.3 | Intel MPI Benchmarks (IMB). [https://software.intel.com/en-us/articles/intel-mpi-benchmarks](https://software.intel.com/en-us/articles/intel-mpi-benchmarks) |
-| omb-gnu15-mpich-ohpc<br>omb-gnu15-openmpi5-ohpc | 7.5 | OSU Micro-benchmarks. [https://mvapich.cse.ohio-state.edu/benchmarks](https://mvapich.cse.ohio-state.edu/benchmarks) |
-| papi-ohpc | 7.2.0 | Performance Application Programming Interface. [http://icl.cs.utk.edu/papi](http://icl.cs.utk.edu/papi) |
-| pdtoolkit-gnu15-ohpc | 3.25.1 | PDT is a framework for analyzing source code. [http://www.cs.uoregon.edu/Research/pdt](http://www.cs.uoregon.edu/Research/pdt) |
-| scalasca-gnu15-mpich-ohpc<br>scalasca-gnu15-openmpi5-ohpc | 2.6.2 | Toolset for performance analysis of large-scale parallel applications. [http://www.scalasca.org](http://www.scalasca.org) |
-| scorep-gnu15-mpich-ohpc<br>scorep-gnu15-openmpi5-ohpc | 9.3 | Scalable Performance Measurement Infrastructure for Parallel Codes. [http://www.vi-hps.org/projects/score-p](http://www.vi-hps.org/projects/score-p) |
-| tau-gnu15-mpich-ohpc<br>tau-gnu15-openmpi5-ohpc | 2.34.1 | Tuning and Analysis Utilities Profiling Package. [http://www.cs.uoregon.edu/research/tau/home.php](http://www.cs.uoregon.edu/research/tau/home.php) |
+|------|--|------------|
+| dimemas | 5.5.0 | Dimemas tool. [https://tools.bsc.es](https://tools.bsc.es) |
+| extrae | 5.0.3 | Extrae tool. [https://tools.bsc.es](https://tools.bsc.es) |
+| imb | 2021.11 | Intel MPI Benchmarks (IMB). [https://software.intel.com/en-us/articles/intel-mpi-benchmarks](https://software.intel.com/en-us/articles/intel-mpi-benchmarks) |
+| likwid | 5.5.1 | Performance tools for the Linux console. [https://github.com/RRZE-HPC/likwid](https://github.com/RRZE-HPC/likwid) |
+| omb | 7.5.2 | OSU Micro-benchmarks. [https://mvapich.cse.ohio-state.edu/benchmarks](https://mvapich.cse.ohio-state.edu/benchmarks) |
+| papi | 7.2.0 | Performance Application Programming Interface. [http://icl.cs.utk.edu/papi](http://icl.cs.utk.edu/papi) |
+| paraver | 4.12.0 | Paraver. [https://tools.bsc.es](https://tools.bsc.es) |
+| pdtoolkit | 3.25.1 | PDT is a framework for analyzing source code. [http://www.cs.uoregon.edu/Research/pdt](http://www.cs.uoregon.edu/Research/pdt) |
+| scalasca | 2.6.2 | Toolset for performance analysis of large-scale parallel applications. [http://www.scalasca.org](http://www.scalasca.org) |
+| scorep | 9.4 | Scalable Performance Measurement Infrastructure for Parallel Codes. [http://www.vi-hps.org/projects/score-p](http://www.vi-hps.org/projects/score-p) |
+| tau | 2.35.1 | Tuning and Analysis Utilities Profiling Package. [http://www.cs.uoregon.edu/research/tau/home.php](http://www.cs.uoregon.edu/research/tau/home.php) |
 
 {% endif %}
 
@@ -117,17 +119,17 @@
 ### IO Libraries
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| adios2-gnu15-mpich-ohpc<br>adios2-gnu15-openmpi5-ohpc | 2.10.2 | The Adaptable IO System v2 (ADIOS2). [https://adios2.readthedocs.io/en/latest/index.html](https://adios2.readthedocs.io/en/latest/index.html) |
-| cubew-gnu15-ohpc | 4.9 | CUBE Uniform Behavioral Encoding generic presentation writer component. [http://www.scalasca.org/software/cube-4.x/download.html](http://www.scalasca.org/software/cube-4.x/download.html) |
-| hdf5-gnu15-ohpc | 1.14.6 | A general purpose library and file format for storing scientific data. [http://www.hdfgroup.org/HDF5](http://www.hdfgroup.org/HDF5) |
-| netcdf-cxx-gnu15-mpich-ohpc<br>netcdf-cxx-gnu15-ohpc<br>netcdf-cxx-gnu15-openmpi5-ohpc | 4.3.1 | C++ Libraries for the Unidata network Common Data Form. [http://www.unidata.ucar.edu/software/netcdf](http://www.unidata.ucar.edu/software/netcdf) |
-| netcdf-fortran-gnu15-mpich-ohpc<br>netcdf-fortran-gnu15-ohpc<br>netcdf-fortran-gnu15-openmpi5-ohpc | 4.6.2 | Fortran Libraries for the Unidata network Common Data Form. [http://www.unidata.ucar.edu/software/netcdf](http://www.unidata.ucar.edu/software/netcdf) |
-| netcdf-gnu15-mpich-ohpc<br>netcdf-gnu15-ohpc<br>netcdf-gnu15-openmpi5-ohpc | 4.9.3 | C Libraries for the Unidata network Common Data Form. [http://www.unidata.ucar.edu/software/netcdf](http://www.unidata.ucar.edu/software/netcdf) |
-| otf2-gnu15-mpich-ohpc<br>otf2-gnu15-openmpi5-ohpc | 3.1.1 | Open Trace Format 2 library. [http://score-p.org](http://score-p.org) |
-| phdf5-gnu15-mpich-ohpc<br>phdf5-gnu15-openmpi5-ohpc | 1.14.6 | A general purpose library and file format for storing scientific data. [http://www.hdfgroup.org/HDF5](http://www.hdfgroup.org/HDF5) |
-| pnetcdf-gnu15-mpich-ohpc<br>pnetcdf-gnu15-openmpi5-ohpc | 1.14.0 | A Parallel NetCDF library (PnetCDF). [http://cucis.ece.northwestern.edu/projects/PnetCDF](http://cucis.ece.northwestern.edu/projects/PnetCDF) |
-| sionlib-gnu15-mpich-ohpc<br>sionlib-gnu15-openmpi5-ohpc | 1.7.7 | Scalable I/O Library for Parallel Access to Task-Local Files. [https://apps.fz-juelich.de/jsc/sionlib/docu/index.html](https://apps.fz-juelich.de/jsc/sionlib/docu/index.html) |
+|------|--|------------|
+| adios2 | 2.11.0 | The Adaptable IO System v2 (ADIOS2). [https://adios2.readthedocs.io/en/latest/index.html](https://adios2.readthedocs.io/en/latest/index.html) |
+| cubew | 4.9.1 | CUBE Uniform Behavioral Encoding generic presentation writer component. [http://www.scalasca.org/software/cube-4.x/download.html](http://www.scalasca.org/software/cube-4.x/download.html) |
+| hdf5 | 2.1.1 | A general purpose library and file format for storing scientific data. [http://www.hdfgroup.org/HDF5](http://www.hdfgroup.org/HDF5) |
+| netcdf-cxx | 4.3.1 | C++ Libraries for the Unidata network Common Data Form. [http://www.unidata.ucar.edu/software/netcdf](http://www.unidata.ucar.edu/software/netcdf) |
+| netcdf-fortran | 4.6.2 | Fortran Libraries for the Unidata network Common Data Form. [http://www.unidata.ucar.edu/software/netcdf](http://www.unidata.ucar.edu/software/netcdf) |
+| netcdf | 4.10.0 | C Libraries for the Unidata network Common Data Form. [http://www.unidata.ucar.edu/software/netcdf](http://www.unidata.ucar.edu/software/netcdf) |
+| otf2 | 3.1.1 | Open Trace Format 2 library. [http://score-p.org](http://score-p.org) |
+| phdf5 | 2.1.1 | A general purpose library and file format for storing scientific data (parallel version). [http://www.hdfgroup.org/HDF5](http://www.hdfgroup.org/HDF5) |
+| pnetcdf | 1.14.1 | A Parallel NetCDF library (PnetCDF). [http://cucis.ece.northwestern.edu/projects/PnetCDF](http://cucis.ece.northwestern.edu/projects/PnetCDF) |
+| sionlib | 1.7.7 | Scalable I/O Library for Parallel Access to Task-Local Files. [https://apps.fz-juelich.de/jsc/sionlib/docu/index.html](https://apps.fz-juelich.de/jsc/sionlib/docu/index.html) |
 
 {% endif %}
 
@@ -135,8 +137,8 @@
 ### Distro Packages
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| python3-Cython-ohpc | 0.29.37 | The Cython compiler for writing C extensions for the Python language. [http://www.cython.org](http://www.cython.org) |
+|------|--|------------|
+| python3-Cython | 3.2.4 | The Cython compiler for writing C extensions for the Python language. [http://www.cython.org](http://www.cython.org) |
 
 {% endif %}
 
@@ -144,8 +146,8 @@
 ### Runtimes
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| charliecloud-ohpc | 0.40 | Lightweight user-defined software stacks for high-performance computing. [https://charliecloud.io](https://charliecloud.io) |
+|------|--|------------|
+| charliecloud | 0.44 | Lightweight user-defined software stacks for high-performance computing. [https://charliecloud.io](https://charliecloud.io) |
 
 {% endif %}
 
@@ -153,17 +155,17 @@
 ### Serial/Threaded Libraries
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| R-gnu15-ohpc | 4.5.0 | R is a language and environment for statistical computing and graphics (S-Plus like). [http://www.r-project.org](http://www.r-project.org) |
-| cubelib-gnu15-ohpc | 4.9 | CUBE Uniform Behavioral Encoding generic presentation library component. [http://www.scalasca.org/software/cube-4.x/download.html](http://www.scalasca.org/software/cube-4.x/download.html) |
-| gotcha-gnu15-ohpc | 1.0.8 | A library for wrapping function calls to shared libraries. [https://github.com/llnl/gotcha](https://github.com/llnl/gotcha) |
-| gsl-gnu15-ohpc | 2.8 | GNU Scientific Library (GSL). [http://www.gnu.org/software/gsl](http://www.gnu.org/software/gsl) |
-| metis-gnu15-ohpc | 5.1.0 | Serial Graph Partitioning and Fill-reducing Matrix Ordering. [http://glaros.dtc.umn.edu/gkhome/metis/metis/overview](http://glaros.dtc.umn.edu/gkhome/metis/metis/overview) |
-| opari2-gnu15-ohpc | 2.0.9 | An OpenMP runtime performance measurement instrumenter. [https://www.vi-hps.org/projects/score-p](https://www.vi-hps.org/projects/score-p) |
-| openblas-gnu15-ohpc | 0.3.29 | An optimized BLAS library based on GotoBLAS2. [http://www.openblas.net](http://www.openblas.net) |
-| plasma-gnu15-ohpc | 24.8.7 | Parallel Linear Algebra Software for Multicore Architectures. [https://github.com/icl-utk-edu/plasma](https://github.com/icl-utk-edu/plasma) |
-| scotch-gnu15-ohpc | 7.0.7 | Graph, mesh and hypergraph partitioning library. [https://gitlab.inria.fr/scotch/scotch](https://gitlab.inria.fr/scotch/scotch) |
-| superlu-gnu15-ohpc | 7.0.0 | A general purpose library for the direct solution of linear equations. [http://crd.lbl.gov/~xiaoye/SuperLU](http://crd.lbl.gov/~xiaoye/SuperLU) |
+|------|--|------------|
+| R | 4.5.3 | R is a language and environment for statistical computing and graphics (S-Plus like). [http://www.r-project.org](http://www.r-project.org) |
+| cubelib | 4.9.1 | CUBE Uniform Behavioral Encoding generic presentation library component. [http://www.scalasca.org/software/cube-4.x/download.html](http://www.scalasca.org/software/cube-4.x/download.html) |
+| gotcha | 1.0.8 | A library for wrapping function calls to shared libraries. [https://github.com/llnl/gotcha](https://github.com/llnl/gotcha) |
+| gsl | 2.8 | GNU Scientific Library (GSL). [http://www.gnu.org/software/gsl](http://www.gnu.org/software/gsl) |
+| metis | 5.1.0 | Serial Graph Partitioning and Fill-reducing Matrix Ordering. [http://glaros.dtc.umn.edu/gkhome/metis/metis/overview](http://glaros.dtc.umn.edu/gkhome/metis/metis/overview) |
+| opari2 | 2.0.9 | An OpenMP runtime performance measurement instrumenter. [https://www.vi-hps.org/projects/score-p](https://www.vi-hps.org/projects/score-p) |
+| openblas | 0.3.32 | An optimized BLAS library based on GotoBLAS2. [http://www.openblas.net](http://www.openblas.net) |
+| plasma | 25.5.27 | Parallel Linear Algebra Software for Multicore Architectures. [https://github.com/icl-utk-edu/plasma](https://github.com/icl-utk-edu/plasma) |
+| scotch | 7.0.11 | Graph, mesh and hypergraph partitioning library. [https://gitlab.inria.fr/scotch/scotch](https://gitlab.inria.fr/scotch/scotch) |
+| superlu | 7.0.1 | A general purpose library for the direct solution of linear equations. [http://crd.lbl.gov/~xiaoye/SuperLU](http://crd.lbl.gov/~xiaoye/SuperLU) |
 
 {% endif %}
 
@@ -171,18 +173,18 @@
 ### Parallel Libraries
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| boost-gnu15-mpich-ohpc<br>boost-gnu15-openmpi5-ohpc | 1.88.0 | Free peer-reviewed portable C++ source libraries. [http://www.boost.org](http://www.boost.org) |
-| fftw-gnu15-mpich-ohpc<br>fftw-gnu15-openmpi5-ohpc | 3.3.10 | A Fast Fourier Transform library. [http://www.fftw.org](http://www.fftw.org) |
-| hypre-gnu15-mpich-ohpc<br>hypre-gnu15-openmpi5-ohpc | 2.33.0 | Scalable algorithms for solving linear systems of equations. [http://www.llnl.gov/casc/hypre](http://www.llnl.gov/casc/hypre) |
-| mfem-gnu15-mpich-ohpc<br>mfem-gnu15-openmpi5-ohpc | 4.4 | Lightweight, general, scalable C++ library for finite element methods. [http://mfem.org](http://mfem.org) |
-| mumps-gnu15-mpich-ohpc<br>mumps-gnu15-openmpi5-ohpc | 5.8.1 | A MUltifrontal Massively Parallel Sparse direct Solver. [https://mumps-solver.org](https://mumps-solver.org) |
-| petsc-gnu15-mpich-ohpc<br>petsc-gnu15-openmpi5-ohpc | 3.23.5 | Portable Extensible Toolkit for Scientific Computation. [http://www.mcs.anl.gov/petsc](http://www.mcs.anl.gov/petsc) |
-| ptscotch-gnu15-mpich-ohpc<br>ptscotch-gnu15-openmpi5-ohpc | 7.0.7 | Graph, mesh and hypergraph partitioning library using MPI. [http://www.labri.fr/perso/pelegrin/scotch](http://www.labri.fr/perso/pelegrin/scotch) |
-| scalapack-gnu15-mpich-ohpc<br>scalapack-gnu15-openmpi5-ohpc | 2.2.2 | A subset of LAPACK routines redesigned for heterogeneous computing. [https://netlib.org/scalapack](https://netlib.org/scalapack) |
-| slepc-gnu15-mpich-ohpc<br>slepc-gnu15-openmpi5-ohpc | 3.23.0 | A library for solving large scale sparse eigenvalue problems. [http://slepc.upv.es](http://slepc.upv.es) |
-| superlu_dist-gnu15-mpich-ohpc<br>superlu_dist-gnu15-openmpi5-ohpc | 6.4.0 | A general purpose library for the direct solution of linear equations. [https://portal.nersc.gov/project/sparse/superlu](https://portal.nersc.gov/project/sparse/superlu) |
-| trilinos-gnu15-mpich-ohpc<br>trilinos-gnu15-openmpi5-ohpc | 16.1.0 | A collection of libraries of numerical algorithms. [https://trilinos.org](https://trilinos.org) |
+|------|--|------------|
+| boost | 1.90.0 | Free peer-reviewed portable C++ source libraries. [http://www.boost.org](http://www.boost.org) |
+| fftw | 3.3.10 | A Fast Fourier Transform library. [http://www.fftw.org](http://www.fftw.org) |
+| hypre | 3.1.0 | Scalable algorithms for solving linear systems of equations. [http://www.llnl.gov/casc/hypre](http://www.llnl.gov/casc/hypre) |
+| mfem | 4.9 | Lightweight, general, scalable C++ library for finite element methods. [http://mfem.org](http://mfem.org) |
+| mumps | 5.8.2 | A MUltifrontal Massively Parallel Sparse direct Solver. [https://mumps-solver.org](https://mumps-solver.org) |
+| petsc | 3.25.0 | Portable Extensible Toolkit for Scientific Computation. [http://www.mcs.anl.gov/petsc](http://www.mcs.anl.gov/petsc) |
+| ptscotch | 7.0.11 | Graph, mesh and hypergraph partitioning library using MPI. [https://gitlab.inria.fr/scotch/scotch](https://gitlab.inria.fr/scotch/scotch) |
+| scalapack | 2.2.3 | A subset of LAPACK routines redesigned for heterogeneous computing. [https://netlib.org/scalapack](https://netlib.org/scalapack) |
+| slepc | 3.25.0 | A library for solving large scale sparse eigenvalue problems. [http://slepc.upv.es](http://slepc.upv.es) |
+| superlu_dist | 9.2.1 | A general purpose library for the direct solution of linear equations. [https://portal.nersc.gov/project/sparse/superlu](https://portal.nersc.gov/project/sparse/superlu) |
+| trilinos | 17.0.0 | A collection of libraries of numerical algorithms. [https://trilinos.org](https://trilinos.org) |
 
 {% endif %}
 

--- a/docs/install/manifests/el10-x86_64/meta-ohpc.md
+++ b/docs/install/manifests/el10-x86_64/meta-ohpc.md
@@ -1,5 +1,5 @@
 | **Group Name** | **Description** |
-|----------------|----------------|
+|-------|-------------|
 | ohpc-autotools | Collection of GNU autotools packages. |
 | ohpc-base | Collection of base packages. |
 | ohpc-base-compute | Collection of compute node base packages. |

--- a/docs/install/manifests/el10-x86_64/pkg-ohpc.md.j2
+++ b/docs/install/manifests/el10-x86_64/pkg-ohpc.md.j2
@@ -2,20 +2,21 @@
 ### Administrative Tools
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| conman-ohpc | 0.3.1 | ConMan: The Console Manager. [http://dun.github.io/conman](http://dun.github.io/conman) |
-| docs-ohpc | 4.0.0 | OpenHPC documentation. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| examples-ohpc | 2.0 | Example source code and templates for use within OpenHPC environment. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| genders-ohpc | 1.32 | Static cluster configuration database. [https://github.com/chaos/genders](https://github.com/chaos/genders) |
-| hpc-workspace-ohpc | 1.5.0 | Temporary workspace management. [https://github.com/holgerBerger/hpc-workspace](https://github.com/holgerBerger/hpc-workspace) |
-| lmod-defaults-gnu15-impi-ohpc<br>lmod-defaults-gnu15-mpich-ohpc<br>lmod-defaults-gnu15-mvapich2-ohpc<br>lmod-defaults-gnu15-openmpi5-ohpc<br>lmod-defaults-intel-impi-ohpc<br>lmod-defaults-intel-mpich-ohpc<br>lmod-defaults-intel-mvapich2-ohpc<br>lmod-defaults-intel-openmpi5-ohpc | 2.0 | OpenHPC default login environments. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| lmod-ohpc | 8.7.64 | Lua based Modules (lmod). [https://github.com/TACC/Lmod](https://github.com/TACC/Lmod) |
-| losf-ohpc | 0.56.0 | A Linux operating system framework for managing HPC clusters. [https://github.com/hpcsi/losf](https://github.com/hpcsi/losf) |
-| nhc-ohpc | 1.4.3 | LBNL Node Health Check. [https://github.com/mej/nhc](https://github.com/mej/nhc) |
+|------|--|------------|
+| conman | 0.3.1 | ConMan: The Console Manager. [http://dun.github.io/conman](http://dun.github.io/conman) |
+| docs | 4.0.0 | OpenHPC documentation. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| examples | 2.0 | Example source code and templates for use within OpenHPC environment. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| genders | 1.32 | Static cluster configuration database. [https://github.com/chaos/genders](https://github.com/chaos/genders) |
+| hpc-workspace | 1.5.0 | Temporary workspace management. [https://github.com/holgerBerger/hpc-workspace](https://github.com/holgerBerger/hpc-workspace) |
+| lmod-defaults | 2.0 | OpenHPC default login environments. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| lmod | 9.2 | Lua based Modules (lmod). [https://github.com/TACC/Lmod](https://github.com/TACC/Lmod) |
+| losf | 0.56.0 | A Linux operating system framework for managing HPC clusters. [https://github.com/hpcsi/losf](https://github.com/hpcsi/losf) |
+| mdtoc | 1.4.0 | Markdown table-of-contents generator. [https://github.com/kubernetes-sigs/mdtoc](https://github.com/kubernetes-sigs/mdtoc) |
+| nhc | 1.4.3 | LBNL Node Health Check. [https://github.com/mej/nhc](https://github.com/mej/nhc) |
 | ohpc-release | 4 | OpenHPC release files. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| pdsh-ohpc | 2.35 | Parallel remote shell program. [https://github.com/chaos/pdsh](https://github.com/chaos/pdsh) |
-| prun-ohpc | 2.2 | Convenience utility for parallel job launch. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| test-suite-ohpc | 4.0.0 | Integration test suite for OpenHPC. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| pdsh | 2.36 | Parallel remote shell program. [https://github.com/chaos/pdsh](https://github.com/chaos/pdsh) |
+| prun | 2.2 | Convenience utility for parallel job launch. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| test-suite | 4.0.0 | Integration test suite for OpenHPC. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
 
 {% endif %}
 
@@ -23,10 +24,10 @@
 ### Provisioning
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| warewulf-ohpc | 4.6.4 | A provisioning system for large clusters of bare metal and/or virtual systems. [https://github.com/warewulf/warewulf](https://github.com/warewulf/warewulf) |
-| warewulf-ohpc-dracut | 4.6.4 | dracut module for loading a Warewulf image. [https://github.com/warewulf/warewulf](https://github.com/warewulf/warewulf) |
-| warewulf-ohpc-sos | 4.6.4 | sos plugin for Warewulf. [https://github.com/warewulf/warewulf](https://github.com/warewulf/warewulf) |
+|------|--|------------|
+| warewulf | 4.6.5 | A provisioning system for large clusters of bare metal and/or virtual systems. [https://github.com/warewulf/warewulf](https://github.com/warewulf/warewulf) |
+| warewulf-ohpc-dracut | 4.6.5 | dracut module for loading a Warewulf image. [https://github.com/warewulf/warewulf](https://github.com/warewulf/warewulf) |
+| warewulf-ohpc-sos | 4.6.5 | sos plugin for Warewulf. [https://github.com/warewulf/warewulf](https://github.com/warewulf/warewulf) |
 
 {% endif %}
 
@@ -34,26 +35,26 @@
 ### Resource Management
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| magpie-ohpc | 3.0 | Scripts for running Big Data software in HPC environments. [https://github.com/LLNL/magpie](https://github.com/LLNL/magpie) |
-| openpbs-client-ohpc | 23.06.06 | OpenPBS for a client host. [http://www.openpbs.org](http://www.openpbs.org) |
-| openpbs-execution-ohpc | 23.06.06 | OpenPBS for an execution host. [http://www.openpbs.org](http://www.openpbs.org) |
-| openpbs-server-ohpc | 23.06.06 | OpenPBS for a server host. [http://www.openpbs.org](http://www.openpbs.org) |
-| pmix-ohpc | 4.2.9 | An extended/exascale implementation of PMI. [https://pmix.github.io/pmix](https://pmix.github.io/pmix) |
-| slurm-contribs-ohpc | 25.05.3 | Perl tool to print Slurm job state information. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-devel-ohpc | 25.05.3 | Development package for Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-example-configs-ohpc | 25.05.3 | Example config files for Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-libpmi-ohpc | 25.05.3 | Slurm\'s implementation of the pmi libraries. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-ohpc | 25.05.3 | Slurm Workload Manager. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-openlava-ohpc | 25.05.3 | openlava/LSF wrappers for transition from OpenLava/LSF to Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-pam_slurm-ohpc | 25.05.3 | PAM module for restricting access to compute nodes via Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-perlapi-ohpc | 25.05.3 | Perl API to Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-sackd-ohpc | 25.05.3 | Slurm authentication daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-slurmctld-ohpc | 25.05.3 | Slurm controller daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-slurmd-ohpc | 25.05.3 | Slurm compute node daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-slurmdbd-ohpc | 25.05.3 | Slurm database daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-sview-ohpc | 25.05.3 | Graphical user interface to view and modify Slurm state. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-torque-ohpc | 25.05.3 | Torque/PBS wrappers for transition from Torque/PBS to Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+|------|--|------------|
+| magpie | 3.2 | Scripts for running Big Data software in HPC environments. [https://github.com/LLNL/magpie](https://github.com/LLNL/magpie) |
+| openpbs-client | 23.06.06 | OpenPBS for a client host. [http://www.openpbs.org](http://www.openpbs.org) |
+| openpbs-execution | 23.06.06 | OpenPBS for an execution host. [http://www.openpbs.org](http://www.openpbs.org) |
+| openpbs-server | 23.06.06 | OpenPBS for a server host. [http://www.openpbs.org](http://www.openpbs.org) |
+| pmix | 4.2.9 | An extended/exascale implementation of PMI. [https://pmix.org](https://pmix.org) |
+| slurm-contribs | 25.05.7 | Perl tool to print Slurm job state information. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-devel | 25.05.7 | Development package for Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-example-configs | 25.05.7 | Example config files for Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-libpmi | 25.05.7 | Slurm\'s implementation of the pmi libraries. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm | 25.05.7 | Slurm Workload Manager. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-openlava | 25.05.7 | openlava/LSF wrappers for transition from OpenLava/LSF to Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-pam_slurm | 25.05.7 | PAM module for restricting access to compute nodes via Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-perlapi | 25.05.7 | Perl API to Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-sackd | 25.05.7 | Slurm authentication daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-slurmctld | 25.05.7 | Slurm controller daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-slurmd | 25.05.7 | Slurm compute node daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-slurmdbd | 25.05.7 | Slurm database daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-sview | 25.05.7 | Graphical user interface to view and modify Slurm state. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-torque | 25.05.7 | Torque/PBS wrappers for transition from Torque/PBS to Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
 
 {% endif %}
 
@@ -61,10 +62,10 @@
 ### Compiler Families
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| gnu15-compilers-ohpc | 15.1.0 | The GNU C Compiler and Support Files. [http://gcc.gnu.org](http://gcc.gnu.org) |
-| intel-compilers-devel-ohpc | 2025.0 | OpenHPC compatibility package for Intel(R) oneAPI HPC Toolkit. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| intel-oneapi-toolkit-release-ohpc | 2025.0 | Intel(R) oneAPI HPC Toolkit Repository Setup. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+|------|--|------------|
+| gnu15-compilers | 15.2.0 | The GNU C Compiler and Support Files. [http://gcc.gnu.org](http://gcc.gnu.org) |
+| intel-compilers-devel | 2025.0 | OpenHPC compatibility package for Intel(R) oneAPI HPC Toolkit. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| intel-oneapi-toolkit-release | 2025.0 | Intel(R) oneAPI HPC Toolkit Repository Setup. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
 
 {% endif %}
 
@@ -72,13 +73,12 @@
 ### MPI Families / Communication Libraries
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| intel-mpi-devel-ohpc | 2025.0 | OpenHPC compatibility package for Intel(R) oneAPI MPI Library. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| mpich-ofi-gnu15-ohpc<br>mpich-ofi-intel-ohpc | 3.4.3 | MPICH MPI implementation. [http://www.mpich.org](http://www.mpich.org) |
-| mpich-ucx-gnu15-ohpc<br>mpich-ucx-intel-ohpc | 3.4.3 | MPICH MPI implementation. [http://www.mpich.org](http://www.mpich.org) |
-| mvapich2-gnu15-ohpc<br>mvapich2-intel-ohpc | 2.3.7 | OSU MVAPICH2 MPI implementation. [http://mvapich.cse.ohio-state.edu](http://mvapich.cse.ohio-state.edu) |
-| openmpi5-gnu15-ohpc<br>openmpi5-intel-ohpc<br>openmpi5-pmix-gnu15-ohpc<br>openmpi5-pmix-intel-ohpc | 5.0.8 | A powerful implementation of MPI/SHMEM. [http://www.open-mpi.org](http://www.open-mpi.org) |
-| ucx-ohpc | 1.18.0 | UCX is a communication library implementing high-performance messaging. [http://www.openucx.org](http://www.openucx.org) |
+|------|--|------------|
+| intel-mpi-devel | 2025.0 | OpenHPC compatibility package for Intel(R) oneAPI MPI Library. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| mpich | 5.0.1 | MPICH MPI implementation. [http://www.mpich.org](http://www.mpich.org) |
+| mvapich2 | 4.1 | OSU MVAPICH2 MPI implementation. [http://mvapich.cse.ohio-state.edu](http://mvapich.cse.ohio-state.edu) |
+| openmpi5 | 5.0.10 | A powerful implementation of MPI/SHMEM. [http://www.open-mpi.org](http://www.open-mpi.org) |
+| ucx | 1.20.0 | UCX is a communication library implementing high-performance messaging. [http://www.openucx.org](http://www.openucx.org) |
 
 {% endif %}
 
@@ -86,19 +86,19 @@
 ### Development Tools
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| EasyBuild-ohpc | 5.1.2 | Software build and installation framework. [https://easybuilders.github.io/easybuild](https://easybuilders.github.io/easybuild) |
-| autoconf-ohpc | 2.71 | A GNU tool for automatically configuring source code. [http://www.gnu.org/software/autoconf](http://www.gnu.org/software/autoconf) |
-| automake-ohpc | 1.16.5 | A GNU tool for automatically creating Makefiles. [http://www.gnu.org/software/automake](http://www.gnu.org/software/automake) |
-| cmake-ohpc | 4.1.2 | CMake is an open-source, cross-platform family of tools designed to build, test and package software. [https://cmake.org](https://cmake.org) |
-| cuda-devel-ohpc | 25.9 | OpenHPC compatibility package for cuda. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| cuda-repo-ohpc | 25.9 | Cuda toolkit online repository. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| hwloc-ohpc | 2.12.1 | Portable Hardware Locality. [http://www.open-mpi.org/projects/hwloc](http://www.open-mpi.org/projects/hwloc) |
-| libtool-ohpc | 2.4.6 | The GNU Portable Library Tool. [http://www.gnu.org/software/libtool](http://www.gnu.org/software/libtool) |
-| python3-mpi4py-gnu15-impi-ohpc<br>python3-mpi4py-gnu15-mpich-ohpc<br>python3-mpi4py-gnu15-mvapich2-ohpc<br>python3-mpi4py-gnu15-openmpi5-ohpc<br>python3-mpi4py-intel-impi-ohpc<br>python3-mpi4py-intel-mpich-ohpc<br>python3-mpi4py-intel-mvapich2-ohpc<br>python3-mpi4py-intel-openmpi5-ohpc | 3.1.5 | Python bindings for the Message Passing Interface (MPI) standard. [https://github.com/mpi4py/mpi4py](https://github.com/mpi4py/mpi4py) |
-| python3-numpy-gnu15-ohpc<br>python3-numpy-intel-ohpc | 1.26.4 | NumPy array processing for numbers, strings, records and objects. [https://github.com/numpy/numpy](https://github.com/numpy/numpy) |
-| spack-ohpc | 1.0.1 | HPC software package management. [https://github.com/spack/spack](https://github.com/spack/spack) |
-| valgrind-ohpc | 3.25.1 | Valgrind Memory Debugger. [http://www.valgrind.org](http://www.valgrind.org) |
+|------|--|------------|
+| EasyBuild | 5.3.0 | Software build and installation framework. [https://easybuilders.github.io/easybuild](https://easybuilders.github.io/easybuild) |
+| autoconf | 2.71 | A GNU tool for automatically configuring source code. [http://www.gnu.org/software/autoconf](http://www.gnu.org/software/autoconf) |
+| automake | 1.16.5 | A GNU tool for automatically creating Makefiles. [http://www.gnu.org/software/automake](http://www.gnu.org/software/automake) |
+| cmake | 4.3.1 | CMake is an open-source, cross-platform family of tools designed to build, test and package software. [https://cmake.org](https://cmake.org) |
+| cuda-devel | 25.9 | OpenHPC compatibility package for cuda. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| cuda-repo | 25.9 | Cuda toolkit online repository. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| hwloc | 2.13.0 | Portable Hardware Locality. [http://www.open-mpi.org/projects/hwloc](http://www.open-mpi.org/projects/hwloc) |
+| libtool | 2.4.6 | The GNU Portable Library Tool. [http://www.gnu.org/software/libtool](http://www.gnu.org/software/libtool) |
+| python3-mpi4py | 4.1.1 | Python bindings for the Message Passing Interface (MPI) standard. [https://github.com/mpi4py/mpi4py](https://github.com/mpi4py/mpi4py) |
+| python3-numpy | 2.4.4 | NumPy array processing for numbers, strings, records and objects. [https://github.com/numpy/numpy](https://github.com/numpy/numpy) |
+| spack | 1.1.1 | HPC software package management. [https://github.com/spack/spack](https://github.com/spack/spack) |
+| valgrind | 3.26.0 | Valgrind Memory Debugger. [http://www.valgrind.org](http://www.valgrind.org) |
 
 {% endif %}
 
@@ -106,17 +106,18 @@
 ### Performance Analysis Tools
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| dimemas-gnu15-impi-ohpc<br>dimemas-gnu15-mpich-ohpc<br>dimemas-gnu15-mvapich2-ohpc<br>dimemas-gnu15-openmpi5-ohpc<br>dimemas-intel-impi-ohpc<br>dimemas-intel-mpich-ohpc<br>dimemas-intel-mvapich2-ohpc<br>dimemas-intel-openmpi5-ohpc | 5.4.2 | Dimemas tool. [https://tools.bsc.es](https://tools.bsc.es) |
-| extrae-gnu15-impi-ohpc<br>extrae-gnu15-mpich-ohpc<br>extrae-gnu15-mvapich2-ohpc<br>extrae-gnu15-openmpi5-ohpc<br>extrae-intel-impi-ohpc<br>extrae-intel-mpich-ohpc<br>extrae-intel-mvapich2-ohpc<br>extrae-intel-openmpi5-ohpc | 3.8.3 | Extrae tool. [https://tools.bsc.es](https://tools.bsc.es) |
-| imb-gnu15-impi-ohpc<br>imb-gnu15-mpich-ohpc<br>imb-gnu15-mvapich2-ohpc<br>imb-gnu15-openmpi5-ohpc<br>imb-intel-impi-ohpc<br>imb-intel-mpich-ohpc<br>imb-intel-mvapich2-ohpc<br>imb-intel-openmpi5-ohpc | 2021.3 | Intel MPI Benchmarks (IMB). [https://software.intel.com/en-us/articles/intel-mpi-benchmarks](https://software.intel.com/en-us/articles/intel-mpi-benchmarks) |
-| likwid-gnu15-ohpc<br>likwid-intel-ohpc | 5.4.1 | Performance tools for the Linux console. [https://github.com/RRZE-HPC/likwid](https://github.com/RRZE-HPC/likwid) |
-| omb-gnu15-impi-ohpc<br>omb-gnu15-mpich-ohpc<br>omb-gnu15-mvapich2-ohpc<br>omb-gnu15-openmpi5-ohpc<br>omb-intel-impi-ohpc<br>omb-intel-mpich-ohpc<br>omb-intel-mvapich2-ohpc<br>omb-intel-openmpi5-ohpc | 7.5 | OSU Micro-benchmarks. [https://mvapich.cse.ohio-state.edu/benchmarks](https://mvapich.cse.ohio-state.edu/benchmarks) |
-| papi-ohpc | 7.2.0 | Performance Application Programming Interface. [http://icl.cs.utk.edu/papi](http://icl.cs.utk.edu/papi) |
-| pdtoolkit-gnu15-ohpc<br>pdtoolkit-intel-ohpc | 3.25.1 | PDT is a framework for analyzing source code. [http://www.cs.uoregon.edu/Research/pdt](http://www.cs.uoregon.edu/Research/pdt) |
-| scalasca-gnu15-impi-ohpc<br>scalasca-gnu15-mpich-ohpc<br>scalasca-gnu15-mvapich2-ohpc<br>scalasca-gnu15-openmpi5-ohpc<br>scalasca-intel-impi-ohpc<br>scalasca-intel-mpich-ohpc<br>scalasca-intel-mvapich2-ohpc<br>scalasca-intel-openmpi5-ohpc | 2.6.2 | Toolset for performance analysis of large-scale parallel applications. [http://www.scalasca.org](http://www.scalasca.org) |
-| scorep-gnu15-impi-ohpc<br>scorep-gnu15-mpich-ohpc<br>scorep-gnu15-mvapich2-ohpc<br>scorep-gnu15-openmpi5-ohpc<br>scorep-intel-impi-ohpc<br>scorep-intel-mpich-ohpc<br>scorep-intel-mvapich2-ohpc<br>scorep-intel-openmpi5-ohpc | 9.3 | Scalable Performance Measurement Infrastructure for Parallel Codes. [http://www.vi-hps.org/projects/score-p](http://www.vi-hps.org/projects/score-p) |
-| tau-gnu15-impi-ohpc<br>tau-gnu15-mpich-ohpc<br>tau-gnu15-mvapich2-ohpc<br>tau-gnu15-openmpi5-ohpc<br>tau-intel-impi-ohpc<br>tau-intel-mpich-ohpc<br>tau-intel-mvapich2-ohpc<br>tau-intel-openmpi5-ohpc | 2.34.1 | Tuning and Analysis Utilities Profiling Package. [http://www.cs.uoregon.edu/research/tau/home.php](http://www.cs.uoregon.edu/research/tau/home.php) |
+|------|--|------------|
+| dimemas | 5.5.0 | Dimemas tool. [https://tools.bsc.es](https://tools.bsc.es) |
+| extrae | 5.0.3 | Extrae tool. [https://tools.bsc.es](https://tools.bsc.es) |
+| imb | 2021.11 | Intel MPI Benchmarks (IMB). [https://software.intel.com/en-us/articles/intel-mpi-benchmarks](https://software.intel.com/en-us/articles/intel-mpi-benchmarks) |
+| likwid | 5.5.1 | Performance tools for the Linux console. [https://github.com/RRZE-HPC/likwid](https://github.com/RRZE-HPC/likwid) |
+| omb | 7.5.2 | OSU Micro-benchmarks. [https://mvapich.cse.ohio-state.edu/benchmarks](https://mvapich.cse.ohio-state.edu/benchmarks) |
+| papi | 7.2.0 | Performance Application Programming Interface. [http://icl.cs.utk.edu/papi](http://icl.cs.utk.edu/papi) |
+| paraver | 4.12.0 | Paraver. [https://tools.bsc.es](https://tools.bsc.es) |
+| pdtoolkit | 3.25.1 | PDT is a framework for analyzing source code. [http://www.cs.uoregon.edu/Research/pdt](http://www.cs.uoregon.edu/Research/pdt) |
+| scalasca | 2.6.2 | Toolset for performance analysis of large-scale parallel applications. [http://www.scalasca.org](http://www.scalasca.org) |
+| scorep | 9.4 | Scalable Performance Measurement Infrastructure for Parallel Codes. [http://www.vi-hps.org/projects/score-p](http://www.vi-hps.org/projects/score-p) |
+| tau | 2.35.1 | Tuning and Analysis Utilities Profiling Package. [http://www.cs.uoregon.edu/research/tau/home.php](http://www.cs.uoregon.edu/research/tau/home.php) |
 
 {% endif %}
 
@@ -124,17 +125,17 @@
 ### IO Libraries
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| adios2-gnu15-impi-ohpc<br>adios2-gnu15-mpich-ohpc<br>adios2-gnu15-mvapich2-ohpc<br>adios2-gnu15-openmpi5-ohpc<br>adios2-intel-impi-ohpc<br>adios2-intel-mpich-ohpc<br>adios2-intel-mvapich2-ohpc<br>adios2-intel-openmpi5-ohpc | 2.10.2 | The Adaptable IO System v2 (ADIOS2). [https://adios2.readthedocs.io/en/latest/index.html](https://adios2.readthedocs.io/en/latest/index.html) |
-| cubew-gnu15-ohpc<br>cubew-intel-ohpc | 4.9 | CUBE Uniform Behavioral Encoding generic presentation writer component. [http://www.scalasca.org/software/cube-4.x/download.html](http://www.scalasca.org/software/cube-4.x/download.html) |
-| hdf5-gnu15-ohpc<br>hdf5-intel-ohpc | 1.14.6 | A general purpose library and file format for storing scientific data. [http://www.hdfgroup.org/HDF5](http://www.hdfgroup.org/HDF5) |
-| netcdf-cxx-gnu15-impi-ohpc<br>netcdf-cxx-gnu15-mpich-ohpc<br>netcdf-cxx-gnu15-mvapich2-ohpc<br>netcdf-cxx-gnu15-ohpc<br>netcdf-cxx-gnu15-openmpi5-ohpc<br>netcdf-cxx-intel-impi-ohpc<br>netcdf-cxx-intel-mpich-ohpc<br>netcdf-cxx-intel-mvapich2-ohpc<br>netcdf-cxx-intel-ohpc<br>netcdf-cxx-intel-openmpi5-ohpc | 4.3.1 | C++ Libraries for the Unidata network Common Data Form. [http://www.unidata.ucar.edu/software/netcdf](http://www.unidata.ucar.edu/software/netcdf) |
-| netcdf-fortran-gnu15-impi-ohpc<br>netcdf-fortran-gnu15-mpich-ohpc<br>netcdf-fortran-gnu15-mvapich2-ohpc<br>netcdf-fortran-gnu15-ohpc<br>netcdf-fortran-gnu15-openmpi5-ohpc<br>netcdf-fortran-intel-impi-ohpc<br>netcdf-fortran-intel-mpich-ohpc<br>netcdf-fortran-intel-mvapich2-ohpc<br>netcdf-fortran-intel-ohpc<br>netcdf-fortran-intel-openmpi5-ohpc | 4.6.2 | Fortran Libraries for the Unidata network Common Data Form. [http://www.unidata.ucar.edu/software/netcdf](http://www.unidata.ucar.edu/software/netcdf) |
-| netcdf-gnu15-impi-ohpc<br>netcdf-gnu15-mpich-ohpc<br>netcdf-gnu15-mvapich2-ohpc<br>netcdf-gnu15-ohpc<br>netcdf-gnu15-openmpi5-ohpc<br>netcdf-intel-impi-ohpc<br>netcdf-intel-mpich-ohpc<br>netcdf-intel-mvapich2-ohpc<br>netcdf-intel-ohpc<br>netcdf-intel-openmpi5-ohpc | 4.9.3 | C Libraries for the Unidata network Common Data Form. [http://www.unidata.ucar.edu/software/netcdf](http://www.unidata.ucar.edu/software/netcdf) |
-| otf2-gnu15-impi-ohpc<br>otf2-gnu15-mpich-ohpc<br>otf2-gnu15-mvapich2-ohpc<br>otf2-gnu15-openmpi5-ohpc<br>otf2-intel-impi-ohpc<br>otf2-intel-mpich-ohpc<br>otf2-intel-mvapich2-ohpc<br>otf2-intel-openmpi5-ohpc | 3.1.1 | Open Trace Format 2 library. [http://score-p.org](http://score-p.org) |
-| phdf5-gnu15-impi-ohpc<br>phdf5-gnu15-mpich-ohpc<br>phdf5-gnu15-mvapich2-ohpc<br>phdf5-gnu15-openmpi5-ohpc<br>phdf5-intel-impi-ohpc<br>phdf5-intel-mpich-ohpc<br>phdf5-intel-mvapich2-ohpc<br>phdf5-intel-openmpi5-ohpc | 1.14.6 | A general purpose library and file format for storing scientific data. [http://www.hdfgroup.org/HDF5](http://www.hdfgroup.org/HDF5) |
-| pnetcdf-gnu15-impi-ohpc<br>pnetcdf-gnu15-mpich-ohpc<br>pnetcdf-gnu15-mvapich2-ohpc<br>pnetcdf-gnu15-openmpi5-ohpc<br>pnetcdf-intel-impi-ohpc<br>pnetcdf-intel-mpich-ohpc<br>pnetcdf-intel-mvapich2-ohpc<br>pnetcdf-intel-openmpi5-ohpc | 1.14.0 | A Parallel NetCDF library (PnetCDF). [http://cucis.ece.northwestern.edu/projects/PnetCDF](http://cucis.ece.northwestern.edu/projects/PnetCDF) |
-| sionlib-gnu15-impi-ohpc<br>sionlib-gnu15-mpich-ohpc<br>sionlib-gnu15-mvapich2-ohpc<br>sionlib-gnu15-openmpi5-ohpc<br>sionlib-intel-impi-ohpc<br>sionlib-intel-mpich-ohpc<br>sionlib-intel-mvapich2-ohpc<br>sionlib-intel-openmpi5-ohpc | 1.7.7 | Scalable I/O Library for Parallel Access to Task-Local Files. [https://apps.fz-juelich.de/jsc/sionlib/docu/index.html](https://apps.fz-juelich.de/jsc/sionlib/docu/index.html) |
+|------|--|------------|
+| adios2 | 2.11.0 | The Adaptable IO System v2 (ADIOS2). [https://adios2.readthedocs.io/en/latest/index.html](https://adios2.readthedocs.io/en/latest/index.html) |
+| cubew | 4.9.1 | CUBE Uniform Behavioral Encoding generic presentation writer component. [http://www.scalasca.org/software/cube-4.x/download.html](http://www.scalasca.org/software/cube-4.x/download.html) |
+| hdf5 | 2.1.1 | A general purpose library and file format for storing scientific data. [http://www.hdfgroup.org/HDF5](http://www.hdfgroup.org/HDF5) |
+| netcdf-cxx | 4.3.1 | C++ Libraries for the Unidata network Common Data Form. [http://www.unidata.ucar.edu/software/netcdf](http://www.unidata.ucar.edu/software/netcdf) |
+| netcdf-fortran | 4.6.2 | Fortran Libraries for the Unidata network Common Data Form. [http://www.unidata.ucar.edu/software/netcdf](http://www.unidata.ucar.edu/software/netcdf) |
+| netcdf | 4.10.0 | C Libraries for the Unidata network Common Data Form. [http://www.unidata.ucar.edu/software/netcdf](http://www.unidata.ucar.edu/software/netcdf) |
+| otf2 | 3.1.1 | Open Trace Format 2 library. [http://score-p.org](http://score-p.org) |
+| phdf5 | 2.1.1 | A general purpose library and file format for storing scientific data (parallel version). [http://www.hdfgroup.org/HDF5](http://www.hdfgroup.org/HDF5) |
+| pnetcdf | 1.14.1 | A Parallel NetCDF library (PnetCDF). [http://cucis.ece.northwestern.edu/projects/PnetCDF](http://cucis.ece.northwestern.edu/projects/PnetCDF) |
+| sionlib | 1.7.7 | Scalable I/O Library for Parallel Access to Task-Local Files. [https://apps.fz-juelich.de/jsc/sionlib/docu/index.html](https://apps.fz-juelich.de/jsc/sionlib/docu/index.html) |
 
 {% endif %}
 
@@ -142,8 +143,8 @@
 ### Distro Packages
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| python3-Cython-ohpc | 0.29.37 | The Cython compiler for writing C extensions for the Python language. [http://www.cython.org](http://www.cython.org) |
+|------|--|------------|
+| python3-Cython | 3.2.4 | The Cython compiler for writing C extensions for the Python language. [http://www.cython.org](http://www.cython.org) |
 
 {% endif %}
 
@@ -151,8 +152,8 @@
 ### Runtimes
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| charliecloud-ohpc | 0.40 | Lightweight user-defined software stacks for high-performance computing. [https://charliecloud.io](https://charliecloud.io) |
+|------|--|------------|
+| charliecloud | 0.44 | Lightweight user-defined software stacks for high-performance computing. [https://charliecloud.io](https://charliecloud.io) |
 
 {% endif %}
 
@@ -160,17 +161,17 @@
 ### Serial/Threaded Libraries
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| R-gnu15-ohpc | 4.5.0 | R is a language and environment for statistical computing and graphics (S-Plus like). [http://www.r-project.org](http://www.r-project.org) |
-| cubelib-gnu15-ohpc<br>cubelib-intel-ohpc | 4.9 | CUBE Uniform Behavioral Encoding generic presentation library component. [http://www.scalasca.org/software/cube-4.x/download.html](http://www.scalasca.org/software/cube-4.x/download.html) |
-| gotcha-gnu15-ohpc<br>gotcha-intel-ohpc | 1.0.8 | A library for wrapping function calls to shared libraries. [https://github.com/llnl/gotcha](https://github.com/llnl/gotcha) |
-| gsl-gnu15-ohpc<br>gsl-intel-ohpc | 2.8 | GNU Scientific Library (GSL). [http://www.gnu.org/software/gsl](http://www.gnu.org/software/gsl) |
-| metis-gnu15-ohpc<br>metis-intel-ohpc | 5.1.0 | Serial Graph Partitioning and Fill-reducing Matrix Ordering. [http://glaros.dtc.umn.edu/gkhome/metis/metis/overview](http://glaros.dtc.umn.edu/gkhome/metis/metis/overview) |
-| opari2-gnu15-ohpc<br>opari2-intel-ohpc | 2.0.9 | An OpenMP runtime performance measurement instrumenter. [https://www.vi-hps.org/projects/score-p](https://www.vi-hps.org/projects/score-p) |
-| openblas-gnu15-ohpc | 0.3.29 | An optimized BLAS library based on GotoBLAS2. [http://www.openblas.net](http://www.openblas.net) |
-| plasma-gnu15-ohpc<br>plasma-intel-ohpc | 24.8.7 | Parallel Linear Algebra Software for Multicore Architectures. [https://github.com/icl-utk-edu/plasma](https://github.com/icl-utk-edu/plasma) |
-| scotch-gnu15-ohpc<br>scotch-intel-ohpc | 7.0.7 | Graph, mesh and hypergraph partitioning library. [https://gitlab.inria.fr/scotch/scotch](https://gitlab.inria.fr/scotch/scotch) |
-| superlu-gnu15-ohpc<br>superlu-intel-ohpc | 7.0.0 | A general purpose library for the direct solution of linear equations. [http://crd.lbl.gov/~xiaoye/SuperLU](http://crd.lbl.gov/~xiaoye/SuperLU) |
+|------|--|------------|
+| R | 4.5.3 | R is a language and environment for statistical computing and graphics (S-Plus like). [http://www.r-project.org](http://www.r-project.org) |
+| cubelib | 4.9.1 | CUBE Uniform Behavioral Encoding generic presentation library component. [http://www.scalasca.org/software/cube-4.x/download.html](http://www.scalasca.org/software/cube-4.x/download.html) |
+| gotcha | 1.0.8 | A library for wrapping function calls to shared libraries. [https://github.com/llnl/gotcha](https://github.com/llnl/gotcha) |
+| gsl | 2.8 | GNU Scientific Library (GSL). [http://www.gnu.org/software/gsl](http://www.gnu.org/software/gsl) |
+| metis | 5.1.0 | Serial Graph Partitioning and Fill-reducing Matrix Ordering. [http://glaros.dtc.umn.edu/gkhome/metis/metis/overview](http://glaros.dtc.umn.edu/gkhome/metis/metis/overview) |
+| opari2 | 2.0.9 | An OpenMP runtime performance measurement instrumenter. [https://www.vi-hps.org/projects/score-p](https://www.vi-hps.org/projects/score-p) |
+| openblas | 0.3.32 | An optimized BLAS library based on GotoBLAS2. [http://www.openblas.net](http://www.openblas.net) |
+| plasma | 25.5.27 | Parallel Linear Algebra Software for Multicore Architectures. [https://github.com/icl-utk-edu/plasma](https://github.com/icl-utk-edu/plasma) |
+| scotch | 7.0.11 | Graph, mesh and hypergraph partitioning library. [https://gitlab.inria.fr/scotch/scotch](https://gitlab.inria.fr/scotch/scotch) |
+| superlu | 7.0.1 | A general purpose library for the direct solution of linear equations. [http://crd.lbl.gov/~xiaoye/SuperLU](http://crd.lbl.gov/~xiaoye/SuperLU) |
 
 {% endif %}
 
@@ -178,18 +179,18 @@
 ### Parallel Libraries
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| boost-gnu15-impi-ohpc<br>boost-gnu15-mpich-ohpc<br>boost-gnu15-mvapich2-ohpc<br>boost-gnu15-openmpi5-ohpc<br>boost-intel-impi-ohpc<br>boost-intel-mpich-ohpc<br>boost-intel-mvapich2-ohpc<br>boost-intel-openmpi5-ohpc | 1.88.0 | Free peer-reviewed portable C++ source libraries. [http://www.boost.org](http://www.boost.org) |
-| fftw-gnu15-impi-ohpc<br>fftw-gnu15-mpich-ohpc<br>fftw-gnu15-mvapich2-ohpc<br>fftw-gnu15-openmpi5-ohpc<br>fftw-intel-impi-ohpc<br>fftw-intel-mpich-ohpc<br>fftw-intel-mvapich2-ohpc<br>fftw-intel-openmpi5-ohpc | 3.3.10 | A Fast Fourier Transform library. [http://www.fftw.org](http://www.fftw.org) |
-| hypre-gnu15-impi-ohpc<br>hypre-gnu15-mpich-ohpc<br>hypre-gnu15-mvapich2-ohpc<br>hypre-gnu15-openmpi5-ohpc<br>hypre-intel-impi-ohpc<br>hypre-intel-mpich-ohpc<br>hypre-intel-mvapich2-ohpc<br>hypre-intel-openmpi5-ohpc | 2.33.0 | Scalable algorithms for solving linear systems of equations. [http://www.llnl.gov/casc/hypre](http://www.llnl.gov/casc/hypre) |
-| mfem-gnu15-impi-ohpc<br>mfem-gnu15-mpich-ohpc<br>mfem-gnu15-mvapich2-ohpc<br>mfem-gnu15-openmpi5-ohpc<br>mfem-intel-impi-ohpc<br>mfem-intel-mpich-ohpc<br>mfem-intel-mvapich2-ohpc<br>mfem-intel-openmpi5-ohpc | 4.4 | Lightweight, general, scalable C++ library for finite element methods. [http://mfem.org](http://mfem.org) |
-| mumps-gnu15-impi-ohpc<br>mumps-gnu15-mpich-ohpc<br>mumps-gnu15-mvapich2-ohpc<br>mumps-gnu15-openmpi5-ohpc<br>mumps-intel-impi-ohpc<br>mumps-intel-mpich-ohpc<br>mumps-intel-mvapich2-ohpc<br>mumps-intel-openmpi5-ohpc | 5.8.1 | A MUltifrontal Massively Parallel Sparse direct Solver. [https://mumps-solver.org](https://mumps-solver.org) |
-| petsc-gnu15-impi-ohpc<br>petsc-gnu15-mpich-ohpc<br>petsc-gnu15-mvapich2-ohpc<br>petsc-gnu15-openmpi5-ohpc<br>petsc-intel-impi-ohpc<br>petsc-intel-mpich-ohpc<br>petsc-intel-mvapich2-ohpc<br>petsc-intel-openmpi5-ohpc | 3.23.5 | Portable Extensible Toolkit for Scientific Computation. [http://www.mcs.anl.gov/petsc](http://www.mcs.anl.gov/petsc) |
-| ptscotch-gnu15-impi-ohpc<br>ptscotch-gnu15-mpich-ohpc<br>ptscotch-gnu15-mvapich2-ohpc<br>ptscotch-gnu15-openmpi5-ohpc<br>ptscotch-intel-impi-ohpc<br>ptscotch-intel-mpich-ohpc<br>ptscotch-intel-mvapich2-ohpc<br>ptscotch-intel-openmpi5-ohpc | 7.0.7 | Graph, mesh and hypergraph partitioning library using MPI. [http://www.labri.fr/perso/pelegrin/scotch](http://www.labri.fr/perso/pelegrin/scotch) |
-| scalapack-gnu15-impi-ohpc<br>scalapack-gnu15-mpich-ohpc<br>scalapack-gnu15-mvapich2-ohpc<br>scalapack-gnu15-openmpi5-ohpc<br>scalapack-intel-impi-ohpc<br>scalapack-intel-mpich-ohpc<br>scalapack-intel-mvapich2-ohpc<br>scalapack-intel-openmpi5-ohpc | 2.2.2 | A subset of LAPACK routines redesigned for heterogeneous computing. [https://netlib.org/scalapack](https://netlib.org/scalapack) |
-| slepc-gnu15-impi-ohpc<br>slepc-gnu15-mpich-ohpc<br>slepc-gnu15-mvapich2-ohpc<br>slepc-gnu15-openmpi5-ohpc<br>slepc-intel-impi-ohpc<br>slepc-intel-mpich-ohpc<br>slepc-intel-mvapich2-ohpc<br>slepc-intel-openmpi5-ohpc | 3.23.0 | A library for solving large scale sparse eigenvalue problems. [http://slepc.upv.es](http://slepc.upv.es) |
-| superlu_dist-gnu15-impi-ohpc<br>superlu_dist-gnu15-mpich-ohpc<br>superlu_dist-gnu15-mvapich2-ohpc<br>superlu_dist-gnu15-openmpi5-ohpc<br>superlu_dist-intel-impi-ohpc<br>superlu_dist-intel-mpich-ohpc<br>superlu_dist-intel-mvapich2-ohpc<br>superlu_dist-intel-openmpi5-ohpc | 6.4.0 | A general purpose library for the direct solution of linear equations. [https://portal.nersc.gov/project/sparse/superlu](https://portal.nersc.gov/project/sparse/superlu) |
-| trilinos-gnu15-impi-ohpc<br>trilinos-gnu15-mpich-ohpc<br>trilinos-gnu15-mvapich2-ohpc<br>trilinos-gnu15-openmpi5-ohpc<br>trilinos-intel-impi-ohpc<br>trilinos-intel-mpich-ohpc<br>trilinos-intel-mvapich2-ohpc<br>trilinos-intel-openmpi5-ohpc | 16.1.0 | A collection of libraries of numerical algorithms. [https://trilinos.org](https://trilinos.org) |
+|------|--|------------|
+| boost | 1.90.0 | Free peer-reviewed portable C++ source libraries. [http://www.boost.org](http://www.boost.org) |
+| fftw | 3.3.10 | A Fast Fourier Transform library. [http://www.fftw.org](http://www.fftw.org) |
+| hypre | 3.1.0 | Scalable algorithms for solving linear systems of equations. [http://www.llnl.gov/casc/hypre](http://www.llnl.gov/casc/hypre) |
+| mfem | 4.9 | Lightweight, general, scalable C++ library for finite element methods. [http://mfem.org](http://mfem.org) |
+| mumps | 5.8.2 | A MUltifrontal Massively Parallel Sparse direct Solver. [https://mumps-solver.org](https://mumps-solver.org) |
+| petsc | 3.25.0 | Portable Extensible Toolkit for Scientific Computation. [http://www.mcs.anl.gov/petsc](http://www.mcs.anl.gov/petsc) |
+| ptscotch | 7.0.11 | Graph, mesh and hypergraph partitioning library using MPI. [https://gitlab.inria.fr/scotch/scotch](https://gitlab.inria.fr/scotch/scotch) |
+| scalapack | 2.2.3 | A subset of LAPACK routines redesigned for heterogeneous computing. [https://netlib.org/scalapack](https://netlib.org/scalapack) |
+| slepc | 3.25.0 | A library for solving large scale sparse eigenvalue problems. [http://slepc.upv.es](http://slepc.upv.es) |
+| superlu_dist | 9.2.1 | A general purpose library for the direct solution of linear equations. [https://portal.nersc.gov/project/sparse/superlu](https://portal.nersc.gov/project/sparse/superlu) |
+| trilinos | 17.0.0 | A collection of libraries of numerical algorithms. [https://trilinos.org](https://trilinos.org) |
 
 {% endif %}
 

--- a/docs/install/manifests/oe2403-aarch64/meta-ohpc.md
+++ b/docs/install/manifests/oe2403-aarch64/meta-ohpc.md
@@ -1,5 +1,5 @@
 | **Group Name** | **Description** |
-|----------------|----------------|
+|-------|-------------|
 | ohpc-autotools | Collection of GNU autotools packages. |
 | ohpc-base | Collection of base packages. |
 | ohpc-base-compute | Collection of compute node base packages. |

--- a/docs/install/manifests/oe2403-aarch64/pkg-ohpc.md.j2
+++ b/docs/install/manifests/oe2403-aarch64/pkg-ohpc.md.j2
@@ -2,20 +2,21 @@
 ### Administrative Tools
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| conman-ohpc | 0.3.1 | ConMan: The Console Manager. [http://dun.github.io/conman](http://dun.github.io/conman) |
-| docs-ohpc | 4.0.0 | OpenHPC documentation. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| examples-ohpc | 2.0 | Example source code and templates for use within OpenHPC environment. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| genders-ohpc | 1.32 | Static cluster configuration database. [https://github.com/chaos/genders](https://github.com/chaos/genders) |
-| hpc-workspace-ohpc | 1.5.0 | Temporary workspace management. [https://github.com/holgerBerger/hpc-workspace](https://github.com/holgerBerger/hpc-workspace) |
-| lmod-defaults-gnu15-mpich-ohpc<br>lmod-defaults-gnu15-openmpi5-ohpc | 2.0 | OpenHPC default login environments. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| lmod-ohpc | 8.7.64 | Lua based Modules (lmod). [https://github.com/TACC/Lmod](https://github.com/TACC/Lmod) |
-| losf-ohpc | 0.56.0 | A Linux operating system framework for managing HPC clusters. [https://github.com/hpcsi/losf](https://github.com/hpcsi/losf) |
-| nhc-ohpc | 1.4.3 | LBNL Node Health Check. [https://github.com/mej/nhc](https://github.com/mej/nhc) |
+|------|--|------------|
+| conman | 0.3.1 | ConMan: The Console Manager. [http://dun.github.io/conman](http://dun.github.io/conman) |
+| docs | 4.0.0 | OpenHPC documentation. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| examples | 2.0 | Example source code and templates for use within OpenHPC environment. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| genders | 1.32 | Static cluster configuration database. [https://github.com/chaos/genders](https://github.com/chaos/genders) |
+| hpc-workspace | 1.5.0 | Temporary workspace management. [https://github.com/holgerBerger/hpc-workspace](https://github.com/holgerBerger/hpc-workspace) |
+| lmod-defaults | 2.0 | OpenHPC default login environments. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| lmod | 9.2 | Lua based Modules (lmod). [https://github.com/TACC/Lmod](https://github.com/TACC/Lmod) |
+| losf | 0.56.0 | A Linux operating system framework for managing HPC clusters. [https://github.com/hpcsi/losf](https://github.com/hpcsi/losf) |
+| mdtoc | 1.4.0 | Markdown table-of-contents generator. [https://github.com/kubernetes-sigs/mdtoc](https://github.com/kubernetes-sigs/mdtoc) |
+| nhc | 1.4.3 | LBNL Node Health Check. [https://github.com/mej/nhc](https://github.com/mej/nhc) |
 | ohpc-release | 4 | OpenHPC release files. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| pdsh-ohpc | 2.35 | Parallel remote shell program. [https://github.com/chaos/pdsh](https://github.com/chaos/pdsh) |
-| prun-ohpc | 2.2 | Convenience utility for parallel job launch. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| test-suite-ohpc | 4.0.0 | Integration test suite for OpenHPC. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| pdsh | 2.36 | Parallel remote shell program. [https://github.com/chaos/pdsh](https://github.com/chaos/pdsh) |
+| prun | 2.2 | Convenience utility for parallel job launch. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| test-suite | 4.0.0 | Integration test suite for OpenHPC. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
 
 {% endif %}
 
@@ -23,10 +24,10 @@
 ### Provisioning
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| warewulf-ohpc | 4.6.4 | A provisioning system for large clusters of bare metal and/or virtual systems. [https://github.com/warewulf/warewulf](https://github.com/warewulf/warewulf) |
-| warewulf-ohpc-dracut | 4.6.4 | dracut module for loading a Warewulf image. [https://github.com/warewulf/warewulf](https://github.com/warewulf/warewulf) |
-| warewulf-ohpc-sos | 4.6.4 | sos plugin for Warewulf. [https://github.com/warewulf/warewulf](https://github.com/warewulf/warewulf) |
+|------|--|------------|
+| warewulf | 4.6.5 | A provisioning system for large clusters of bare metal and/or virtual systems. [https://github.com/warewulf/warewulf](https://github.com/warewulf/warewulf) |
+| warewulf-ohpc-dracut | 4.6.5 | dracut module for loading a Warewulf image. [https://github.com/warewulf/warewulf](https://github.com/warewulf/warewulf) |
+| warewulf-ohpc-sos | 4.6.5 | sos plugin for Warewulf. [https://github.com/warewulf/warewulf](https://github.com/warewulf/warewulf) |
 
 {% endif %}
 
@@ -34,26 +35,26 @@
 ### Resource Management
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| magpie-ohpc | 3.0 | Scripts for running Big Data software in HPC environments. [https://github.com/LLNL/magpie](https://github.com/LLNL/magpie) |
-| openpbs-client-ohpc | 23.06.06 | OpenPBS for a client host. [http://www.openpbs.org](http://www.openpbs.org) |
-| openpbs-execution-ohpc | 23.06.06 | OpenPBS for an execution host. [http://www.openpbs.org](http://www.openpbs.org) |
-| openpbs-server-ohpc | 23.06.06 | OpenPBS for a server host. [http://www.openpbs.org](http://www.openpbs.org) |
-| pmix-ohpc | 4.2.9 | An extended/exascale implementation of PMI. [https://pmix.github.io/pmix](https://pmix.github.io/pmix) |
-| slurm-contribs-ohpc | 25.05.3 | Perl tool to print Slurm job state information. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-devel-ohpc | 25.05.3 | Development package for Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-example-configs-ohpc | 25.05.3 | Example config files for Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-libpmi-ohpc | 25.05.3 | Slurm\'s implementation of the pmi libraries. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-ohpc | 25.05.3 | Slurm Workload Manager. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-openlava-ohpc | 25.05.3 | openlava/LSF wrappers for transition from OpenLava/LSF to Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-pam_slurm-ohpc | 25.05.3 | PAM module for restricting access to compute nodes via Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-perlapi-ohpc | 25.05.3 | Perl API to Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-sackd-ohpc | 25.05.3 | Slurm authentication daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-slurmctld-ohpc | 25.05.3 | Slurm controller daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-slurmd-ohpc | 25.05.3 | Slurm compute node daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-slurmdbd-ohpc | 25.05.3 | Slurm database daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-sview-ohpc | 25.05.3 | Graphical user interface to view and modify Slurm state. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-torque-ohpc | 25.05.3 | Torque/PBS wrappers for transition from Torque/PBS to Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+|------|--|------------|
+| magpie | 3.2 | Scripts for running Big Data software in HPC environments. [https://github.com/LLNL/magpie](https://github.com/LLNL/magpie) |
+| openpbs-client | 23.06.06 | OpenPBS for a client host. [http://www.openpbs.org](http://www.openpbs.org) |
+| openpbs-execution | 23.06.06 | OpenPBS for an execution host. [http://www.openpbs.org](http://www.openpbs.org) |
+| openpbs-server | 23.06.06 | OpenPBS for a server host. [http://www.openpbs.org](http://www.openpbs.org) |
+| pmix | 4.2.9 | An extended/exascale implementation of PMI. [https://pmix.org](https://pmix.org) |
+| slurm-contribs | 25.05.7 | Perl tool to print Slurm job state information. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-devel | 25.05.7 | Development package for Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-example-configs | 25.05.7 | Example config files for Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-libpmi | 25.05.7 | Slurm\'s implementation of the pmi libraries. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm | 25.05.7 | Slurm Workload Manager. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-openlava | 25.05.7 | openlava/LSF wrappers for transition from OpenLava/LSF to Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-pam_slurm | 25.05.7 | PAM module for restricting access to compute nodes via Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-perlapi | 25.05.7 | Perl API to Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-sackd | 25.05.7 | Slurm authentication daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-slurmctld | 25.05.7 | Slurm controller daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-slurmd | 25.05.7 | Slurm compute node daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-slurmdbd | 25.05.7 | Slurm database daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-sview | 25.05.7 | Graphical user interface to view and modify Slurm state. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-torque | 25.05.7 | Torque/PBS wrappers for transition from Torque/PBS to Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
 
 {% endif %}
 
@@ -61,8 +62,8 @@
 ### Compiler Families
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| gnu15-compilers-ohpc | 15.1.0 | The GNU C Compiler and Support Files. [http://gcc.gnu.org](http://gcc.gnu.org) |
+|------|--|------------|
+| gnu15-compilers | 15.2.0 | The GNU C Compiler and Support Files. [http://gcc.gnu.org](http://gcc.gnu.org) |
 
 {% endif %}
 
@@ -70,11 +71,10 @@
 ### MPI Families / Communication Libraries
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| mpich-ofi-gnu15-ohpc | 3.4.3 | MPICH MPI implementation. [http://www.mpich.org](http://www.mpich.org) |
-| mpich-ucx-gnu15-ohpc | 3.4.3 | MPICH MPI implementation. [http://www.mpich.org](http://www.mpich.org) |
-| openmpi5-gnu15-ohpc<br>openmpi5-pmix-gnu15-ohpc | 5.0.8 | A powerful implementation of MPI/SHMEM. [http://www.open-mpi.org](http://www.open-mpi.org) |
-| ucx-ohpc | 1.18.0 | UCX is a communication library implementing high-performance messaging. [http://www.openucx.org](http://www.openucx.org) |
+|------|--|------------|
+| mpich | 5.0.1 | MPICH MPI implementation. [http://www.mpich.org](http://www.mpich.org) |
+| openmpi5 | 5.0.10 | A powerful implementation of MPI/SHMEM. [http://www.open-mpi.org](http://www.open-mpi.org) |
+| ucx | 1.20.0 | UCX is a communication library implementing high-performance messaging. [http://www.openucx.org](http://www.openucx.org) |
 
 {% endif %}
 
@@ -82,17 +82,17 @@
 ### Development Tools
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| EasyBuild-ohpc | 5.1.2 | Software build and installation framework. [https://easybuilders.github.io/easybuild](https://easybuilders.github.io/easybuild) |
-| autoconf-ohpc | 2.71 | A GNU tool for automatically configuring source code. [http://www.gnu.org/software/autoconf](http://www.gnu.org/software/autoconf) |
-| automake-ohpc | 1.16.5 | A GNU tool for automatically creating Makefiles. [http://www.gnu.org/software/automake](http://www.gnu.org/software/automake) |
-| cmake-ohpc | 4.1.2 | CMake is an open-source, cross-platform family of tools designed to build, test and package software. [https://cmake.org](https://cmake.org) |
-| hwloc-ohpc | 2.12.1 | Portable Hardware Locality. [http://www.open-mpi.org/projects/hwloc](http://www.open-mpi.org/projects/hwloc) |
-| libtool-ohpc | 2.4.6 | The GNU Portable Library Tool. [http://www.gnu.org/software/libtool](http://www.gnu.org/software/libtool) |
-| python3-mpi4py-gnu15-mpich-ohpc<br>python3-mpi4py-gnu15-openmpi5-ohpc | 3.1.5 | Python bindings for the Message Passing Interface (MPI) standard. [https://github.com/mpi4py/mpi4py](https://github.com/mpi4py/mpi4py) |
-| python3-numpy-gnu15-ohpc | 1.26.4 | NumPy array processing for numbers, strings, records and objects. [https://github.com/numpy/numpy](https://github.com/numpy/numpy) |
-| spack-ohpc | 1.0.1 | HPC software package management. [https://github.com/spack/spack](https://github.com/spack/spack) |
-| valgrind-ohpc | 3.25.1 | Valgrind Memory Debugger. [http://www.valgrind.org](http://www.valgrind.org) |
+|------|--|------------|
+| EasyBuild | 5.3.0 | Software build and installation framework. [https://easybuilders.github.io/easybuild](https://easybuilders.github.io/easybuild) |
+| autoconf | 2.71 | A GNU tool for automatically configuring source code. [http://www.gnu.org/software/autoconf](http://www.gnu.org/software/autoconf) |
+| automake | 1.16.5 | A GNU tool for automatically creating Makefiles. [http://www.gnu.org/software/automake](http://www.gnu.org/software/automake) |
+| cmake | 4.3.1 | CMake is an open-source, cross-platform family of tools designed to build, test and package software. [https://cmake.org](https://cmake.org) |
+| hwloc | 2.13.0 | Portable Hardware Locality. [http://www.open-mpi.org/projects/hwloc](http://www.open-mpi.org/projects/hwloc) |
+| libtool | 2.4.6 | The GNU Portable Library Tool. [http://www.gnu.org/software/libtool](http://www.gnu.org/software/libtool) |
+| python3-mpi4py | 4.1.1 | Python bindings for the Message Passing Interface (MPI) standard. [https://github.com/mpi4py/mpi4py](https://github.com/mpi4py/mpi4py) |
+| python3-numpy | 2.4.4 | NumPy array processing for numbers, strings, records and objects. [https://github.com/numpy/numpy](https://github.com/numpy/numpy) |
+| spack | 1.1.1 | HPC software package management. [https://github.com/spack/spack](https://github.com/spack/spack) |
+| valgrind | 3.26.0 | Valgrind Memory Debugger. [http://www.valgrind.org](http://www.valgrind.org) |
 
 {% endif %}
 
@@ -100,16 +100,18 @@
 ### Performance Analysis Tools
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| dimemas-gnu15-mpich-ohpc<br>dimemas-gnu15-openmpi5-ohpc | 5.4.2 | Dimemas tool. [https://tools.bsc.es](https://tools.bsc.es) |
-| extrae-gnu15-mpich-ohpc<br>extrae-gnu15-openmpi5-ohpc | 3.8.3 | Extrae tool. [https://tools.bsc.es](https://tools.bsc.es) |
-| imb-gnu15-mpich-ohpc<br>imb-gnu15-openmpi5-ohpc | 2021.3 | Intel MPI Benchmarks (IMB). [https://software.intel.com/en-us/articles/intel-mpi-benchmarks](https://software.intel.com/en-us/articles/intel-mpi-benchmarks) |
-| omb-gnu15-mpich-ohpc<br>omb-gnu15-openmpi5-ohpc | 7.5 | OSU Micro-benchmarks. [https://mvapich.cse.ohio-state.edu/benchmarks](https://mvapich.cse.ohio-state.edu/benchmarks) |
-| papi-ohpc | 7.2.0 | Performance Application Programming Interface. [http://icl.cs.utk.edu/papi](http://icl.cs.utk.edu/papi) |
-| pdtoolkit-gnu15-ohpc | 3.25.1 | PDT is a framework for analyzing source code. [http://www.cs.uoregon.edu/Research/pdt](http://www.cs.uoregon.edu/Research/pdt) |
-| scalasca-gnu15-mpich-ohpc<br>scalasca-gnu15-openmpi5-ohpc | 2.6.2 | Toolset for performance analysis of large-scale parallel applications. [http://www.scalasca.org](http://www.scalasca.org) |
-| scorep-gnu15-mpich-ohpc<br>scorep-gnu15-openmpi5-ohpc | 9.3 | Scalable Performance Measurement Infrastructure for Parallel Codes. [http://www.vi-hps.org/projects/score-p](http://www.vi-hps.org/projects/score-p) |
-| tau-gnu15-mpich-ohpc<br>tau-gnu15-openmpi5-ohpc | 2.34.1 | Tuning and Analysis Utilities Profiling Package. [http://www.cs.uoregon.edu/research/tau/home.php](http://www.cs.uoregon.edu/research/tau/home.php) |
+|------|--|------------|
+| dimemas | 5.5.0 | Dimemas tool. [https://tools.bsc.es](https://tools.bsc.es) |
+| extrae | 5.0.3 | Extrae tool. [https://tools.bsc.es](https://tools.bsc.es) |
+| imb | 2021.11 | Intel MPI Benchmarks (IMB). [https://software.intel.com/en-us/articles/intel-mpi-benchmarks](https://software.intel.com/en-us/articles/intel-mpi-benchmarks) |
+| likwid | 5.5.1 | Performance tools for the Linux console. [https://github.com/RRZE-HPC/likwid](https://github.com/RRZE-HPC/likwid) |
+| omb | 7.5.2 | OSU Micro-benchmarks. [https://mvapich.cse.ohio-state.edu/benchmarks](https://mvapich.cse.ohio-state.edu/benchmarks) |
+| papi | 7.2.0 | Performance Application Programming Interface. [http://icl.cs.utk.edu/papi](http://icl.cs.utk.edu/papi) |
+| paraver | 4.12.0 | Paraver. [https://tools.bsc.es](https://tools.bsc.es) |
+| pdtoolkit | 3.25.1 | PDT is a framework for analyzing source code. [http://www.cs.uoregon.edu/Research/pdt](http://www.cs.uoregon.edu/Research/pdt) |
+| scalasca | 2.6.2 | Toolset for performance analysis of large-scale parallel applications. [http://www.scalasca.org](http://www.scalasca.org) |
+| scorep | 9.4 | Scalable Performance Measurement Infrastructure for Parallel Codes. [http://www.vi-hps.org/projects/score-p](http://www.vi-hps.org/projects/score-p) |
+| tau | 2.35.1 | Tuning and Analysis Utilities Profiling Package. [http://www.cs.uoregon.edu/research/tau/home.php](http://www.cs.uoregon.edu/research/tau/home.php) |
 
 {% endif %}
 
@@ -117,17 +119,17 @@
 ### IO Libraries
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| adios2-gnu15-mpich-ohpc<br>adios2-gnu15-openmpi5-ohpc | 2.10.2 | The Adaptable IO System v2 (ADIOS2). [https://adios2.readthedocs.io/en/latest/index.html](https://adios2.readthedocs.io/en/latest/index.html) |
-| cubew-gnu15-ohpc | 4.9 | CUBE Uniform Behavioral Encoding generic presentation writer component. [http://www.scalasca.org/software/cube-4.x/download.html](http://www.scalasca.org/software/cube-4.x/download.html) |
-| hdf5-gnu15-ohpc | 1.14.6 | A general purpose library and file format for storing scientific data. [http://www.hdfgroup.org/HDF5](http://www.hdfgroup.org/HDF5) |
-| netcdf-cxx-gnu15-mpich-ohpc<br>netcdf-cxx-gnu15-ohpc<br>netcdf-cxx-gnu15-openmpi5-ohpc | 4.3.1 | C++ Libraries for the Unidata network Common Data Form. [http://www.unidata.ucar.edu/software/netcdf](http://www.unidata.ucar.edu/software/netcdf) |
-| netcdf-fortran-gnu15-mpich-ohpc<br>netcdf-fortran-gnu15-ohpc<br>netcdf-fortran-gnu15-openmpi5-ohpc | 4.6.2 | Fortran Libraries for the Unidata network Common Data Form. [http://www.unidata.ucar.edu/software/netcdf](http://www.unidata.ucar.edu/software/netcdf) |
-| netcdf-gnu15-mpich-ohpc<br>netcdf-gnu15-ohpc<br>netcdf-gnu15-openmpi5-ohpc | 4.9.3 | C Libraries for the Unidata network Common Data Form. [http://www.unidata.ucar.edu/software/netcdf](http://www.unidata.ucar.edu/software/netcdf) |
-| otf2-gnu15-mpich-ohpc<br>otf2-gnu15-openmpi5-ohpc | 3.1.1 | Open Trace Format 2 library. [http://score-p.org](http://score-p.org) |
-| phdf5-gnu15-mpich-ohpc<br>phdf5-gnu15-openmpi5-ohpc | 1.14.6 | A general purpose library and file format for storing scientific data. [http://www.hdfgroup.org/HDF5](http://www.hdfgroup.org/HDF5) |
-| pnetcdf-gnu15-mpich-ohpc<br>pnetcdf-gnu15-openmpi5-ohpc | 1.14.0 | A Parallel NetCDF library (PnetCDF). [http://cucis.ece.northwestern.edu/projects/PnetCDF](http://cucis.ece.northwestern.edu/projects/PnetCDF) |
-| sionlib-gnu15-mpich-ohpc<br>sionlib-gnu15-openmpi5-ohpc | 1.7.7 | Scalable I/O Library for Parallel Access to Task-Local Files. [https://apps.fz-juelich.de/jsc/sionlib/docu/index.html](https://apps.fz-juelich.de/jsc/sionlib/docu/index.html) |
+|------|--|------------|
+| adios2 | 2.11.0 | The Adaptable IO System v2 (ADIOS2). [https://adios2.readthedocs.io/en/latest/index.html](https://adios2.readthedocs.io/en/latest/index.html) |
+| cubew | 4.9.1 | CUBE Uniform Behavioral Encoding generic presentation writer component. [http://www.scalasca.org/software/cube-4.x/download.html](http://www.scalasca.org/software/cube-4.x/download.html) |
+| hdf5 | 2.1.1 | A general purpose library and file format for storing scientific data. [http://www.hdfgroup.org/HDF5](http://www.hdfgroup.org/HDF5) |
+| netcdf-cxx | 4.3.1 | C++ Libraries for the Unidata network Common Data Form. [http://www.unidata.ucar.edu/software/netcdf](http://www.unidata.ucar.edu/software/netcdf) |
+| netcdf-fortran | 4.6.2 | Fortran Libraries for the Unidata network Common Data Form. [http://www.unidata.ucar.edu/software/netcdf](http://www.unidata.ucar.edu/software/netcdf) |
+| netcdf | 4.10.0 | C Libraries for the Unidata network Common Data Form. [http://www.unidata.ucar.edu/software/netcdf](http://www.unidata.ucar.edu/software/netcdf) |
+| otf2 | 3.1.1 | Open Trace Format 2 library. [http://score-p.org](http://score-p.org) |
+| phdf5 | 2.1.1 | A general purpose library and file format for storing scientific data (parallel version). [http://www.hdfgroup.org/HDF5](http://www.hdfgroup.org/HDF5) |
+| pnetcdf | 1.14.1 | A Parallel NetCDF library (PnetCDF). [http://cucis.ece.northwestern.edu/projects/PnetCDF](http://cucis.ece.northwestern.edu/projects/PnetCDF) |
+| sionlib | 1.7.7 | Scalable I/O Library for Parallel Access to Task-Local Files. [https://apps.fz-juelich.de/jsc/sionlib/docu/index.html](https://apps.fz-juelich.de/jsc/sionlib/docu/index.html) |
 
 {% endif %}
 
@@ -135,8 +137,8 @@
 ### Distro Packages
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| python3-Cython-ohpc | 0.29.37 | The Cython compiler for writing C extensions for the Python language. [http://www.cython.org](http://www.cython.org) |
+|------|--|------------|
+| python3-Cython | 3.2.4 | The Cython compiler for writing C extensions for the Python language. [http://www.cython.org](http://www.cython.org) |
 
 {% endif %}
 
@@ -144,8 +146,8 @@
 ### Runtimes
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| charliecloud-ohpc | 0.40 | Lightweight user-defined software stacks for high-performance computing. [https://charliecloud.io](https://charliecloud.io) |
+|------|--|------------|
+| charliecloud | 0.44 | Lightweight user-defined software stacks for high-performance computing. [https://charliecloud.io](https://charliecloud.io) |
 
 {% endif %}
 
@@ -153,17 +155,17 @@
 ### Serial/Threaded Libraries
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| R-gnu15-ohpc | 4.5.0 | R is a language and environment for statistical computing and graphics (S-Plus like). [http://www.r-project.org](http://www.r-project.org) |
-| cubelib-gnu15-ohpc | 4.9 | CUBE Uniform Behavioral Encoding generic presentation library component. [http://www.scalasca.org/software/cube-4.x/download.html](http://www.scalasca.org/software/cube-4.x/download.html) |
-| gotcha-gnu15-ohpc | 1.0.8 | A library for wrapping function calls to shared libraries. [https://github.com/llnl/gotcha](https://github.com/llnl/gotcha) |
-| gsl-gnu15-ohpc | 2.8 | GNU Scientific Library (GSL). [http://www.gnu.org/software/gsl](http://www.gnu.org/software/gsl) |
-| metis-gnu15-ohpc | 5.1.0 | Serial Graph Partitioning and Fill-reducing Matrix Ordering. [http://glaros.dtc.umn.edu/gkhome/metis/metis/overview](http://glaros.dtc.umn.edu/gkhome/metis/metis/overview) |
-| opari2-gnu15-ohpc | 2.0.9 | An OpenMP runtime performance measurement instrumenter. [https://www.vi-hps.org/projects/score-p](https://www.vi-hps.org/projects/score-p) |
-| openblas-gnu15-ohpc | 0.3.29 | An optimized BLAS library based on GotoBLAS2. [http://www.openblas.net](http://www.openblas.net) |
-| plasma-gnu15-ohpc | 24.8.7 | Parallel Linear Algebra Software for Multicore Architectures. [https://github.com/icl-utk-edu/plasma](https://github.com/icl-utk-edu/plasma) |
-| scotch-gnu15-ohpc | 7.0.7 | Graph, mesh and hypergraph partitioning library. [https://gitlab.inria.fr/scotch/scotch](https://gitlab.inria.fr/scotch/scotch) |
-| superlu-gnu15-ohpc | 7.0.0 | A general purpose library for the direct solution of linear equations. [http://crd.lbl.gov/~xiaoye/SuperLU](http://crd.lbl.gov/~xiaoye/SuperLU) |
+|------|--|------------|
+| R | 4.5.3 | R is a language and environment for statistical computing and graphics (S-Plus like). [http://www.r-project.org](http://www.r-project.org) |
+| cubelib | 4.9.1 | CUBE Uniform Behavioral Encoding generic presentation library component. [http://www.scalasca.org/software/cube-4.x/download.html](http://www.scalasca.org/software/cube-4.x/download.html) |
+| gotcha | 1.0.8 | A library for wrapping function calls to shared libraries. [https://github.com/llnl/gotcha](https://github.com/llnl/gotcha) |
+| gsl | 2.8 | GNU Scientific Library (GSL). [http://www.gnu.org/software/gsl](http://www.gnu.org/software/gsl) |
+| metis | 5.1.0 | Serial Graph Partitioning and Fill-reducing Matrix Ordering. [http://glaros.dtc.umn.edu/gkhome/metis/metis/overview](http://glaros.dtc.umn.edu/gkhome/metis/metis/overview) |
+| opari2 | 2.0.9 | An OpenMP runtime performance measurement instrumenter. [https://www.vi-hps.org/projects/score-p](https://www.vi-hps.org/projects/score-p) |
+| openblas | 0.3.32 | An optimized BLAS library based on GotoBLAS2. [http://www.openblas.net](http://www.openblas.net) |
+| plasma | 25.5.27 | Parallel Linear Algebra Software for Multicore Architectures. [https://github.com/icl-utk-edu/plasma](https://github.com/icl-utk-edu/plasma) |
+| scotch | 7.0.11 | Graph, mesh and hypergraph partitioning library. [https://gitlab.inria.fr/scotch/scotch](https://gitlab.inria.fr/scotch/scotch) |
+| superlu | 7.0.1 | A general purpose library for the direct solution of linear equations. [http://crd.lbl.gov/~xiaoye/SuperLU](http://crd.lbl.gov/~xiaoye/SuperLU) |
 
 {% endif %}
 
@@ -171,18 +173,18 @@
 ### Parallel Libraries
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| boost-gnu15-mpich-ohpc<br>boost-gnu15-openmpi5-ohpc | 1.88.0 | Free peer-reviewed portable C++ source libraries. [http://www.boost.org](http://www.boost.org) |
-| fftw-gnu15-mpich-ohpc<br>fftw-gnu15-openmpi5-ohpc | 3.3.10 | A Fast Fourier Transform library. [http://www.fftw.org](http://www.fftw.org) |
-| hypre-gnu15-mpich-ohpc<br>hypre-gnu15-openmpi5-ohpc | 2.33.0 | Scalable algorithms for solving linear systems of equations. [http://www.llnl.gov/casc/hypre](http://www.llnl.gov/casc/hypre) |
-| mfem-gnu15-mpich-ohpc<br>mfem-gnu15-openmpi5-ohpc | 4.4 | Lightweight, general, scalable C++ library for finite element methods. [http://mfem.org](http://mfem.org) |
-| mumps-gnu15-mpich-ohpc<br>mumps-gnu15-openmpi5-ohpc | 5.8.1 | A MUltifrontal Massively Parallel Sparse direct Solver. [https://mumps-solver.org](https://mumps-solver.org) |
-| petsc-gnu15-mpich-ohpc<br>petsc-gnu15-openmpi5-ohpc | 3.23.5 | Portable Extensible Toolkit for Scientific Computation. [http://www.mcs.anl.gov/petsc](http://www.mcs.anl.gov/petsc) |
-| ptscotch-gnu15-mpich-ohpc<br>ptscotch-gnu15-openmpi5-ohpc | 7.0.7 | Graph, mesh and hypergraph partitioning library using MPI. [http://www.labri.fr/perso/pelegrin/scotch](http://www.labri.fr/perso/pelegrin/scotch) |
-| scalapack-gnu15-mpich-ohpc<br>scalapack-gnu15-openmpi5-ohpc | 2.2.2 | A subset of LAPACK routines redesigned for heterogeneous computing. [https://netlib.org/scalapack](https://netlib.org/scalapack) |
-| slepc-gnu15-mpich-ohpc<br>slepc-gnu15-openmpi5-ohpc | 3.23.0 | A library for solving large scale sparse eigenvalue problems. [http://slepc.upv.es](http://slepc.upv.es) |
-| superlu_dist-gnu15-mpich-ohpc<br>superlu_dist-gnu15-openmpi5-ohpc | 6.4.0 | A general purpose library for the direct solution of linear equations. [https://portal.nersc.gov/project/sparse/superlu](https://portal.nersc.gov/project/sparse/superlu) |
-| trilinos-gnu15-mpich-ohpc<br>trilinos-gnu15-openmpi5-ohpc | 16.1.0 | A collection of libraries of numerical algorithms. [https://trilinos.org](https://trilinos.org) |
+|------|--|------------|
+| boost | 1.90.0 | Free peer-reviewed portable C++ source libraries. [http://www.boost.org](http://www.boost.org) |
+| fftw | 3.3.10 | A Fast Fourier Transform library. [http://www.fftw.org](http://www.fftw.org) |
+| hypre | 3.1.0 | Scalable algorithms for solving linear systems of equations. [http://www.llnl.gov/casc/hypre](http://www.llnl.gov/casc/hypre) |
+| mfem | 4.9 | Lightweight, general, scalable C++ library for finite element methods. [http://mfem.org](http://mfem.org) |
+| mumps | 5.8.2 | A MUltifrontal Massively Parallel Sparse direct Solver. [https://mumps-solver.org](https://mumps-solver.org) |
+| petsc | 3.25.0 | Portable Extensible Toolkit for Scientific Computation. [http://www.mcs.anl.gov/petsc](http://www.mcs.anl.gov/petsc) |
+| ptscotch | 7.0.11 | Graph, mesh and hypergraph partitioning library using MPI. [https://gitlab.inria.fr/scotch/scotch](https://gitlab.inria.fr/scotch/scotch) |
+| scalapack | 2.2.3 | A subset of LAPACK routines redesigned for heterogeneous computing. [https://netlib.org/scalapack](https://netlib.org/scalapack) |
+| slepc | 3.25.0 | A library for solving large scale sparse eigenvalue problems. [http://slepc.upv.es](http://slepc.upv.es) |
+| superlu_dist | 9.2.1 | A general purpose library for the direct solution of linear equations. [https://portal.nersc.gov/project/sparse/superlu](https://portal.nersc.gov/project/sparse/superlu) |
+| trilinos | 17.0.0 | A collection of libraries of numerical algorithms. [https://trilinos.org](https://trilinos.org) |
 
 {% endif %}
 

--- a/docs/install/manifests/oe2403-x86_64/meta-ohpc.md
+++ b/docs/install/manifests/oe2403-x86_64/meta-ohpc.md
@@ -1,5 +1,5 @@
 | **Group Name** | **Description** |
-|----------------|----------------|
+|-------|-------------|
 | ohpc-autotools | Collection of GNU autotools packages. |
 | ohpc-base | Collection of base packages. |
 | ohpc-base-compute | Collection of compute node base packages. |
@@ -7,6 +7,9 @@
 | ohpc-gnu15-mpich-io-libs | Collection of IO library builds for use with GNU compiler toolchain and the MPICH runtime. |
 | ohpc-gnu15-mpich-parallel-libs | Collection of parallel library builds for use with GNU compiler toolchain and the MPICH runtime. |
 | ohpc-gnu15-mpich-perf-tools | Collection of performance tool builds for use with GNU compiler toolchain and the MPICH runtime. |
+| ohpc-gnu15-mvapich2-io-libs | Collection of IO library builds for use with GNU compiler toolchain and the MVAPICH2 runtime. |
+| ohpc-gnu15-mvapich2-parallel-libs | Collection of parallel library builds for use with GNU compiler toolchain and the MVAPICH2 runtime. |
+| ohpc-gnu15-mvapich2-perf-tools | Collection of performance tool builds for use with GNU compiler toolchain and the MVAPICH2 runtime. |
 | ohpc-gnu15-openmpi5-io-libs | Collection of IO library builds for use with GNU compiler toolchain and the OpenMPI runtime. |
 | ohpc-gnu15-openmpi5-parallel-libs | Collection of parallel library builds for use with GNU compiler toolchain and the OpenMPI runtime. |
 | ohpc-gnu15-openmpi5-perf-tools | Collection of performance tool builds for use with GNU compiler toolchain and the OpenMPI runtime. |

--- a/docs/install/manifests/oe2403-x86_64/pkg-ohpc.md.j2
+++ b/docs/install/manifests/oe2403-x86_64/pkg-ohpc.md.j2
@@ -2,20 +2,21 @@
 ### Administrative Tools
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| conman-ohpc | 0.3.1 | ConMan: The Console Manager. [http://dun.github.io/conman](http://dun.github.io/conman) |
-| docs-ohpc | 4.0.0 | OpenHPC documentation. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| examples-ohpc | 2.0 | Example source code and templates for use within OpenHPC environment. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| genders-ohpc | 1.32 | Static cluster configuration database. [https://github.com/chaos/genders](https://github.com/chaos/genders) |
-| hpc-workspace-ohpc | 1.5.0 | Temporary workspace management. [https://github.com/holgerBerger/hpc-workspace](https://github.com/holgerBerger/hpc-workspace) |
-| lmod-defaults-gnu15-mpich-ohpc<br>lmod-defaults-gnu15-mvapich2-ohpc<br>lmod-defaults-gnu15-openmpi5-ohpc<br>lmod-defaults-intel-impi-ohpc<br>lmod-defaults-intel-mpich-ohpc<br>lmod-defaults-intel-mvapich2-ohpc<br>lmod-defaults-intel-openmpi5-ohpc | 2.0 | OpenHPC default login environments. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| lmod-ohpc | 8.7.64 | Lua based Modules (lmod). [https://github.com/TACC/Lmod](https://github.com/TACC/Lmod) |
-| losf-ohpc | 0.56.0 | A Linux operating system framework for managing HPC clusters. [https://github.com/hpcsi/losf](https://github.com/hpcsi/losf) |
-| nhc-ohpc | 1.4.3 | LBNL Node Health Check. [https://github.com/mej/nhc](https://github.com/mej/nhc) |
+|------|--|------------|
+| conman | 0.3.1 | ConMan: The Console Manager. [http://dun.github.io/conman](http://dun.github.io/conman) |
+| docs | 4.0.0 | OpenHPC documentation. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| examples | 2.0 | Example source code and templates for use within OpenHPC environment. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| genders | 1.32 | Static cluster configuration database. [https://github.com/chaos/genders](https://github.com/chaos/genders) |
+| hpc-workspace | 1.5.0 | Temporary workspace management. [https://github.com/holgerBerger/hpc-workspace](https://github.com/holgerBerger/hpc-workspace) |
+| lmod-defaults | 2.0 | OpenHPC default login environments. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| lmod | 9.2 | Lua based Modules (lmod). [https://github.com/TACC/Lmod](https://github.com/TACC/Lmod) |
+| losf | 0.56.0 | A Linux operating system framework for managing HPC clusters. [https://github.com/hpcsi/losf](https://github.com/hpcsi/losf) |
+| mdtoc | 1.4.0 | Markdown table-of-contents generator. [https://github.com/kubernetes-sigs/mdtoc](https://github.com/kubernetes-sigs/mdtoc) |
+| nhc | 1.4.3 | LBNL Node Health Check. [https://github.com/mej/nhc](https://github.com/mej/nhc) |
 | ohpc-release | 4 | OpenHPC release files. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| pdsh-ohpc | 2.35 | Parallel remote shell program. [https://github.com/chaos/pdsh](https://github.com/chaos/pdsh) |
-| prun-ohpc | 2.2 | Convenience utility for parallel job launch. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| test-suite-ohpc | 4.0.0 | Integration test suite for OpenHPC. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| pdsh | 2.36 | Parallel remote shell program. [https://github.com/chaos/pdsh](https://github.com/chaos/pdsh) |
+| prun | 2.2 | Convenience utility for parallel job launch. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| test-suite | 4.0.0 | Integration test suite for OpenHPC. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
 
 {% endif %}
 
@@ -23,10 +24,10 @@
 ### Provisioning
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| warewulf-ohpc | 4.6.4 | A provisioning system for large clusters of bare metal and/or virtual systems. [https://github.com/warewulf/warewulf](https://github.com/warewulf/warewulf) |
-| warewulf-ohpc-dracut | 4.6.4 | dracut module for loading a Warewulf image. [https://github.com/warewulf/warewulf](https://github.com/warewulf/warewulf) |
-| warewulf-ohpc-sos | 4.6.4 | sos plugin for Warewulf. [https://github.com/warewulf/warewulf](https://github.com/warewulf/warewulf) |
+|------|--|------------|
+| warewulf | 4.6.5 | A provisioning system for large clusters of bare metal and/or virtual systems. [https://github.com/warewulf/warewulf](https://github.com/warewulf/warewulf) |
+| warewulf-ohpc-dracut | 4.6.5 | dracut module for loading a Warewulf image. [https://github.com/warewulf/warewulf](https://github.com/warewulf/warewulf) |
+| warewulf-ohpc-sos | 4.6.5 | sos plugin for Warewulf. [https://github.com/warewulf/warewulf](https://github.com/warewulf/warewulf) |
 
 {% endif %}
 
@@ -34,26 +35,26 @@
 ### Resource Management
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| magpie-ohpc | 3.0 | Scripts for running Big Data software in HPC environments. [https://github.com/LLNL/magpie](https://github.com/LLNL/magpie) |
-| openpbs-client-ohpc | 23.06.06 | OpenPBS for a client host. [http://www.openpbs.org](http://www.openpbs.org) |
-| openpbs-execution-ohpc | 23.06.06 | OpenPBS for an execution host. [http://www.openpbs.org](http://www.openpbs.org) |
-| openpbs-server-ohpc | 23.06.06 | OpenPBS for a server host. [http://www.openpbs.org](http://www.openpbs.org) |
-| pmix-ohpc | 4.2.9 | An extended/exascale implementation of PMI. [https://pmix.github.io/pmix](https://pmix.github.io/pmix) |
-| slurm-contribs-ohpc | 25.05.3 | Perl tool to print Slurm job state information. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-devel-ohpc | 25.05.3 | Development package for Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-example-configs-ohpc | 25.05.3 | Example config files for Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-libpmi-ohpc | 25.05.3 | Slurm\'s implementation of the pmi libraries. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-ohpc | 25.05.3 | Slurm Workload Manager. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-openlava-ohpc | 25.05.3 | openlava/LSF wrappers for transition from OpenLava/LSF to Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-pam_slurm-ohpc | 25.05.3 | PAM module for restricting access to compute nodes via Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-perlapi-ohpc | 25.05.3 | Perl API to Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-sackd-ohpc | 25.05.3 | Slurm authentication daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-slurmctld-ohpc | 25.05.3 | Slurm controller daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-slurmd-ohpc | 25.05.3 | Slurm compute node daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-slurmdbd-ohpc | 25.05.3 | Slurm database daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-sview-ohpc | 25.05.3 | Graphical user interface to view and modify Slurm state. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
-| slurm-torque-ohpc | 25.05.3 | Torque/PBS wrappers for transition from Torque/PBS to Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+|------|--|------------|
+| magpie | 3.2 | Scripts for running Big Data software in HPC environments. [https://github.com/LLNL/magpie](https://github.com/LLNL/magpie) |
+| openpbs-client | 23.06.06 | OpenPBS for a client host. [http://www.openpbs.org](http://www.openpbs.org) |
+| openpbs-execution | 23.06.06 | OpenPBS for an execution host. [http://www.openpbs.org](http://www.openpbs.org) |
+| openpbs-server | 23.06.06 | OpenPBS for a server host. [http://www.openpbs.org](http://www.openpbs.org) |
+| pmix | 4.2.9 | An extended/exascale implementation of PMI. [https://pmix.org](https://pmix.org) |
+| slurm-contribs | 25.05.7 | Perl tool to print Slurm job state information. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-devel | 25.05.7 | Development package for Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-example-configs | 25.05.7 | Example config files for Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-libpmi | 25.05.7 | Slurm\'s implementation of the pmi libraries. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm | 25.05.7 | Slurm Workload Manager. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-openlava | 25.05.7 | openlava/LSF wrappers for transition from OpenLava/LSF to Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-pam_slurm | 25.05.7 | PAM module for restricting access to compute nodes via Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-perlapi | 25.05.7 | Perl API to Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-sackd | 25.05.7 | Slurm authentication daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-slurmctld | 25.05.7 | Slurm controller daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-slurmd | 25.05.7 | Slurm compute node daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-slurmdbd | 25.05.7 | Slurm database daemon. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-sview | 25.05.7 | Graphical user interface to view and modify Slurm state. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
+| slurm-torque | 25.05.7 | Torque/PBS wrappers for transition from Torque/PBS to Slurm. [https://slurm.schedmd.com](https://slurm.schedmd.com) |
 
 {% endif %}
 
@@ -61,10 +62,10 @@
 ### Compiler Families
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| gnu15-compilers-ohpc | 15.1.0 | The GNU C Compiler and Support Files. [http://gcc.gnu.org](http://gcc.gnu.org) |
-| intel-compilers-devel-ohpc | 2025.0 | OpenHPC compatibility package for Intel(R) oneAPI HPC Toolkit. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| intel-oneapi-toolkit-release-ohpc | 2025.0 | Intel(R) oneAPI HPC Toolkit Repository Setup. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+|------|--|------------|
+| gnu15-compilers | 15.2.0 | The GNU C Compiler and Support Files. [http://gcc.gnu.org](http://gcc.gnu.org) |
+| intel-compilers-devel | 2025.0 | OpenHPC compatibility package for Intel(R) oneAPI HPC Toolkit. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| intel-oneapi-toolkit-release | 2025.0 | Intel(R) oneAPI HPC Toolkit Repository Setup. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
 
 {% endif %}
 
@@ -72,12 +73,11 @@
 ### MPI Families / Communication Libraries
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| mpich-ofi-gnu15-ohpc | 3.4.3 | MPICH MPI implementation. [http://www.mpich.org](http://www.mpich.org) |
-| mpich-ucx-gnu15-ohpc | 3.4.3 | MPICH MPI implementation. [http://www.mpich.org](http://www.mpich.org) |
-| mvapich2-gnu15-ohpc | 2.3.7 | OSU MVAPICH2 MPI implementation. [http://mvapich.cse.ohio-state.edu](http://mvapich.cse.ohio-state.edu) |
-| openmpi5-gnu15-ohpc<br>openmpi5-pmix-gnu15-ohpc | 5.0.8 | A powerful implementation of MPI/SHMEM. [http://www.open-mpi.org](http://www.open-mpi.org) |
-| ucx-ohpc | 1.18.0 | UCX is a communication library implementing high-performance messaging. [http://www.openucx.org](http://www.openucx.org) |
+|------|--|------------|
+| mpich | 5.0.1 | MPICH MPI implementation. [http://www.mpich.org](http://www.mpich.org) |
+| mvapich2 | 4.1 | OSU MVAPICH2 MPI implementation. [http://mvapich.cse.ohio-state.edu](http://mvapich.cse.ohio-state.edu) |
+| openmpi5 | 5.0.10 | A powerful implementation of MPI/SHMEM. [http://www.open-mpi.org](http://www.open-mpi.org) |
+| ucx | 1.20.0 | UCX is a communication library implementing high-performance messaging. [http://www.openucx.org](http://www.openucx.org) |
 
 {% endif %}
 
@@ -85,19 +85,19 @@
 ### Development Tools
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| EasyBuild-ohpc | 5.1.2 | Software build and installation framework. [https://easybuilders.github.io/easybuild](https://easybuilders.github.io/easybuild) |
-| autoconf-ohpc | 2.71 | A GNU tool for automatically configuring source code. [http://www.gnu.org/software/autoconf](http://www.gnu.org/software/autoconf) |
-| automake-ohpc | 1.16.5 | A GNU tool for automatically creating Makefiles. [http://www.gnu.org/software/automake](http://www.gnu.org/software/automake) |
-| cmake-ohpc | 4.1.2 | CMake is an open-source, cross-platform family of tools designed to build, test and package software. [https://cmake.org](https://cmake.org) |
-| cuda-devel-ohpc | 25.1 | OpenHPC compatibility package for cuda. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| cuda-repo-ohpc | 25.1 | Cuda toolkit online repository. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
-| hwloc-ohpc | 2.12.1 | Portable Hardware Locality. [http://www.open-mpi.org/projects/hwloc](http://www.open-mpi.org/projects/hwloc) |
-| libtool-ohpc | 2.4.6 | The GNU Portable Library Tool. [http://www.gnu.org/software/libtool](http://www.gnu.org/software/libtool) |
-| python3-mpi4py-gnu15-mpich-ohpc<br>python3-mpi4py-gnu15-mvapich2-ohpc<br>python3-mpi4py-gnu15-openmpi5-ohpc | 3.1.5 | Python bindings for the Message Passing Interface (MPI) standard. [https://github.com/mpi4py/mpi4py](https://github.com/mpi4py/mpi4py) |
-| python3-numpy-gnu15-ohpc | 1.26.4 | NumPy array processing for numbers, strings, records and objects. [https://github.com/numpy/numpy](https://github.com/numpy/numpy) |
-| spack-ohpc | 1.0.1 | HPC software package management. [https://github.com/spack/spack](https://github.com/spack/spack) |
-| valgrind-ohpc | 3.25.1 | Valgrind Memory Debugger. [http://www.valgrind.org](http://www.valgrind.org) |
+|------|--|------------|
+| EasyBuild | 5.3.0 | Software build and installation framework. [https://easybuilders.github.io/easybuild](https://easybuilders.github.io/easybuild) |
+| autoconf | 2.71 | A GNU tool for automatically configuring source code. [http://www.gnu.org/software/autoconf](http://www.gnu.org/software/autoconf) |
+| automake | 1.16.5 | A GNU tool for automatically creating Makefiles. [http://www.gnu.org/software/automake](http://www.gnu.org/software/automake) |
+| cmake | 4.3.1 | CMake is an open-source, cross-platform family of tools designed to build, test and package software. [https://cmake.org](https://cmake.org) |
+| cuda-devel | 25.1 | OpenHPC compatibility package for cuda. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| cuda-repo | 25.1 | Cuda toolkit online repository. [https://github.com/openhpc/ohpc](https://github.com/openhpc/ohpc) |
+| hwloc | 2.13.0 | Portable Hardware Locality. [http://www.open-mpi.org/projects/hwloc](http://www.open-mpi.org/projects/hwloc) |
+| libtool | 2.4.6 | The GNU Portable Library Tool. [http://www.gnu.org/software/libtool](http://www.gnu.org/software/libtool) |
+| python3-mpi4py | 4.1.1 | Python bindings for the Message Passing Interface (MPI) standard. [https://github.com/mpi4py/mpi4py](https://github.com/mpi4py/mpi4py) |
+| python3-numpy | 2.4.4 | NumPy array processing for numbers, strings, records and objects. [https://github.com/numpy/numpy](https://github.com/numpy/numpy) |
+| spack | 1.1.1 | HPC software package management. [https://github.com/spack/spack](https://github.com/spack/spack) |
+| valgrind | 3.26.0 | Valgrind Memory Debugger. [http://www.valgrind.org](http://www.valgrind.org) |
 
 {% endif %}
 
@@ -105,17 +105,18 @@
 ### Performance Analysis Tools
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| dimemas-gnu15-mpich-ohpc<br>dimemas-gnu15-mvapich2-ohpc<br>dimemas-gnu15-openmpi5-ohpc | 5.4.2 | Dimemas tool. [https://tools.bsc.es](https://tools.bsc.es) |
-| extrae-gnu15-mpich-ohpc<br>extrae-gnu15-mvapich2-ohpc<br>extrae-gnu15-openmpi5-ohpc | 3.8.3 | Extrae tool. [https://tools.bsc.es](https://tools.bsc.es) |
-| imb-gnu15-mpich-ohpc<br>imb-gnu15-mvapich2-ohpc<br>imb-gnu15-openmpi5-ohpc | 2021.3 | Intel MPI Benchmarks (IMB). [https://software.intel.com/en-us/articles/intel-mpi-benchmarks](https://software.intel.com/en-us/articles/intel-mpi-benchmarks) |
-| likwid-gnu15-ohpc | 5.4.1 | Performance tools for the Linux console. [https://github.com/RRZE-HPC/likwid](https://github.com/RRZE-HPC/likwid) |
-| omb-gnu15-mpich-ohpc<br>omb-gnu15-mvapich2-ohpc<br>omb-gnu15-openmpi5-ohpc | 7.5 | OSU Micro-benchmarks. [https://mvapich.cse.ohio-state.edu/benchmarks](https://mvapich.cse.ohio-state.edu/benchmarks) |
-| papi-ohpc | 7.2.0 | Performance Application Programming Interface. [http://icl.cs.utk.edu/papi](http://icl.cs.utk.edu/papi) |
-| pdtoolkit-gnu15-ohpc | 3.25.1 | PDT is a framework for analyzing source code. [http://www.cs.uoregon.edu/Research/pdt](http://www.cs.uoregon.edu/Research/pdt) |
-| scalasca-gnu15-mpich-ohpc<br>scalasca-gnu15-mvapich2-ohpc<br>scalasca-gnu15-openmpi5-ohpc | 2.6.2 | Toolset for performance analysis of large-scale parallel applications. [http://www.scalasca.org](http://www.scalasca.org) |
-| scorep-gnu15-mpich-ohpc<br>scorep-gnu15-mvapich2-ohpc<br>scorep-gnu15-openmpi5-ohpc | 9.3 | Scalable Performance Measurement Infrastructure for Parallel Codes. [http://www.vi-hps.org/projects/score-p](http://www.vi-hps.org/projects/score-p) |
-| tau-gnu15-mpich-ohpc<br>tau-gnu15-mvapich2-ohpc<br>tau-gnu15-openmpi5-ohpc | 2.34.1 | Tuning and Analysis Utilities Profiling Package. [http://www.cs.uoregon.edu/research/tau/home.php](http://www.cs.uoregon.edu/research/tau/home.php) |
+|------|--|------------|
+| dimemas | 5.5.0 | Dimemas tool. [https://tools.bsc.es](https://tools.bsc.es) |
+| extrae | 5.0.3 | Extrae tool. [https://tools.bsc.es](https://tools.bsc.es) |
+| imb | 2021.11 | Intel MPI Benchmarks (IMB). [https://software.intel.com/en-us/articles/intel-mpi-benchmarks](https://software.intel.com/en-us/articles/intel-mpi-benchmarks) |
+| likwid | 5.5.1 | Performance tools for the Linux console. [https://github.com/RRZE-HPC/likwid](https://github.com/RRZE-HPC/likwid) |
+| omb | 7.5.2 | OSU Micro-benchmarks. [https://mvapich.cse.ohio-state.edu/benchmarks](https://mvapich.cse.ohio-state.edu/benchmarks) |
+| papi | 7.2.0 | Performance Application Programming Interface. [http://icl.cs.utk.edu/papi](http://icl.cs.utk.edu/papi) |
+| paraver | 4.12.0 | Paraver. [https://tools.bsc.es](https://tools.bsc.es) |
+| pdtoolkit | 3.25.1 | PDT is a framework for analyzing source code. [http://www.cs.uoregon.edu/Research/pdt](http://www.cs.uoregon.edu/Research/pdt) |
+| scalasca | 2.6.2 | Toolset for performance analysis of large-scale parallel applications. [http://www.scalasca.org](http://www.scalasca.org) |
+| scorep | 9.4 | Scalable Performance Measurement Infrastructure for Parallel Codes. [http://www.vi-hps.org/projects/score-p](http://www.vi-hps.org/projects/score-p) |
+| tau | 2.35.1 | Tuning and Analysis Utilities Profiling Package. [http://www.cs.uoregon.edu/research/tau/home.php](http://www.cs.uoregon.edu/research/tau/home.php) |
 
 {% endif %}
 
@@ -123,17 +124,17 @@
 ### IO Libraries
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| adios2-gnu15-mpich-ohpc<br>adios2-gnu15-mvapich2-ohpc<br>adios2-gnu15-openmpi5-ohpc | 2.10.2 | The Adaptable IO System v2 (ADIOS2). [https://adios2.readthedocs.io/en/latest/index.html](https://adios2.readthedocs.io/en/latest/index.html) |
-| cubew-gnu15-ohpc | 4.9 | CUBE Uniform Behavioral Encoding generic presentation writer component. [http://www.scalasca.org/software/cube-4.x/download.html](http://www.scalasca.org/software/cube-4.x/download.html) |
-| hdf5-gnu15-ohpc | 1.14.6 | A general purpose library and file format for storing scientific data. [http://www.hdfgroup.org/HDF5](http://www.hdfgroup.org/HDF5) |
-| netcdf-cxx-gnu15-mpich-ohpc<br>netcdf-cxx-gnu15-mvapich2-ohpc<br>netcdf-cxx-gnu15-ohpc<br>netcdf-cxx-gnu15-openmpi5-ohpc | 4.3.1 | C++ Libraries for the Unidata network Common Data Form. [http://www.unidata.ucar.edu/software/netcdf](http://www.unidata.ucar.edu/software/netcdf) |
-| netcdf-fortran-gnu15-mpich-ohpc<br>netcdf-fortran-gnu15-mvapich2-ohpc<br>netcdf-fortran-gnu15-ohpc<br>netcdf-fortran-gnu15-openmpi5-ohpc | 4.6.2 | Fortran Libraries for the Unidata network Common Data Form. [http://www.unidata.ucar.edu/software/netcdf](http://www.unidata.ucar.edu/software/netcdf) |
-| netcdf-gnu15-mpich-ohpc<br>netcdf-gnu15-mvapich2-ohpc<br>netcdf-gnu15-ohpc<br>netcdf-gnu15-openmpi5-ohpc | 4.9.3 | C Libraries for the Unidata network Common Data Form. [http://www.unidata.ucar.edu/software/netcdf](http://www.unidata.ucar.edu/software/netcdf) |
-| otf2-gnu15-mpich-ohpc<br>otf2-gnu15-mvapich2-ohpc<br>otf2-gnu15-openmpi5-ohpc | 3.1.1 | Open Trace Format 2 library. [http://score-p.org](http://score-p.org) |
-| phdf5-gnu15-mpich-ohpc<br>phdf5-gnu15-mvapich2-ohpc<br>phdf5-gnu15-openmpi5-ohpc | 1.14.6 | A general purpose library and file format for storing scientific data. [http://www.hdfgroup.org/HDF5](http://www.hdfgroup.org/HDF5) |
-| pnetcdf-gnu15-mpich-ohpc<br>pnetcdf-gnu15-mvapich2-ohpc<br>pnetcdf-gnu15-openmpi5-ohpc | 1.14.0 | A Parallel NetCDF library (PnetCDF). [http://cucis.ece.northwestern.edu/projects/PnetCDF](http://cucis.ece.northwestern.edu/projects/PnetCDF) |
-| sionlib-gnu15-mpich-ohpc<br>sionlib-gnu15-mvapich2-ohpc<br>sionlib-gnu15-openmpi5-ohpc | 1.7.7 | Scalable I/O Library for Parallel Access to Task-Local Files. [https://apps.fz-juelich.de/jsc/sionlib/docu/index.html](https://apps.fz-juelich.de/jsc/sionlib/docu/index.html) |
+|------|--|------------|
+| adios2 | 2.11.0 | The Adaptable IO System v2 (ADIOS2). [https://adios2.readthedocs.io/en/latest/index.html](https://adios2.readthedocs.io/en/latest/index.html) |
+| cubew | 4.9.1 | CUBE Uniform Behavioral Encoding generic presentation writer component. [http://www.scalasca.org/software/cube-4.x/download.html](http://www.scalasca.org/software/cube-4.x/download.html) |
+| hdf5 | 2.1.1 | A general purpose library and file format for storing scientific data. [http://www.hdfgroup.org/HDF5](http://www.hdfgroup.org/HDF5) |
+| netcdf-cxx | 4.3.1 | C++ Libraries for the Unidata network Common Data Form. [http://www.unidata.ucar.edu/software/netcdf](http://www.unidata.ucar.edu/software/netcdf) |
+| netcdf-fortran | 4.6.2 | Fortran Libraries for the Unidata network Common Data Form. [http://www.unidata.ucar.edu/software/netcdf](http://www.unidata.ucar.edu/software/netcdf) |
+| netcdf | 4.10.0 | C Libraries for the Unidata network Common Data Form. [http://www.unidata.ucar.edu/software/netcdf](http://www.unidata.ucar.edu/software/netcdf) |
+| otf2 | 3.1.1 | Open Trace Format 2 library. [http://score-p.org](http://score-p.org) |
+| phdf5 | 2.1.1 | A general purpose library and file format for storing scientific data (parallel version). [http://www.hdfgroup.org/HDF5](http://www.hdfgroup.org/HDF5) |
+| pnetcdf | 1.14.1 | A Parallel NetCDF library (PnetCDF). [http://cucis.ece.northwestern.edu/projects/PnetCDF](http://cucis.ece.northwestern.edu/projects/PnetCDF) |
+| sionlib | 1.7.7 | Scalable I/O Library for Parallel Access to Task-Local Files. [https://apps.fz-juelich.de/jsc/sionlib/docu/index.html](https://apps.fz-juelich.de/jsc/sionlib/docu/index.html) |
 
 {% endif %}
 
@@ -141,8 +142,8 @@
 ### Distro Packages
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| python3-Cython-ohpc | 0.29.37 | The Cython compiler for writing C extensions for the Python language. [http://www.cython.org](http://www.cython.org) |
+|------|--|------------|
+| python3-Cython | 3.2.4 | The Cython compiler for writing C extensions for the Python language. [http://www.cython.org](http://www.cython.org) |
 
 {% endif %}
 
@@ -150,8 +151,8 @@
 ### Runtimes
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| charliecloud-ohpc | 0.40 | Lightweight user-defined software stacks for high-performance computing. [https://charliecloud.io](https://charliecloud.io) |
+|------|--|------------|
+| charliecloud | 0.44 | Lightweight user-defined software stacks for high-performance computing. [https://charliecloud.io](https://charliecloud.io) |
 
 {% endif %}
 
@@ -159,17 +160,17 @@
 ### Serial/Threaded Libraries
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| R-gnu15-ohpc | 4.5.0 | R is a language and environment for statistical computing and graphics (S-Plus like). [http://www.r-project.org](http://www.r-project.org) |
-| cubelib-gnu15-ohpc | 4.9 | CUBE Uniform Behavioral Encoding generic presentation library component. [http://www.scalasca.org/software/cube-4.x/download.html](http://www.scalasca.org/software/cube-4.x/download.html) |
-| gotcha-gnu15-ohpc | 1.0.8 | A library for wrapping function calls to shared libraries. [https://github.com/llnl/gotcha](https://github.com/llnl/gotcha) |
-| gsl-gnu15-ohpc | 2.8 | GNU Scientific Library (GSL). [http://www.gnu.org/software/gsl](http://www.gnu.org/software/gsl) |
-| metis-gnu15-ohpc | 5.1.0 | Serial Graph Partitioning and Fill-reducing Matrix Ordering. [http://glaros.dtc.umn.edu/gkhome/metis/metis/overview](http://glaros.dtc.umn.edu/gkhome/metis/metis/overview) |
-| opari2-gnu15-ohpc | 2.0.9 | An OpenMP runtime performance measurement instrumenter. [https://www.vi-hps.org/projects/score-p](https://www.vi-hps.org/projects/score-p) |
-| openblas-gnu15-ohpc | 0.3.29 | An optimized BLAS library based on GotoBLAS2. [http://www.openblas.net](http://www.openblas.net) |
-| plasma-gnu15-ohpc | 24.8.7 | Parallel Linear Algebra Software for Multicore Architectures. [https://github.com/icl-utk-edu/plasma](https://github.com/icl-utk-edu/plasma) |
-| scotch-gnu15-ohpc | 7.0.7 | Graph, mesh and hypergraph partitioning library. [https://gitlab.inria.fr/scotch/scotch](https://gitlab.inria.fr/scotch/scotch) |
-| superlu-gnu15-ohpc | 7.0.0 | A general purpose library for the direct solution of linear equations. [http://crd.lbl.gov/~xiaoye/SuperLU](http://crd.lbl.gov/~xiaoye/SuperLU) |
+|------|--|------------|
+| R | 4.5.3 | R is a language and environment for statistical computing and graphics (S-Plus like). [http://www.r-project.org](http://www.r-project.org) |
+| cubelib | 4.9.1 | CUBE Uniform Behavioral Encoding generic presentation library component. [http://www.scalasca.org/software/cube-4.x/download.html](http://www.scalasca.org/software/cube-4.x/download.html) |
+| gotcha | 1.0.8 | A library for wrapping function calls to shared libraries. [https://github.com/llnl/gotcha](https://github.com/llnl/gotcha) |
+| gsl | 2.8 | GNU Scientific Library (GSL). [http://www.gnu.org/software/gsl](http://www.gnu.org/software/gsl) |
+| metis | 5.1.0 | Serial Graph Partitioning and Fill-reducing Matrix Ordering. [http://glaros.dtc.umn.edu/gkhome/metis/metis/overview](http://glaros.dtc.umn.edu/gkhome/metis/metis/overview) |
+| opari2 | 2.0.9 | An OpenMP runtime performance measurement instrumenter. [https://www.vi-hps.org/projects/score-p](https://www.vi-hps.org/projects/score-p) |
+| openblas | 0.3.32 | An optimized BLAS library based on GotoBLAS2. [http://www.openblas.net](http://www.openblas.net) |
+| plasma | 25.5.27 | Parallel Linear Algebra Software for Multicore Architectures. [https://github.com/icl-utk-edu/plasma](https://github.com/icl-utk-edu/plasma) |
+| scotch | 7.0.11 | Graph, mesh and hypergraph partitioning library. [https://gitlab.inria.fr/scotch/scotch](https://gitlab.inria.fr/scotch/scotch) |
+| superlu | 7.0.1 | A general purpose library for the direct solution of linear equations. [http://crd.lbl.gov/~xiaoye/SuperLU](http://crd.lbl.gov/~xiaoye/SuperLU) |
 
 {% endif %}
 
@@ -177,18 +178,18 @@
 ### Parallel Libraries
 
 | **RPM Package Name** | **Version** | **Info/URL** |
-|----------------------|-------------|--------------|
-| boost-gnu15-mpich-ohpc<br>boost-gnu15-mvapich2-ohpc<br>boost-gnu15-openmpi5-ohpc | 1.88.0 | Free peer-reviewed portable C++ source libraries. [http://www.boost.org](http://www.boost.org) |
-| fftw-gnu15-mpich-ohpc<br>fftw-gnu15-mvapich2-ohpc<br>fftw-gnu15-openmpi5-ohpc | 3.3.10 | A Fast Fourier Transform library. [http://www.fftw.org](http://www.fftw.org) |
-| hypre-gnu15-mpich-ohpc<br>hypre-gnu15-mvapich2-ohpc<br>hypre-gnu15-openmpi5-ohpc | 2.33.0 | Scalable algorithms for solving linear systems of equations. [http://www.llnl.gov/casc/hypre](http://www.llnl.gov/casc/hypre) |
-| mfem-gnu15-mpich-ohpc<br>mfem-gnu15-mvapich2-ohpc<br>mfem-gnu15-openmpi5-ohpc | 4.4 | Lightweight, general, scalable C++ library for finite element methods. [http://mfem.org](http://mfem.org) |
-| mumps-gnu15-mpich-ohpc<br>mumps-gnu15-mvapich2-ohpc<br>mumps-gnu15-openmpi5-ohpc | 5.8.1 | A MUltifrontal Massively Parallel Sparse direct Solver. [https://mumps-solver.org](https://mumps-solver.org) |
-| petsc-gnu15-mpich-ohpc<br>petsc-gnu15-mvapich2-ohpc<br>petsc-gnu15-openmpi5-ohpc | 3.23.5 | Portable Extensible Toolkit for Scientific Computation. [http://www.mcs.anl.gov/petsc](http://www.mcs.anl.gov/petsc) |
-| ptscotch-gnu15-mpich-ohpc<br>ptscotch-gnu15-mvapich2-ohpc<br>ptscotch-gnu15-openmpi5-ohpc | 7.0.7 | Graph, mesh and hypergraph partitioning library using MPI. [http://www.labri.fr/perso/pelegrin/scotch](http://www.labri.fr/perso/pelegrin/scotch) |
-| scalapack-gnu15-mpich-ohpc<br>scalapack-gnu15-mvapich2-ohpc<br>scalapack-gnu15-openmpi5-ohpc | 2.2.2 | A subset of LAPACK routines redesigned for heterogeneous computing. [https://netlib.org/scalapack](https://netlib.org/scalapack) |
-| slepc-gnu15-mpich-ohpc<br>slepc-gnu15-mvapich2-ohpc<br>slepc-gnu15-openmpi5-ohpc | 3.23.0 | A library for solving large scale sparse eigenvalue problems. [http://slepc.upv.es](http://slepc.upv.es) |
-| superlu_dist-gnu15-mpich-ohpc<br>superlu_dist-gnu15-mvapich2-ohpc<br>superlu_dist-gnu15-openmpi5-ohpc | 6.4.0 | A general purpose library for the direct solution of linear equations. [https://portal.nersc.gov/project/sparse/superlu](https://portal.nersc.gov/project/sparse/superlu) |
-| trilinos-gnu15-mpich-ohpc<br>trilinos-gnu15-mvapich2-ohpc<br>trilinos-gnu15-openmpi5-ohpc | 16.1.0 | A collection of libraries of numerical algorithms. [https://trilinos.org](https://trilinos.org) |
+|------|--|------------|
+| boost | 1.90.0 | Free peer-reviewed portable C++ source libraries. [http://www.boost.org](http://www.boost.org) |
+| fftw | 3.3.10 | A Fast Fourier Transform library. [http://www.fftw.org](http://www.fftw.org) |
+| hypre | 3.1.0 | Scalable algorithms for solving linear systems of equations. [http://www.llnl.gov/casc/hypre](http://www.llnl.gov/casc/hypre) |
+| mfem | 4.9 | Lightweight, general, scalable C++ library for finite element methods. [http://mfem.org](http://mfem.org) |
+| mumps | 5.8.2 | A MUltifrontal Massively Parallel Sparse direct Solver. [https://mumps-solver.org](https://mumps-solver.org) |
+| petsc | 3.25.0 | Portable Extensible Toolkit for Scientific Computation. [http://www.mcs.anl.gov/petsc](http://www.mcs.anl.gov/petsc) |
+| ptscotch | 7.0.11 | Graph, mesh and hypergraph partitioning library using MPI. [https://gitlab.inria.fr/scotch/scotch](https://gitlab.inria.fr/scotch/scotch) |
+| scalapack | 2.2.3 | A subset of LAPACK routines redesigned for heterogeneous computing. [https://netlib.org/scalapack](https://netlib.org/scalapack) |
+| slepc | 3.25.0 | A library for solving large scale sparse eigenvalue problems. [http://slepc.upv.es](http://slepc.upv.es) |
+| superlu_dist | 9.2.1 | A general purpose library for the direct solution of linear equations. [https://portal.nersc.gov/project/sparse/superlu](https://portal.nersc.gov/project/sparse/superlu) |
+| trilinos | 17.0.0 | A collection of libraries of numerical algorithms. [https://trilinos.org](https://trilinos.org) |
 
 {% endif %}
 

--- a/docs/install/pandoc/format-filters.lua
+++ b/docs/install/pandoc/format-filters.lua
@@ -7,6 +7,16 @@
 --   - Vertical fill (vfill for LaTeX)
 --   - Unnumbered sections (via .unnumbered class)
 --   - Unicode checkmarks (convert to \checkmark for LaTeX)
+--   - HTML <br> tags in table cells (convert to line breaks for PDF)
+--   - Package manifest tables (dashed row separators for PDF)
+
+function RawInline(elem)
+  -- Convert HTML <br> tags to proper line breaks so they render in PDF
+  if elem.format == 'html' and elem.text:match '^<br%s*/?>' then
+    return pandoc.LineBreak()
+  end
+  return elem
+end
 
 function Str(elem)
   -- Replace Unicode checkmark (✓) with LaTeX \checkmark command
@@ -325,4 +335,86 @@ function Div(elem)
     end
   end
   return elem
+end
+
+function Table(elem)
+  -- Add thin gray row separators to manifest tables in PDF output
+  if not FORMAT:match 'latex' then
+    return elem
+  end
+
+  -- Only process manifest tables: package tables ("RPM Package Name")
+  -- and meta-package tables ("Group Name")
+  local head = elem.head
+  if not head.rows or #head.rows == 0 then return elem end
+  local hrow = head.rows[1]
+  if not hrow.cells or #hrow.cells < 2 then return elem end
+  local txt = pandoc.utils.stringify(hrow.cells[1].contents)
+  if txt ~= 'RPM Package Name' and txt ~= 'Group Name' then return elem end
+
+  -- Helper: convert cell content blocks to LaTeX
+  local function cell_to_latex(cell)
+    if not cell.contents or #cell.contents == 0 then return '' end
+    local s = pandoc.write(pandoc.Pandoc(cell.contents), 'latex')
+    s = s:gsub('%s+$', '')
+    return s
+  end
+
+  -- Build column spec from colspecs
+  local ncols = #elem.colspecs
+  local cols = {}
+  for _, spec in ipairs(elem.colspecs) do
+    local w = spec[2]
+    if w and w > 0 then
+      table.insert(cols, string.format(
+        '>{\\raggedright\\arraybackslash}p{(\\linewidth - %d\\tabcolsep) * \\real{%.4f}}',
+        2 * ncols, w))
+    else
+      table.insert(cols, 'l')
+    end
+  end
+
+  -- Header cells
+  local hcells = {}
+  for _, c in ipairs(hrow.cells) do
+    table.insert(hcells, cell_to_latex(c))
+  end
+
+  -- Collect all body rows
+  local all_rows = {}
+  for _, tbody in ipairs(elem.bodies) do
+    for _, row in ipairs(tbody.body) do
+      table.insert(all_rows, row)
+    end
+  end
+
+  -- Build LaTeX
+  local latex = {}
+  table.insert(latex, '\\begin{longtable}[]{@{}')
+  for i, col in ipairs(cols) do
+    table.insert(latex, '  ' .. col)
+  end
+  table.insert(latex, '@{}}')
+  table.insert(latex, '\\toprule\\noalign{}')
+  table.insert(latex, table.concat(hcells, ' & ') .. ' \\\\')
+  table.insert(latex, '\\midrule\\noalign{}')
+  table.insert(latex, '\\endhead')
+  table.insert(latex, '\\bottomrule\\noalign{}')
+  table.insert(latex, '\\endlastfoot')
+
+  -- Body rows with dashed separators
+  for i, row in ipairs(all_rows) do
+    local rcells = {}
+    for _, c in ipairs(row.cells) do
+      table.insert(rcells, cell_to_latex(c))
+    end
+    table.insert(latex, table.concat(rcells, ' & ') .. ' \\\\')
+    if i < #all_rows then
+      table.insert(latex, '\\arrayrulecolor{black!20}\\specialrule{0.3pt}{1pt}{1pt}\\arrayrulecolor{black}')
+    end
+  end
+
+  table.insert(latex, '\\end{longtable}')
+
+  return pandoc.RawBlock('latex', table.concat(latex, '\n'))
 end

--- a/docs/install/pandoc/header-includes.tex.j2
+++ b/docs/install/pandoc/header-includes.tex.j2
@@ -2,6 +2,7 @@
 \usepackage{fancyhdr}
 \usepackage{fancyvrb}
 \usepackage{xcolor}
+\usepackage{colortbl}
 
 % Define light gray color for code block backgrounds
 \definecolor{codebggray}{RGB}{245,245,245}


### PR DESCRIPTION
- Strip -ohpc suffix and compiler/MPI/build variant names from package display names, showing only the base package name (e.g. phdf5 instead of phdf5-gnu15-impi-ohpc)
- Add build_variants config (ofi, ucx, pmix) for stripping transport and build variant infixes
- Merge groups sharing the same base name and version into a single table row
- Set column widths via separator dashes (30/10/60 for package tables, 35/65 for meta-package tables)
- Add Lua filter to render thin gray row separators and convert HTML <br> tags to line breaks in PDF output
- Add colortbl LaTeX package for separator styling