### PR TITLE
OpenPBS fixes

### DIFF
--- a/docs/install/templates/scheduler/openpbs/startup.md.j2
+++ b/docs/install/templates/scheduler/openpbs/startup.md.j2
@@ -9,7 +9,8 @@ manager services in preparation for running user jobs.
 <!-- ohpc_comment Resource Manager Startup -->
 ```bash
 # Start PBS daemons on head node
-systemctl enable --now pbs
+systemctl enable pbs
+systemctl start pbs
 ```
 <!-- ohpc_end -->
 


### PR DESCRIPTION
Fix for OpenPBS on OpenEuler.

The `--now` does not work on openEluer.

Tested for openeuler-aarch-warewulf3-openpbs on qemu on M3 mac.
