### PR TITLE
fix(warewulf3): assemble VNFS after optional customization steps

### DIFF
--- a/docs/install/templates/chapters/deploy-warewulf3.md.j2
+++ b/docs/install/templates/chapters/deploy-warewulf3.md.j2
@@ -1,6 +1,7 @@
 {# Warewulf v3 Deploy Aggregator #}
 # Deploy Cluster
 
+{% include "provisioner/warewulf3/finalize-provisioning.md.j2" %}
 {% include "provisioner/warewulf3/add-hosts.md.j2" %}
 
 {% if is_slurm %}

--- a/docs/install/templates/chapters/provisioner-warewulf3.md.j2
+++ b/docs/install/templates/chapters/provisioner-warewulf3.md.j2
@@ -12,5 +12,3 @@
 
 {% include "provisioner/warewulf3/compute-customize.md.j2" %}
 {% include "provisioner/warewulf3/compute-import-files.md.j2" %}
-
-{% include "provisioner/warewulf3/finalize-provisioning.md.j2" %}


### PR DESCRIPTION
Move finalize-provisioning (wwbootstrap + wwvnfs) from the end of the "Install Warewulf Provisioner" chapter to the start of the "Deploy Cluster" chapter.

Previously, wwvnfs snapshotted the chroot before the "Additional Customization" chapter ran, so optional components installed into the compute image (InfiniBand, OmniPath, GPU drivers, NHC, syslog, etc.) were silently missing from the image served to compute nodes.

With this change, all chroot modifications — including optional ones — are complete before wwvnfs assembles the VNFS capsule.