### PR TITLE
components: add check-updates skip tags to spec files

### DIFF
--- a/components/admin/mrsh/SPECS/mrsh.spec
+++ b/components/admin/mrsh/SPECS/mrsh.spec
@@ -7,6 +7,7 @@
 # desired integration conventions.
 #
 #----------------------------------------------------------------------------eh-
+# OpenHPC:check-updates:skip no upstream releases
 
 %include %{_sourcedir}/OHPC_macros
 

--- a/components/dev-tools/cuda-devel/SPECS/cuda-devel.spec
+++ b/components/dev-tools/cuda-devel/SPECS/cuda-devel.spec
@@ -7,6 +7,7 @@
 # desired integration conventions.
 #
 #----------------------------------------------------------------------------eh-
+# OpenHPC:check-updates:skip no upstream
 
 %include %{_sourcedir}/OHPC_macros
 

--- a/components/distro-packages/sigar/SPECS/sigar.spec
+++ b/components/distro-packages/sigar/SPECS/sigar.spec
@@ -7,6 +7,7 @@
 # desired integration conventions.
 #
 #----------------------------------------------------------------------------eh-
+# OpenHPC:check-updates:skip no upstream releases
 
 %include %{_sourcedir}/OHPC_macros
 

--- a/components/provisioning/warewulf-cluster/SPECS/warewulf-cluster.spec
+++ b/components/provisioning/warewulf-cluster/SPECS/warewulf-cluster.spec
@@ -7,6 +7,7 @@
 # desired integration conventions.
 #
 #----------------------------------------------------------------------------eh-
+# OpenHPC:check-updates:skip upstream no longer active
 
 %include %{_sourcedir}/OHPC_macros
 

--- a/components/provisioning/warewulf-common/SPECS/warewulf-common.spec
+++ b/components/provisioning/warewulf-common/SPECS/warewulf-common.spec
@@ -7,6 +7,7 @@
 # desired integration conventions.
 #
 #----------------------------------------------------------------------------eh-
+# OpenHPC:check-updates:skip upstream no longer active
 
 %include %{_sourcedir}/OHPC_macros
 

--- a/components/provisioning/warewulf-ipmi/SPECS/warewulf-ipmi.spec
+++ b/components/provisioning/warewulf-ipmi/SPECS/warewulf-ipmi.spec
@@ -7,6 +7,7 @@
 # desired integration conventions.
 #
 #----------------------------------------------------------------------------eh-
+# OpenHPC:check-updates:skip upstream no longer active
 
 %include %{_sourcedir}/OHPC_macros
 

--- a/components/provisioning/warewulf-provision/SPECS/warewulf-provision.spec
+++ b/components/provisioning/warewulf-provision/SPECS/warewulf-provision.spec
@@ -7,6 +7,7 @@
 # desired integration conventions.
 #
 #----------------------------------------------------------------------------eh-
+# OpenHPC:check-updates:skip upstream no longer active
 
 %include %{_sourcedir}/OHPC_macros
 

--- a/components/provisioning/warewulf-vnfs/SPECS/warewulf-vnfs.spec
+++ b/components/provisioning/warewulf-vnfs/SPECS/warewulf-vnfs.spec
@@ -7,6 +7,7 @@
 # desired integration conventions.
 #
 #----------------------------------------------------------------------------eh-
+# OpenHPC:check-updates:skip upstream no longer active
 
 %include %{_sourcedir}/OHPC_macros
 

--- a/components/serial-libs/metis/SPECS/metis.spec
+++ b/components/serial-libs/metis/SPECS/metis.spec
@@ -7,6 +7,7 @@
 # desired integration conventions.
 #
 #----------------------------------------------------------------------------eh-
+# OpenHPC:check-updates:skip no upstream releases
 
 # Serial metis build dependent on compiler toolchain
 %global ohpc_compiler_dependent 1


### PR DESCRIPTION
Mark warewulf3 components (common, cluster, ipmi, provision, vnfs) as skipped since upstream is no longer active. Mark sigar, mrsh, and metis as skipped due to no upstream releases. Mark cuda-devel as skipped due to no upstream.

Generated with Claude Code (https://claude.ai/code)