### PR TITLE
ci: add 3.x validate container build and cleanup

### DIFF
--- a/.github/workflows/build-ohpc-validate-container.yml
+++ b/.github/workflows/build-ohpc-validate-container.yml
@@ -99,3 +99,97 @@ jobs:
         run: |
           echo "Container built and pushed successfully!"
           echo "Image: ${{ env.REGISTRY }}/openhpc/ohpc-validate-${{ matrix.distro }}:latest"
+
+  build-3x:
+    runs-on: ${{ matrix.runs-on }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        distro: [ almalinux, openeuler, leap ]
+        arch: [ x86_64, aarch64 ]
+        include:
+          - arch: x86_64
+            runs-on: ubuntu-24.04
+          - arch: aarch64
+            runs-on: ubuntu-24.04-arm
+    outputs:
+      almalinux-digest-x86_64: ${{ steps.export.outputs.almalinux-digest-x86_64 }}
+      almalinux-digest-aarch64: ${{ steps.export.outputs.almalinux-digest-aarch64 }}
+      openeuler-digest-x86_64: ${{ steps.export.outputs.openeuler-digest-x86_64 }}
+      openeuler-digest-aarch64: ${{ steps.export.outputs.openeuler-digest-aarch64 }}
+      leap-digest-x86_64: ${{ steps.export.outputs.leap-digest-x86_64 }}
+      leap-digest-aarch64: ${{ steps.export.outputs.leap-digest-aarch64 }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: 3.x
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/openhpc/ohpc-validate-${{ matrix.distro }}
+          tags: |
+            type=raw,value=3.x
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./tests/ci/Containerfile.ohpc-validate-${{ matrix.distro }}
+          platforms: linux/${{ matrix.arch }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          sbom: false
+          outputs: type=image,name=${{ env.REGISTRY }}/openhpc/ohpc-validate-${{ matrix.distro }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        id: export
+        run: |
+          echo "${{ matrix.distro }}-digest-${{ matrix.arch }}=${{ steps.build.outputs.digest }}" >> $GITHUB_OUTPUT
+
+  publish-3x:
+    runs-on: ubuntu-24.04
+    needs: build-3x
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        distro: [ almalinux, openeuler, leap ]
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push manifest
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.REGISTRY }}/openhpc/ohpc-validate-${{ matrix.distro }}:3.x \
+            ${{ env.REGISTRY }}/openhpc/ohpc-validate-${{ matrix.distro }}@${{ needs.build-3x.outputs[format('{0}-digest-x86_64', matrix.distro)] }} \
+            ${{ env.REGISTRY }}/openhpc/ohpc-validate-${{ matrix.distro }}@${{ needs.build-3x.outputs[format('{0}-digest-aarch64', matrix.distro)] }}
+
+      - name: Output image details
+        run: |
+          echo "Container built and pushed successfully!"
+          echo "Image: ${{ env.REGISTRY }}/openhpc/ohpc-validate-${{ matrix.distro }}:3.x"

--- a/.github/workflows/cleanup-packages.yml
+++ b/.github/workflows/cleanup-packages.yml
@@ -77,6 +77,17 @@ jobs:
           delete-only-untagged-versions: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Delete untagged ohpc-validate-leap images
+        id: cleanup-validate-leap
+        continue-on-error: true
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: ohpc-validate-leap
+          package-type: container
+          min-versions-to-keep: 3
+          delete-only-untagged-versions: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Report cleanup results
         run: |
           echo "Cleanup Results:"
@@ -85,6 +96,7 @@ jobs:
           echo "Analysis container cleanup: ${{ steps.cleanup-analysis.outcome }}"
           echo "Validate AlmaLinux container cleanup: ${{ steps.cleanup-validate-almalinux.outcome }}"
           echo "Validate openEuler container cleanup: ${{ steps.cleanup-validate-openeuler.outcome }}"
+          echo "Validate Leap container cleanup: ${{ steps.cleanup-validate-leap.outcome }}"
 
           if [[ "${{ steps.cleanup-main.outcome }}" == "failure" ]]; then
             echo "Warning: Main container cleanup failed - package may not exist yet"
@@ -104,6 +116,10 @@ jobs:
 
           if [[ "${{ steps.cleanup-validate-openeuler.outcome }}" == "failure" ]]; then
             echo "Warning: Validate openEuler container cleanup failed - package may not exist yet"
+          fi
+
+          if [[ "${{ steps.cleanup-validate-leap.outcome }}" == "failure" ]]; then
+            echo "Warning: Validate Leap container cleanup failed - package may not exist yet"
           fi
 
           echo "Cleanup workflow completed"


### PR DESCRIPTION
Add build-3x and publish-3x jobs to build validate containers from the 3.x branch, including leap alongside almalinux and openeuler. Images are tagged with 3.x instead of latest. Add ohpc-validate-leap cleanup step to the cleanup workflow.