### PR TITLE
fix(openeuler): correct Warewulf3 recipes and update SP4/COPR repos

### DIFF
--- a/components/admin/docs/SPECS/docs.spec
+++ b/components/admin/docs/SPECS/docs.spec
@@ -61,8 +61,8 @@ for recipe in \
 	"almalinux9/x86_64/warewulf3/openpbs" \
 	"almalinux9/x86_64/confluent/slurm" \
 	"almalinux9/x86_64/openchami/slurm" \
-	"openeuler22.03/x86_64/warewulf/slurm" \
-	"openeuler22.03/x86_64/warewulf/openpbs" \
+	"openeuler22.03/x86_64/warewulf3/slurm" \
+	"openeuler22.03/x86_64/warewulf3/openpbs" \
 	"leap15/x86_64/warewulf3/slurm" \
 	"leap15/x86_64/warewulf3/openpbs" \
 	"rocky9/aarch64/warewulf/slurm" \
@@ -75,8 +75,8 @@ for recipe in \
 	"almalinux9/aarch64/warewulf3/openpbs" \
 	"almalinux9/aarch64/confluent/slurm" \
 	"almalinux9/aarch64/openchami/slurm" \
-	"openeuler22.03/aarch64/warewulf/slurm" \
-	"openeuler22.03/aarch64/warewulf/openpbs" \
+	"openeuler22.03/aarch64/warewulf3/slurm" \
+	"openeuler22.03/aarch64/warewulf3/openpbs" \
 	"leap15/aarch64/warewulf3/slurm" \
 	"leap15/aarch64/warewulf3/openpbs" \
 ; do

--- a/components/provisioning/warewulf-vnfs/SOURCES/openeuler-22.03.tmpl
+++ b/components/provisioning/warewulf-vnfs/SOURCES/openeuler-22.03.tmpl
@@ -18,11 +18,11 @@ if [ -z "$YUM_MIRROR" ]; then
     if [ -z "$YUM_MIRROR_BASE" ]; then
         YUM_MIRROR_BASE="http://repo.openeuler.org"
     fi
-    YUM_MIRROR="${YUM_MIRROR_BASE}/openEuler-22.03-LTS-SP3/OS/\$basearch/, \
-	${YUM_MIRROR_BASE}/openEuler-22.03-LTS-SP3/everything/\$basearch/, \
-	${YUM_MIRROR_BASE}/openEuler-22.03-LTS-SP3/EPOL/main/\$basearch/, \
-        ${YUM_MIRROR_BASE}/openEuler-22.03-LTS-SP3/EPOL/update/main/\$basearch/, \
-	${YUM_MIRROR_BASE}/openEuler-22.03-LTS-SP3/update/\$basearch/"
+    YUM_MIRROR="${YUM_MIRROR_BASE}/openEuler-22.03-LTS-SP4/OS/\$basearch/, \
+	${YUM_MIRROR_BASE}/openEuler-22.03-LTS-SP4/everything/\$basearch/, \
+	${YUM_MIRROR_BASE}/openEuler-22.03-LTS-SP4/EPOL/main/\$basearch/, \
+        ${YUM_MIRROR_BASE}/openEuler-22.03-LTS-SP4/EPOL/update/main/\$basearch/, \
+	${YUM_MIRROR_BASE}/openEuler-22.03-LTS-SP4/update/\$basearch/"
 fi
 
 # Install only what is necessary/specific for this distribution

--- a/docs/install/config/distro/el9.yaml
+++ b/docs/install/config/distro/el9.yaml
@@ -23,3 +23,6 @@ pkg_remove: "dnf -y remove"
 pkg_upgrade: "dnf -y upgrade"
 pkg_upgrade_chroot: 'dnf -y --installroot="$CHROOT" upgrade'
 pkg_tftp: "syslinux-tftpboot"
+mariadb_cnf: "/etc/my.cnf.d/mariadb-server.cnf"
+mariadb_service: "mariadb"
+extra_repos_pkg: "epel-release"

--- a/docs/install/config/distro/openeuler22.03.yaml
+++ b/docs/install/config/distro/openeuler22.03.yaml
@@ -30,11 +30,11 @@ pkg_remove: "dnf -y remove"
 pkg_upgrade: "dnf -y upgrade"
 pkg_upgrade_chroot: 'dnf -y --installroot="$CHROOT" upgrade'
 pkg_tftp: "syslinux-tftpboot"
-
-# External repository URLs
-beegfs_repo: "https://www.beegfs.io/release/beegfs_7.4.5/dists/beegfs-rhel9.repo"
+mariadb_cnf: "/etc/my.cnf.d/mysql-server.cnf"
+mariadb_service: "mysqld"
+extra_repos_pkg: "openEuler-release"
 
 # openEuler-specific OHPC repo (COPR for compute image)
 openeuler_ohpc_repo_server: "https://eur.openeuler.openatom.cn"
-openeuler_ohpc_repo_dir: "coprs/openhpc/OpenHPC/repo/openeuler-22.03_LTS_SP4"
-openeuler_ohpc_repo_file: "openhpc-OpenHPC-openeuler-22.03_LTS_SP4.repo"
+openeuler_ohpc_repo_dir: "coprs/openhpc/OpenHPC/repo/openeuler-24.03_LTS_SP2"
+openeuler_ohpc_repo_file: "openhpc-OpenHPC-openeuler-24.03_LTS_SP2.repo"

--- a/docs/install/recipes/openeuler22.03-aarch64-warewulf3-openpbs.conf
+++ b/docs/install/recipes/openeuler22.03-aarch64-warewulf3-openpbs.conf
@@ -1,0 +1,5 @@
+config/base.yaml
+config/distro/openeuler22.03.yaml
+config/arch/aarch64.yaml
+config/provisioner/warewulf3.yaml
+config/scheduler/openpbs.yaml

--- a/docs/install/recipes/openeuler22.03-aarch64-warewulf3-slurm.conf
+++ b/docs/install/recipes/openeuler22.03-aarch64-warewulf3-slurm.conf
@@ -1,5 +1,5 @@
 config/base.yaml
 config/distro/openeuler22.03.yaml
 config/arch/aarch64.yaml
-config/provisioner/warewulf.yaml
+config/provisioner/warewulf3.yaml
 config/scheduler/slurm.yaml

--- a/docs/install/recipes/openeuler22.03-x86_64-warewulf-slurm.conf
+++ b/docs/install/recipes/openeuler22.03-x86_64-warewulf-slurm.conf
@@ -1,5 +1,0 @@
-config/base.yaml
-config/distro/openeuler22.03.yaml
-config/arch/x86_64.yaml
-config/provisioner/warewulf.yaml
-config/scheduler/slurm.yaml

--- a/docs/install/recipes/openeuler22.03-x86_64-warewulf3-openpbs.conf
+++ b/docs/install/recipes/openeuler22.03-x86_64-warewulf3-openpbs.conf
@@ -1,5 +1,5 @@
 config/base.yaml
 config/distro/openeuler22.03.yaml
-config/arch/aarch64.yaml
-config/provisioner/warewulf.yaml
+config/arch/x86_64.yaml
+config/provisioner/warewulf3.yaml
 config/scheduler/openpbs.yaml

--- a/docs/install/recipes/openeuler22.03-x86_64-warewulf3-slurm.conf
+++ b/docs/install/recipes/openeuler22.03-x86_64-warewulf3-slurm.conf
@@ -1,5 +1,5 @@
 config/base.yaml
 config/distro/openeuler22.03.yaml
 config/arch/x86_64.yaml
-config/provisioner/warewulf.yaml
-config/scheduler/openpbs.yaml
+config/provisioner/warewulf3.yaml
+config/scheduler/slurm.yaml

--- a/docs/install/templates/base-os/proxy.md.j2
+++ b/docs/install/templates/base-os/proxy.md.j2
@@ -1,8 +1,12 @@
 ## Configure HTTPS Proxy (Optional)
 
 If your environment requires an HTTPS caching proxy for external network access,
-configure it here before installing any packages. The placeholder below marks
-where site-specific proxy setup should be injected by a pre-processing step.
+configure it here before installing any packages.
+
+<!--
+The placeholder below marks where site-specific proxy setup should be injected by
+a pre-processing step.
+-->
 
 <!-- ohpc_begin -->
 <!-- ohpc_comment Configure HTTPS proxy for head node (site-specific) -->

--- a/docs/install/templates/distro/openeuler/repos.md.j2
+++ b/docs/install/templates/distro/openeuler/repos.md.j2
@@ -1,22 +1,3 @@
-In addition to the OpenHPC package repository, the *head node* also requires
-access to the standard base OS distro repositories in order to resolve necessary
-dependencies. For {{ distro_full_name }}, the requirements are to have access to
-the OS, Everything, EPOL main, and EPOL update repositories. Note that the OS,
-Everything, and EPOL main repositories are typically enabled by default. To
-enable the EPOL update repository on {{ distro_full_name }}, you can run the
-following command:
-
-<!-- ohpc_begin -->
-<!-- ohpc_comment Install EPOL -->
-
-```bash
-{{ pkg_add_repo }} {{ openeuler_ohpc_repo_server }}\
-/{{ openeuler_ohpc_repo_dir }}\
-/{{ openeuler_ohpc_repo_file }}
-{{ pkg_install }} openeuler-extra-repos
-```
-<!-- ohpc_end -->
-
 By default all repositories use
 [http://repo.openeuler.org](http://repo.openeuler.org). For better network speed
 it could be replaced with any of the mirrors listed

--- a/docs/install/templates/provisioner/warewulf3/compute-create-image.md.j2
+++ b/docs/install/templates/provisioner/warewulf3/compute-create-image.md.j2
@@ -16,8 +16,8 @@ of the compute node. The default location for this example is
 ::: {.tip}
 Warewulf is configured by default to access an external repository during the
 `wwmkchroot` process. If the head node cannot reach the public {{ distro_full_name }}
-mirrors, set the `${BOS_MIRROR}` environment variable to your desired repo
-location prior to running `wwmkchroot`.
+mirrors, set the `YUM_MIRROR_BASE` environment variable to your desired mirror
+base URL prior to running `wwmkchroot`.
 :::
 
 <!-- ohpc_begin -->
@@ -40,14 +40,11 @@ cp -p /etc/zypp/repos.d/OpenHPC*.repo $CHROOT/etc/zypp/repos.d
 # Import GPG keys for chroot repository usage
 zypper -n --root $CHROOT --no-gpg-checks --gpg-auto-import-keys refresh
 {% else %}
-# Override default OS repository (optional) - set BOS_MIRROR to desired repo
-# export YUM_MIRROR=${BOS_MIRROR}
-
 # Build initial chroot image
 wwmkchroot -v {{ baseos }} $CHROOT
 
-# Enable OpenHPC and EPEL repos inside chroot
-{{ pkg_install_chroot }} epel-release
+# Enable OpenHPC and distro repos inside chroot
+{{ pkg_install_chroot }} {{ extra_repos_pkg }}
 cp -p /etc/yum.repos.d/OpenHPC*.repo $CHROOT/etc/yum.repos.d
 {% endif %}
 ```

--- a/docs/install/templates/provisioner/warewulf3/finalize-provisioning.md.j2
+++ b/docs/install/templates/provisioner/warewulf3/finalize-provisioning.md.j2
@@ -12,10 +12,10 @@ as some simple scripts to complete the provisioning process.
 <!-- ohpc_begin -->
 <!-- ohpc_comment Assemble bootstrap image -->
 ```bash
-# Optionally include drivers from kernel updates; add virtio_net for VM support
+# Optionally include drivers from kernel updates; add virtio drivers for VM support
 export WW_CONF=/etc/warewulf/bootstrap.conf
 echo "drivers += updates/kernel/" >> $WW_CONF
-echo "modprobe += virtio_net" >> $WW_CONF
+echo "modprobe += virtio_pci, virtio_net" >> $WW_CONF
 
 # Build bootstrap image
 wwbootstrap $(uname -r)

--- a/docs/install/templates/provisioner/warewulf3/warewulf3-setup.md.j2
+++ b/docs/install/templates/provisioner/warewulf3/warewulf3-setup.md.j2
@@ -44,11 +44,11 @@ systemctl enable apache2.service
 systemctl restart apache2
 {% else %}
 # Configure MariaDB to handle large VNFS images
-sed -i "/\[mysqld\]/a max_allowed_packet=32M" /etc/my.cnf.d/mariadb-server.cnf
+sed -i "/\[mysqld\]/a max_allowed_packet=32M" {{ mariadb_cnf }}
 sed -i "s/^# database chunk size.*/database chunk size = 16777216/" \
     /etc/warewulf/database.conf
-systemctl enable mariadb
-systemctl restart mariadb
+systemctl enable {{ mariadb_service }}
+systemctl restart {{ mariadb_service }}
 systemctl enable httpd.service
 systemctl restart httpd
 {% endif %}


### PR DESCRIPTION
- Rename openEuler 22.03 recipes from warewulf -> warewulf3 provisioner
- Update VNFS chroot template to SP4 repository URLs (was SP3)
- Update OpenHPC COPR repo target to openeuler-24.03_LTS_SP2
- Add virtio_pci before virtio_net in Warewulf3 bootstrap for VM support
- Abstract MariaDB/MySQL service name and config path per distro
- Abstract extra-repos package per distro (epel-release vs openEuler-release)
- Remove stale BOS_MIRROR comment and openeuler-extra-repos install step
- Add ChangeLog entries for 3.x

Tested on aarch64 via qemu on a M3 mac.