### PR TITLE
fix: use http for UOregon TAU/PDT upstream URLs

### DIFF
--- a/components/perf-tools/pdtoolkit/SPECS/pdtoolkit.spec
+++ b/components/perf-tools/pdtoolkit/SPECS/pdtoolkit.spec
@@ -22,7 +22,8 @@ License:        Program Database Toolkit License
 Summary:        PDT is a framework for analyzing source code
 Url:            http://www.cs.uoregon.edu/Research/pdt
 Group:          %{PROJ_NAME}/perf-tools
-Source0:        https://www.cs.uoregon.edu/research/paracomp/pdtoolkit/Download/pdtoolkit-%{version}.tar.gz
+# upstream https certificate is broken, use http
+Source0:        http://www.cs.uoregon.edu/research/paracomp/pdtoolkit/Download/pdtoolkit-%{version}.tar.gz
 Patch1:         pdtoolkit-3.25-umask.patch
 Patch2:         pdtoolkit-icx.patch
 Provides:       %{name} = %{version}%{release}

--- a/components/perf-tools/tau/SPECS/tau.spec
+++ b/components/perf-tools/tau/SPECS/tau.spec
@@ -24,7 +24,8 @@ Summary:   Tuning and Analysis Utilities Profiling Package
 License:   Tuning and Analysis Utilities License
 Group:     %{PROJ_NAME}/perf-tools
 Url:       http://www.cs.uoregon.edu/research/tau/home.php
-Source0:   https://www.cs.uoregon.edu/research/tau/tau_releases/tau-%{version}.tar.gz
+# upstream https certificate is broken, use http
+Source0:   http://www.cs.uoregon.edu/research/tau/tau_releases/tau-%{version}.tar.gz
 Patch1:    tau-2.34.1.patch
 
 Provides:  lib%{PNAME}.so()(64bit)(%{PROJ_NAME})

--- a/misc/check_for_package_updates.py
+++ b/misc/check_for_package_updates.py
@@ -729,11 +729,17 @@ def get_latest_uoregon_tau_version(
     try:
         r = requests.get(base_url, timeout=30)
     except requests.exceptions.SSLError:
+        # upstream https certificate is broken, fall back to http
         debug_warn(
-            f"SSL certificate error fetching {base_url}",
+            f"SSL certificate error fetching {base_url}, falling back to HTTP",
             verbose,
         )
-        return None
+        base_url = f"http://www.cs.uoregon.edu/research/tau/{directory}/"
+        try:
+            r = requests.get(base_url, timeout=30)
+        except requests.RequestException as e:
+            debug_warn(f"HTTP fallback also failed: {e}", verbose)
+            return None
     if not r.ok:
         debug_warn(
             f"Failed to fetch UOregon TAU directory listing for {directory}",


### PR DESCRIPTION
The HTTPS certificate on www.cs.uoregon.edu is broken, causing SSL errors when fetching source tarballs and checking for updates. Switch Source0 URLs in tau and pdtoolkit spec files to http, and add an http fallback in the package update checker script.

Generated with Claude Code (https://claude.ai/code)