### PR TITLE
Update Confluent to use the latest Rocky 9

### DIFF
--- a/docs/install/recipes/almalinux9-aarch64-confluent-slurm.yaml
+++ b/docs/install/recipes/almalinux9-aarch64-confluent-slurm.yaml
@@ -1,2 +1,1 @@
-distro_id: "alma-9.5-aarch64-default"
-distro_iso_image: "AlmaLinux-9.5-aarch64-dvd.iso"
+distro_iso_image: "AlmaLinux-9-latest-aarch64-dvd.iso"

--- a/docs/install/recipes/almalinux9-x86_64-confluent-slurm.yaml
+++ b/docs/install/recipes/almalinux9-x86_64-confluent-slurm.yaml
@@ -1,2 +1,1 @@
-distro_id: "alma-9.5-x86_64-default"
-distro_iso_image: "AlmaLinux-9.5-x86_64-dvd.iso"
+distro_iso_image: "AlmaLinux-9-latest-x86_64-dvd.iso"

--- a/docs/install/recipes/rocky9-aarch64-confluent-slurm.yaml
+++ b/docs/install/recipes/rocky9-aarch64-confluent-slurm.yaml
@@ -1,2 +1,1 @@
-distro_id: "rocky-9.5-aarch64-default"
-distro_iso_image: "Rocky-9.5-aarch64-dvd1.iso"
+distro_iso_image: "Rocky-9-latest-aarch64-dvd.iso"

--- a/docs/install/recipes/rocky9-x86_64-confluent-slurm.yaml
+++ b/docs/install/recipes/rocky9-x86_64-confluent-slurm.yaml
@@ -1,2 +1,1 @@
-distro_id: "rocky-9.5-x86_64-default"
-distro_iso_image: "Rocky-9.5-x86_64-dvd1.iso"
+distro_iso_image: "Rocky-9-latest-x86_64-dvd.iso"

--- a/docs/install/templates/provisioner/confluent/add-nodes.md.j2
+++ b/docs/install/templates/provisioner/confluent/add-nodes.md.j2
@@ -73,6 +73,6 @@ network services like DNS and DHCP. These tasks are accomplished as follows:
 <!-- ohpc_comment Complete networking setup, associate provisioning image -->
 ```bash
 # Associate desired provisioning image for computes
-nodedeploy -n compute -p {{ distro_id }}
+nodedeploy -n compute -p ${distro_id}
 ```
 <!-- ohpc_end -->

--- a/docs/install/templates/provisioner/confluent/init-os-images.md.j2
+++ b/docs/install/templates/provisioner/confluent/init-os-images.md.j2
@@ -18,7 +18,10 @@ initialize -i`
 <!-- ohpc_comment Initialize OS images for use with Confluent -->
 ```bash
 osdeploy initialize -${initialize_options:-usklpta}
-osdeploy import ${iso_path:-{{ distro_iso_image }}}
+: "${iso_path:={{ distro_iso_image }}}"
+distro_id=$(osdeploy importcheck "${iso_path}" 2>&1 \
+	| sed -En 's/Detected distribution name: (.*)/\1-default/p')
+osdeploy import "${iso_path}"
 restorecon -Rv /var/lib/confluent/
 ```
 <!-- ohpc_end -->
@@ -36,10 +39,12 @@ You could also add `debug` here as well to increase debug messages.
 
 <!-- ohpc_begin -->
 ```bash
-# Update kernel arguments
-yq -i '.kernelargs = "console=ttyS0,115200 console=tty0 rd.shell"' \
-  /var/lib/confluent/public/os/{{ distro_id }}/profile.yaml
-osdeploy updateboot {{ distro_id }}
+# Update kernel arguments: drop quiet, add serial console
+yq -i '.kernelargs |= sub("quiet ?", "")' \
+  /var/lib/confluent/public/os/${distro_id}/profile.yaml
+yq -i ".kernelargs += \" console=tty0 console={% if is_aarch64 %}ttyAMA0{% else %}ttyS0{% endif %},115200 rd.shell\"" \
+  /var/lib/confluent/public/os/${distro_id}/profile.yaml
+osdeploy updateboot ${distro_id}
 ```
 <!-- ohpc_end -->
 
@@ -53,6 +58,6 @@ command should be run.
 <!-- ohpc_comment Sync the hosts file in cluster -->
 ```bash
 echo "/etc/hosts -> /etc/hosts" >> \
-	/var/lib/confluent/public/os/{{ distro_id }}/syncfiles
+	/var/lib/confluent/public/os/${distro_id}/syncfiles
 ```
 <!-- ohpc_end -->

--- a/docs/install/templates/provisioner/confluent/post-add-user.md.j2
+++ b/docs/install/templates/provisioner/confluent/post-add-user.md.j2
@@ -17,9 +17,9 @@ credential files on *compute* nodes:
 ```bash
 # Create a sync file for pushing user credentials to the nodes
 echo "/etc/passwd -> /etc/passwd" >> \
-	/var/lib/confluent/public/os/{{ distro_id }}/syncfiles
+	/var/lib/confluent/public/os/${distro_id}/syncfiles
 echo "/etc/group -> /etc/group" >> \
-	/var/lib/confluent/public/os/{{ distro_id }}/syncfiles
+	/var/lib/confluent/public/os/${distro_id}/syncfiles
 
 # Use Confluent to distribute credentials to nodes
 nodeapply -F compute


### PR DESCRIPTION
* Point to the latest release DVD and derive distro_id from the iso.

Tested on x86_64 and tested on aarch64 with PR https://github.com/xcat2/confluent/pull/209 applied w/ qemu on M3 mac.