### PR TITLE
Allow a single node for openpbs

### DIFF
--- a/docs/install/templates/scheduler/openpbs/startup.md.j2
+++ b/docs/install/templates/scheduler/openpbs/startup.md.j2
@@ -28,8 +28,8 @@ qmgr -c "set server resources_default.place=scatter"
 # Enable support for job accounting
 qmgr -c "set server job_history_enable=True"
 # Register compute hosts with PBS
-for host in "${c_name[@]}"; do
-    qmgr -c "create node $host"
+for ((i=0; i<num_computes; i++)); do
+    qmgr -c "create node ${c_name[$i]}"
 done
 ```
 <!-- ohpc_end -->


### PR DESCRIPTION
OpenPBS now works on a single node.  

OpenPBS/rocky-9/aarch/warewulf3 now works tested via qemu on m3 mac.

docs: fix openpbs node registration to respect num_computes

When num_computes=1, the PBS node registration loop iterated over the full pre-allocated c_name array (c1–c4), causing qmgr "Unknown node" errors for c2–c4. Use the index pattern to stop at num_computes.
