### PR TITLE
adios2: fix <filesystem> build failure with Intel compiler

### DIFF
--- a/components/io-libs/adios2/SOURCES/adios2-intel-filesystem.patch
+++ b/components/io-libs/adios2/SOURCES/adios2-intel-filesystem.patch
@@ -1,0 +1,13 @@
+--- a/source/adios2/toolkit/transport/file/FileFStream.cpp.orig
++++ b/source/adios2/toolkit/transport/file/FileFStream.cpp
+@@ -15,8 +15,8 @@
+ #if __cplusplus >= 201703L
+ #define ADIOS2_USE_STD_FILESYSTEM
+
+-#if defined(__GNUC__) && (__GNUC__ < 8) && !defined(__llvm__) && !defined(__INTEL_COMPILER)
+-// GCC version 7 does not support std::filesystem from C++17 even though it
++#if defined(__GNUC__) && (__GNUC__ < 8) && !defined(__llvm__)
++// GCC version 7 (and compilers using its libstdc++) does not support std::filesystem from C++17 even though it
+ // reports to support C++17.
+ #undef ADIOS2_USE_STD_FILESYSTEM
+ #endif

--- a/components/io-libs/adios2/SPECS/adios2.spec
+++ b/components/io-libs/adios2/SPECS/adios2.spec
@@ -26,6 +26,7 @@ License: Apache License 2.0
 Group:   %{PROJ_NAME}/io-libs
 Url:     https://adios2.readthedocs.io/en/latest/index.html
 Source0: https://github.com/ornladios/ADIOS2/archive/refs/tags/v%{version}.tar.gz
+Patch0:  adios2-intel-filesystem.patch
 AutoReq: no
 
 %if 0%{?rhel} || 0%{?openEuler}
@@ -63,6 +64,7 @@ how they process the data.
 
 %prep
 %setup -q -n %{PNAME}-%{version}
+%patch -P 0 -p1
 
 %build
 mkdir adios2-build


### PR DESCRIPTION
The upstream preprocessor guard in FileFStream.cpp excludes __INTEL_COMPILER from the GCC < 8 check, but when icpc uses an older GCC's libstdc++ (e.g. GCC 7 on openSUSE 15.x), the <filesystem> header does not exist. Remove the Intel exclusion so the guard fires based on __GNUC__ version regardless of compiler frontend.