### PR TITLE
ci: add Containerfiles for validate containers and add

### DIFF
--- a/tests/ci/Containerfile.ohpc-validate-almalinux
+++ b/tests/ci/Containerfile.ohpc-validate-almalinux
@@ -1,0 +1,14 @@
+FROM docker.io/library/almalinux:9
+
+# Install git first (required for cloning/checkout)
+RUN dnf -y install git
+
+# Update all packages
+RUN dnf -y update
+
+# Copy the prepare script
+COPY tests/ci/prepare-ci-environment.sh /tmp/prepare-ci-environment.sh
+RUN chmod +x /tmp/prepare-ci-environment.sh
+
+# Run prepare-ci-environment.sh
+RUN /tmp/prepare-ci-environment.sh

--- a/tests/ci/Containerfile.ohpc-validate-leap
+++ b/tests/ci/Containerfile.ohpc-validate-leap
@@ -1,0 +1,14 @@
+FROM registry.opensuse.org/opensuse/leap:15.5
+
+# Install git first (required for cloning/checkout)
+RUN zypper -n install git
+
+# Update all packages
+RUN zypper -n update
+
+# Copy the prepare script
+COPY tests/ci/prepare-ci-environment.sh /tmp/prepare-ci-environment.sh
+RUN chmod +x /tmp/prepare-ci-environment.sh
+
+# Run prepare-ci-environment.sh
+RUN /tmp/prepare-ci-environment.sh

--- a/tests/ci/Containerfile.ohpc-validate-openeuler
+++ b/tests/ci/Containerfile.ohpc-validate-openeuler
@@ -1,0 +1,14 @@
+FROM docker.io/openeuler/openeuler:22.03-lts-sp3
+
+# Install git first (required for cloning/checkout)
+RUN dnf -y install git
+
+# Update all packages
+RUN dnf -y update
+
+# Copy the prepare script
+COPY tests/ci/prepare-ci-environment.sh /tmp/prepare-ci-environment.sh
+RUN chmod +x /tmp/prepare-ci-environment.sh
+
+# Run prepare-ci-environment.sh
+RUN /tmp/prepare-ci-environment.sh

--- a/tests/ci/prepare-ci-environment.sh
+++ b/tests/ci/prepare-ci-environment.sh
@@ -22,7 +22,7 @@ fi
 . /etc/os-release
 
 PKG_MANAGER=zypper
-COMMON_PKGS="wget python3 jq man"
+COMMON_PKGS="wget python3 jq man createrepo_c"
 UNAME_M=$(uname -m)
 YES="-n"
 


### PR DESCRIPTION
createrepo_c to common packages

Add Containerfiles for almalinux, openeuler, and leap validate containers to be built by the 4.x branch workflow. Add createrepo_c to COMMON_PKGS in prepare-ci-environment.sh.