### PR TITLE
dev-tools: skip update checks for autoconf, automake, libtool

### DIFF
--- a/components/dev-tools/autoconf/SPECS/autoconf.spec
+++ b/components/dev-tools/autoconf/SPECS/autoconf.spec
@@ -8,6 +8,8 @@
 #
 #----------------------------------------------------------------------------eh-
 
+# OpenHPC:check-updates:skip not following upstream
+
 %include %{_sourcedir}/OHPC_macros
 
 %define pname autoconf

--- a/components/dev-tools/automake/SPECS/automake.spec
+++ b/components/dev-tools/automake/SPECS/automake.spec
@@ -8,6 +8,8 @@
 #
 #----------------------------------------------------------------------------eh-
 
+# OpenHPC:check-updates:skip not following upstream
+
 %include %{_sourcedir}/OHPC_macros
 
 %define pname automake

--- a/components/dev-tools/libtool/SPECS/libtool.spec
+++ b/components/dev-tools/libtool/SPECS/libtool.spec
@@ -8,6 +8,8 @@
 #
 #----------------------------------------------------------------------------eh-
 
+# OpenHPC:check-updates:skip not following upstream
+
 %include %{_sourcedir}/OHPC_macros
 
 %define pname libtool


### PR DESCRIPTION
These packages are not following upstream releases.