### PR TITLE
ci: update all GitHub Actions to latest versions

### DIFF
--- a/.github/actions/oneapi-cache/action.yml
+++ b/.github/actions/oneapi-cache/action.yml
@@ -14,7 +14,7 @@ runs:
     - name: Restore oneAPI package cache
       if: inputs.mode == 'restore'
       id: restore-oneapi
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: /var/cache/dnf/oneAPI-*/packages
         key: dnf-oneapi-rhel
@@ -42,7 +42,7 @@ runs:
         done
     - name: Save oneAPI package cache
       if: inputs.mode == 'save'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: /var/cache/dnf/oneAPI-*/packages
         key: dnf-oneapi-rhel-${{ github.run_id }}

--- a/.github/actions/upload-ccache-stats/action.yml
+++ b/.github/actions/upload-ccache-stats/action.yml
@@ -32,7 +32,7 @@ runs:
         # Raw output for collapsible section
         echo "$RAW_STATS" > /tmp/ccache-stats/raw.txt
     - name: Upload ccache stats
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ccache-stats-${{ inputs.artifact-suffix }}
         retention-days: 1

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,7 +14,8 @@ available on GitHub and manages GitHub issues to track update status.
 1. **Schedule**: Manual triggering only (hourly schedule disabled for now)
 2. **Container**: Uses Red Hat UBI 10 container
    (`registry.access.redhat.com/ubi10:latest`)
-3. **Dependencies**: Installs required tools (rpm-build, rpmdevtools, curl, jq, git)
+3. **Dependencies**: Installs required tools
+   (rpm-build, rpmdevtools, curl, jq, git)
 4. **RPM Environment**: Sets up RPM build directories for proper spec file parsing
 5. **Package Check**: Executes `misc/check_for_package_updates.sh` with
    markdown output

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -32,14 +32,14 @@ jobs:
       digest-aarch64: ${{ steps.export.outputs.digest-aarch64 }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -48,7 +48,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -56,7 +56,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./containers
           file: ./containers/container/Containerfile
@@ -81,11 +81,11 @@ jobs:
       packages: write
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -94,7 +94,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/build-ohpc-analysis-container.yml
+++ b/.github/workflows/build-ohpc-analysis-container.yml
@@ -18,13 +18,13 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -32,14 +32,14 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest
 
       - name: Build and push container
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./tests/ci/Containerfile.ohpc-analysis

--- a/.github/workflows/build-ohpc-lint-container.yml
+++ b/.github/workflows/build-ohpc-lint-container.yml
@@ -18,13 +18,13 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -32,14 +32,14 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest
 
       - name: Build and push container
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./tests/ci/Containerfile.ohpc-lint

--- a/.github/workflows/build-ohpc-validate-container.yml
+++ b/.github/workflows/build-ohpc-validate-container.yml
@@ -31,13 +31,13 @@ jobs:
       openeuler-digest-aarch64: ${{ steps.export.outputs.openeuler-digest-aarch64 }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -45,7 +45,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/openhpc/ohpc-validate-${{ matrix.distro }}
           tags: |
@@ -53,7 +53,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./tests/ci/Containerfile.ohpc-validate-${{ matrix.distro }}
@@ -79,10 +79,10 @@ jobs:
         distro: [ almalinux, openeuler ]
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/build-order-analysis.yml
+++ b/.github/workflows/build-order-analysis.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Save PR context
       env:
@@ -150,7 +150,7 @@ jobs:
 
     - name: Upload build order results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: build-order-analysis
         retention-days: 5

--- a/.github/workflows/build-order-comment.yml
+++ b/.github/workflows/build-order-comment.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: Post comment to PR
       if: steps.artifact_check.outputs.artifacts_found == 'true'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         script: |
           const fs = require('fs');

--- a/.github/workflows/ccache-stats-comment.yml
+++ b/.github/workflows/ccache-stats-comment.yml
@@ -185,7 +185,7 @@ jobs:
 
     - name: Post comment to PR
       if: steps.artifact_check.outputs.artifacts_found == 'true' && steps.pr.outputs.number != ''
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         script: |
           const fs = require('fs');

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,9 +16,9 @@ jobs:
     name: Run markdown linter
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Lint markdown
-      uses: DavidAnson/markdownlint-cli2-action@v15
+      uses: DavidAnson/markdownlint-cli2-action@v23
       with:
         globs: |
           README.md
@@ -35,6 +35,6 @@ jobs:
     container:
       image: ghcr.io/openhpc/ohpc-lint:latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Run ${{ matrix.step }}
       run: make -C tests/ci/ ${{ matrix.step }}-lint

--- a/.github/workflows/package-count-analysis.yml
+++ b/.github/workflows/package-count-analysis.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0  # Fetch full history for proper branch detection
 
@@ -114,7 +114,7 @@ jobs:
 
     - name: Upload package count results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: package-count-analysis
         retention-days: 5

--- a/.github/workflows/package-count-comment.yml
+++ b/.github/workflows/package-count-comment.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: Post comment to PR
       if: steps.artifact_check.outputs.artifacts_found == 'true'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         script: |
           const fs = require('fs');

--- a/.github/workflows/package-update-checker.yml
+++ b/.github/workflows/package-update-checker.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ matrix.branch }}
 
@@ -93,7 +93,7 @@ jobs:
       run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
     - name: Manage GitHub issue
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |

--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -14,9 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send custom JSON to Slack
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@v3
         with:
-          # This converts the GitHub data into the "text" field Slack was missing
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "text": "*${{ github.event_name == 'pull_request_target' && 'Pull Request' || 'Issue' }} Update* in ${{ github.repository }}",
@@ -45,6 +46,3 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'A friendly reminder that this issue had no activity for 30 days.'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,7 +28,7 @@ jobs:
       image: ghcr.io/openhpc/ohpc-analysis:latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - id: files
       uses: Ana06/get-changed-files@v2.3.0
     - name: Validate Changes
@@ -64,9 +64,9 @@ jobs:
         rm -rf /host/usr/share/dotnet /host/usr/local/lib/android /host/opt/ghc
     - name: Update packages
       run: dnf -y update
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Restore ccache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: /var/cache/ccache
         key: ccache-rhel-${{ matrix.arch }}-${{ matrix.compiler }}-${{ github.sha }}
@@ -99,7 +99,7 @@ jobs:
         . /etc/profile.d/lmod.sh
         tests/ci/run_build.py ohpc ${{ steps.files.outputs.added_modified }} --compiler-family ${{ matrix.compiler }}
         touch /tmp/empty
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: rhel-rpms-${{ matrix.compiler }}-${{ matrix.os }}
         retention-days: 1
@@ -115,7 +115,7 @@ jobs:
         mode: save
     - name: Save ccache
       if: always()
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: /var/cache/ccache
         key: ccache-rhel-${{ matrix.arch }}-${{ matrix.compiler }}-${{ github.sha }}-${{ github.run_id }}-build
@@ -152,9 +152,9 @@ jobs:
         rm -rf /host/usr/share/dotnet /host/usr/local/lib/android /host/opt/ghc
     - name: Update packages
       run: dnf -y update
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Restore ccache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: /var/cache/ccache
         key: ccache-rhel-${{ matrix.arch }}-${{ matrix.compiler }}-${{ github.sha }}-${{ github.run_id }}-build
@@ -169,7 +169,7 @@ jobs:
       run: tests/ci/prepare-ci-environment.sh  ${{ matrix.compiler }}
     - id: files
       uses: Ana06/get-changed-files@v2.3.0
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         name: rhel-rpms-${{ matrix.compiler }}-${{ matrix.os }}
         path: /home/ohpc/rpmbuild/RPMS
@@ -208,7 +208,7 @@ jobs:
       # To display test results from forked repositories they need to
       # be uploaded and then analyzed.
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: test-results-${{ matrix.compiler }}-${{ matrix.os }}
         retention-days: 1
@@ -220,7 +220,7 @@ jobs:
         mode: save
     - name: Save ccache
       if: always()
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: /var/cache/ccache
         key: ccache-rhel-${{ matrix.arch }}-${{ matrix.compiler }}-${{ github.sha }}-${{ github.run_id }}
@@ -251,9 +251,9 @@ jobs:
     steps:
     - name: Update packages
       run: dnf -y update
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Restore ccache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: /var/cache/ccache
         key: ccache-openeuler-${{ matrix.arch }}-${{ github.sha }}
@@ -275,7 +275,7 @@ jobs:
         . /etc/profile.d/lmod.sh
         tests/ci/run_build.py ohpc ${{ steps.files.outputs.added_modified }}
         touch /tmp/empty
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: openEuler-rpms-${{ matrix.os }}
         retention-days: 1
@@ -286,7 +286,7 @@ jobs:
           /tmp/empty
     - name: Save ccache
       if: always()
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: /var/cache/ccache
         key: ccache-openeuler-${{ matrix.arch }}-${{ github.sha }}-${{ github.run_id }}-build
@@ -316,9 +316,9 @@ jobs:
     steps:
     - name: Update packages
       run: dnf -y update
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Restore ccache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: /var/cache/ccache
         key: ccache-openeuler-${{ matrix.arch }}-${{ github.sha }}-${{ github.run_id }}-build
@@ -328,7 +328,7 @@ jobs:
       run: tests/ci/prepare-ci-environment.sh  ${{ matrix.compiler }}
     - id: files
       uses: Ana06/get-changed-files@v2.3.0
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         name: openEuler-rpms-${{ matrix.os }}
         path: /home/ohpc/rpmbuild/RPMS
@@ -357,7 +357,7 @@ jobs:
         fi
     - name: Save ccache
       if: always()
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: /var/cache/ccache
         key: ccache-openeuler-${{ matrix.arch }}-${{ github.sha }}-${{ github.run_id }}
@@ -374,7 +374,7 @@ jobs:
     steps:
     - name: Upload
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: event-file
         retention-days: 1

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 This stack provides a variety of common, pre-built ingredients required to
 deploy and manage an HPC Linux cluster including provisioning tools, resource
-management, I/O clients, runtimes, development tools, containers, and a variety of
-scientific libraries.
+management, I/O clients, runtimes, development tools, containers,
+and a variety of scientific libraries.
 
 There are currently three release series: the [2.x][2xbranch], the
 [3.x][3xbranch] and the [4.x][4xbranch] which target different major Linux OS


### PR DESCRIPTION
Update 12 actions across 16 workflow files and 2 composite actions:
- actions/checkout v4 -> v6
- actions/cache v4 -> v5
- actions/upload-artifact v4 -> v7
- actions/download-artifact v4 -> v8
- actions/stale v9 -> v10
- actions/github-script v7 -> v9
- docker/build-push-action v6 -> v7
- docker/login-action v3 -> v4
- docker/metadata-action v5 -> v6
- docker/setup-buildx-action v3 -> v4
- DavidAnson/markdownlint-cli2-action v15 -> v23
- slackapi/slack-github-action v1.26.0 -> v3

The Slack action v3 has breaking API changes: webhook URL and type are now passed as inputs instead of environment variables.

Generated with Claude Code (https://claude.ai/code)