### PR TITLE
parallel-libs: update mumps to 5.8.2

### DIFF
--- a/components/parallel-libs/mumps/SPECS/mumps.spec
+++ b/components/parallel-libs/mumps/SPECS/mumps.spec
@@ -19,7 +19,7 @@
 %define pname mumps
 
 Name:           %{pname}-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-Version:        5.8.1
+Version:        5.8.2
 Release:        1%{?dist}
 Summary:        A MUltifrontal Massively Parallel Sparse direct Solver
 License:        CeCILL-C


### PR DESCRIPTION
- mumps: 5.8.1 -> 5.8.2
  upstream: release-monitoring.org/mumps

Command: `misc/check_for_package_updates.py -v -o markdown mumps
  --update`


(cherry picked from commit cd4d4adb6bc5a8d47c9322d843cdec033dcd1835)