### PR TITLE
ci: switch to pre-built validate containers

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Build on RHEL (${{ matrix.arch }}/${{ matrix.compiler }})
     container:
-      image: docker.io/library/almalinux:9
+      image: ghcr.io/openhpc/ohpc-validate-almalinux:3.x
       volumes:
         - /usr:/host/usr
         - /opt:/host/opt
@@ -57,8 +57,8 @@ jobs:
       # Needed to have enough space to install the Intel compiler
       run: |
         rm -rf /host/usr/share/dotnet /host/usr/local/lib/android /host/opt/ghc
-    - name: Install git
-      run: dnf -y install git createrepo_c
+    - name: Update packages
+      run: dnf -y update
     - uses: actions/checkout@v4
     - name: Restore ccache
       uses: actions/cache/restore@v4
@@ -125,7 +125,7 @@ jobs:
       JOB_SKIP_CI_SPECS: |
         components/perf-tools/likwid/SPECS/likwid.spec
     container:
-      image: docker.io/library/almalinux:9
+      image: ghcr.io/openhpc/ohpc-validate-almalinux:3.x
       options: --privileged --security-opt seccomp=unconfined --security-opt apparmor=unconfined
       volumes:
         - /usr:/host/usr
@@ -136,8 +136,8 @@ jobs:
       # Needed to have enough space to install the Intel compiler
       run: |
         rm -rf /host/usr/share/dotnet /host/usr/local/lib/android /host/opt/ghc
-    - name: Install git
-      run: dnf -y install git
+    - name: Update packages
+      run: dnf -y update
     - uses: actions/checkout@v4
     - name: Restore ccache
       uses: actions/cache/restore@v4
@@ -223,14 +223,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Build on openEuler (${{ matrix.arch }})
     container:
-      image: docker.io/openeuler/openeuler:22.03-lts-sp3
+      image: ghcr.io/openhpc/ohpc-validate-openeuler:3.x
     steps:
-    - name: Switch repo
-      run: |
-        sed -i "s@repo.openeuler.org@mirrors.ocf.berkeley.edu/openeuler@g" /etc/yum.repos.d/openEuler.repo
-        sed -i "s@^\(metalink=\)@#\1@g" /etc/yum.repos.d/openEuler.repo
-    - name: Install git
-      run: dnf -y install git createrepo_c
+    - name: Update packages
+      run: dnf -y update
     - uses: actions/checkout@v4
     - name: Restore ccache
       uses: actions/cache/restore@v4
@@ -289,16 +285,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Test on openEuler (${{ matrix.arch }}/${{ matrix.compiler }})
     container:
-      image: docker.io/openeuler/openeuler:22.03-lts-sp3
+      image: ghcr.io/openhpc/ohpc-validate-openeuler:3.x
       options: --privileged --security-opt seccomp=unconfined --security-opt apparmor=unconfined
     needs: build_on_openEuler
     steps:
-    - name: Switch repo
-      run: |
-        sed -i "s@repo.openeuler.org@mirrors.ocf.berkeley.edu/openeuler@g" /etc/yum.repos.d/openEuler.repo
-        sed -i "s@^\(metalink=\)@#\1@g" /etc/yum.repos.d/openEuler.repo
-    - name: Install git
-      run: dnf -y install git
+    - name: Update packages
+      run: dnf -y update
     - uses: actions/checkout@v4
     - name: Restore ccache
       uses: actions/cache/restore@v4
@@ -363,10 +355,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Build on LEAP (${{ matrix.arch }})
     container:
-      image: registry.opensuse.org/opensuse/leap:15.5
+      image: ghcr.io/openhpc/ohpc-validate-leap:3.x
     steps:
-    - name: Install git
-      run: zypper -n update; zypper -n install git createrepo_c python311
+    - name: Update packages
+      run: zypper -n update
     - uses: actions/checkout@v4
     - name: Restore ccache
       uses: actions/cache/restore@v4
@@ -424,12 +416,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Test on LEAP (${{ matrix.arch }}/${{ matrix.compiler }})
     container:
-      image: registry.opensuse.org/opensuse/leap:15.5
+      image: ghcr.io/openhpc/ohpc-validate-leap:3.x
       options: --privileged --security-opt seccomp=unconfined --security-opt apparmor=unconfined
     needs: build_on_leap
     steps:
-    - name: Install git
-      run: zypper -n update; zypper -n install git
+    - name: Update packages
+      run: zypper -n update
     - uses: actions/checkout@v4
     - name: Restore ccache
       uses: actions/cache/restore@v4

--- a/tests/ci/prepare-ci-environment.sh
+++ b/tests/ci/prepare-ci-environment.sh
@@ -154,14 +154,17 @@ if [ "${PKG_MANAGER}" = "dnf" ]; then
 	else
 		dnf_rhel
 	fi
-	adduser ohpc
+	adduser ohpc || true
 else
 	loop_command "${PKG_MANAGER}" "${YES}" --no-gpg-checks install ${COMMON_PKGS} awk rpmbuild bats ccache "${OHPC_RELEASE}"
 	if [ "${FACTORY_VERSION}" != "" ]; then
 		loop_command wget "${FACTORY_REPOSITORY}" -O "${FACTORY_REPOSITORY_DESTINATION}"
 	fi
 	loop_command "${PKG_MANAGER}" "${YES}" --no-gpg-checks install lmod-ohpc "${ENABLE_ONEAPI}"
-	useradd -m ohpc -U
-	mkdir -p /var/cache/ccache
-	chown -R ohpc:ohpc /var/cache/ccache
+	useradd -m ohpc -U || true
 fi
+
+# Setup ccache
+echo "cache_dir=/var/cache/ccache" >/etc/ccache.conf
+mkdir -p /var/cache/ccache
+chown -R ohpc:ohpc /var/cache/ccache


### PR DESCRIPTION
Use ghcr.io/openhpc/ohpc-validate-*:3.x containers instead of bare distro images. Replace install steps with update steps since git, createrepo_c, and other dependencies are already in the pre-built containers.

Generated with Claude Code (https://claude.ai/code)