### PR TITLE
ci: use pre-built container images for validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,12 +21,9 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: docker.io/library/rockylinux:8
+      image: ghcr.io/openhpc/ohpc-analysis:latest
 
     steps:
-    - name: Setup
-      run: |
-        dnf install -y epel-release git python3
     - uses: actions/checkout@v6
     - id: files
       uses: Ana06/get-changed-files@v2.3.0
@@ -66,10 +63,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Build on RHEL
     container:
-      image: docker.io/library/rockylinux:8
+      image: ghcr.io/openhpc/ohpc-validate-almalinux:2.x
     steps:
-    - name: Install git
-      run: dnf -y install git
+    - name: Update packages
+      run: dnf -y update
     - uses: actions/checkout@v6
     - name: Setup
       run: tests/ci/prepare-ci-environment.sh
@@ -90,18 +87,21 @@ jobs:
           /tmp/empty
 
   test_on_rhel:
+    strategy:
+      matrix:
+        compiler: [gnu12]
     runs-on: ubuntu-latest
     name: Test on RHEL
     env:
       JOB_SKIP_CI_SPECS: |
         components/perf-tools/likwid/SPECS/likwid.spec
     container:
-      image: docker.io/library/rockylinux:8
-      options: --privileged
+      image: ghcr.io/openhpc/ohpc-validate-almalinux:2.x
+      options: --privileged --security-opt seccomp=unconfined --security-opt apparmor=unconfined
     needs: build_on_rhel
     steps:
-    - name: Install git
-      run: dnf -y install git
+    - name: Update packages
+      run: dnf -y update
     - uses: actions/checkout@v6
     - name: Setup
       run: tests/ci/prepare-ci-environment.sh
@@ -111,21 +111,25 @@ jobs:
       with:
         name: rhel-rpms
         path: /home/ohpc/rpmbuild/RPMS
+    - name: Enable unprivileged user namespaces
+      run: |
+        sysctl -w kernel.unprivileged_userns_clone=1 || true
+        sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
     - name: Run CI Tests
       run: |
         export SKIP_CI_SPECS="${{ env.SKIP_CI_SPECS }}${{ env.JOB_SKIP_CI_SPECS }}"
         . /etc/profile.d/lmod.sh
         chown ohpc -R tests
-        tests/ci/setup_slurm_and_run_tests.sh ohpc ${{ steps.files.outputs.added_modified }}
+        tests/ci/setup_slurm_and_run_tests.sh ohpc ${{ matrix.compiler }} ${{ steps.files.outputs.added_modified }}
 
   build_on_leap:
     runs-on: ubuntu-latest
     name: Build on LEAP
     container:
-      image: registry.opensuse.org/opensuse/leap:15.3
+      image: ghcr.io/openhpc/ohpc-validate-leap:2.x
     steps:
-    - name: Install git
-      run: zypper -n install git
+    - name: Update packages
+      run: zypper -n update
     - uses: actions/checkout@v6
     - name: Setup
       run: tests/ci/prepare-ci-environment.sh
@@ -135,3 +139,48 @@ jobs:
       run: |
         . /etc/profile.d/lmod.sh
         tests/ci/run_build.py ohpc ${{ steps.files.outputs.added_modified }}
+        touch /tmp/empty
+    - uses: actions/upload-artifact@v7
+      with:
+        name: leap-rpms
+        retention-days: 1
+        path: |
+          /home/ohpc/rpmbuild/RPMS/noarch/*rpm
+          /home/ohpc/rpmbuild/RPMS/x86_64/*rpm
+          /tmp/empty
+
+  test_on_leap:
+    strategy:
+      matrix:
+        compiler: [gnu12]
+    runs-on: ubuntu-latest
+    name: Test on LEAP
+    env:
+      JOB_SKIP_CI_SPECS: |
+        components/perf-tools/likwid/SPECS/likwid.spec
+    container:
+      image: ghcr.io/openhpc/ohpc-validate-leap:2.x
+      options: --privileged --security-opt seccomp=unconfined --security-opt apparmor=unconfined
+    needs: build_on_leap
+    steps:
+    - name: Update packages
+      run: zypper -n update
+    - uses: actions/checkout@v6
+    - name: Setup
+      run: tests/ci/prepare-ci-environment.sh
+    - id: files
+      uses: Ana06/get-changed-files@v2.3.0
+    - uses: actions/download-artifact@v8
+      with:
+        name: leap-rpms
+        path: /home/ohpc/rpmbuild/RPMS
+    - name: Enable unprivileged user namespaces
+      run: |
+        sysctl -w kernel.unprivileged_userns_clone=1 || true
+        sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+    - name: Run CI Tests
+      run: |
+        export SKIP_CI_SPECS="${{ env.SKIP_CI_SPECS }}${{ env.JOB_SKIP_CI_SPECS }}"
+        . /etc/profile.d/lmod.sh
+        chown ohpc -R tests
+        tests/ci/setup_slurm_and_run_tests.sh ohpc ${{ matrix.compiler }} ${{ steps.files.outputs.added_modified }}

--- a/tests/ci/prepare-ci-environment.sh
+++ b/tests/ci/prepare-ci-environment.sh
@@ -83,7 +83,7 @@ dnf_rhel() {
 	loop_command "${PKG_MANAGER}" -y install ${COMMON_PKGS} epel-release dnf-plugins-core git rpm-build gawk "${OHPC_RELEASE}"
 	if [ -z "${NINE}" ]; then
 		loop_command "${PKG_MANAGER}" config-manager --set-enabled powertools
-		if "${PKG_MANAGER}" repolist --all | grep -q devel; then
+		if "${PKG_MANAGER}" repolist --all | grep -q "^devel"; then
 			loop_command "${PKG_MANAGER}" config-manager --set-enabled devel
 		fi
 	else
@@ -92,12 +92,12 @@ dnf_rhel() {
 	if [ "${FACTORY_VERSION}" != "" ]; then
 		loop_command wget "${FACTORY_REPOSITORY}" -O "${FACTORY_REPOSITORY_DESTINATION}"
 	fi
-	loop_command "${PKG_MANAGER}" -y install lmod-ohpc
+	loop_command "${PKG_MANAGER}" -y install lmod-ohpc ccache
 }
 
 dnf_openeuler() {
 	loop_command "${PKG_MANAGER}" -y install ${COMMON_PKGS} git dnf-plugins-core rpm-build gawk
-	loop_command "${PKG_MANAGER}" -y install ohpc-filesystem lmod-ohpc hostname
+	loop_command "${PKG_MANAGER}" -y install ohpc-filesystem lmod-ohpc hostname ccache
 }
 
 if [ "${PKG_MANAGER}" = "dnf" ]; then
@@ -106,13 +106,18 @@ if [ "${PKG_MANAGER}" = "dnf" ]; then
 	else
 		dnf_rhel
 	fi
-	adduser ohpc
+	adduser ohpc || true
 else
-	loop_command "${PKG_MANAGER}" -n install ${COMMON_PKGS} awk rpmbuild
+	loop_command "${PKG_MANAGER}" -n install ${COMMON_PKGS} awk rpmbuild ccache man
 	loop_command "${PKG_MANAGER}" -n --no-gpg-checks install "${OHPC_RELEASE}"
 	if [ "${FACTORY_VERSION}" != "" ]; then
 		loop_command wget "${FACTORY_REPOSITORY}" -O "${FACTORY_REPOSITORY_DESTINATION}"
 	fi
 	loop_command "${PKG_MANAGER}" -n --no-gpg-checks install lmod-ohpc
-	useradd -m ohpc
+	groupadd ohpc || true
+	useradd -m ohpc -g ohpc || true
 fi
+
+# Setup ccache
+echo "cache_dir=/var/cache/ccache" >/etc/ccache.conf
+install -d -o ohpc -g ohpc /var/cache/ccache

--- a/tests/ci/setup_slurm_and_run_tests.sh
+++ b/tests/ci/setup_slurm_and_run_tests.sh
@@ -6,31 +6,59 @@ set -e
 USER=$1
 shift
 
-# First install slurm and needed packages
-dnf -y install \
-	autoconf \
-	automake \
-	make \
-	which \
-	sudo \
-	prun-ohpc \
-	openmpi4-gnu12-ohpc \
-	mpich-gnu12-ohpc \
-	slurm-slurmd-ohpc \
-	slurm-slurmctld-ohpc \
-	slurm-example-configs-ohpc \
+COMPILER_FAMILY=$1
+shift
+
+PKG=("dnf" "-y")
+
+if hash zypper >/dev/null 2>&1; then
+	PKG=("zypper" "-n" "--no-gpg-checks")
+fi
+
+# First remove a possible conflicts from a previous run
+"${PKG[@]}" remove lmod-defaults-*-ohpc || true
+
+# Then install slurm and needed packages
+INSTALL_PKGS=(
+	hostname
+	make
+	openssh-clients
+	which
+	sudo
+	autoconf
+	automake
+	libtool
+	ohpc-autotools
+	prun-ohpc
+	openmpi4-"${COMPILER_FAMILY}"-ohpc
+	mpich-"${COMPILER_FAMILY}"-ohpc
+	lmod-defaults-"${COMPILER_FAMILY}"-openmpi4-ohpc
+	slurm-slurmd-ohpc
+	slurm-slurmctld-ohpc
+	slurm-example-configs-ohpc
 	slurm-ohpc
+)
+
+if [ "$(uname -m)" != "aarch64" ]; then
+	INSTALL_PKGS+=(mvapich2-"${COMPILER_FAMILY}"-ohpc)
+fi
+
+"${PKG[@]}" install "${INSTALL_PKGS[@]}"
 
 # Install rebuilt packages (if any)
+FIND_EXCLUDE=(! -name "*arm1*")
+if [ "${COMPILER_FAMILY}" != "intel" ]; then
+	FIND_EXCLUDE+=(! -name "*-intel-*")
+fi
 # shellcheck disable=SC2046 # (we want the words to be split)
-dnf -y install $(find /home/"${USER}"/rpmbuild/RPMS/ -name "*rpm") || true
+"${PKG[@]}" install $(find /home/"${USER}"/rpmbuild/RPMS/ -name "*rpm" "${FIND_EXCLUDE[@]}") || true
 
 # Remove OpenPBS, if it is installed as a dependency. The tests use Slurm Resource Manager
-dnf -y remove openpbs-*-ohpc || true
+"${PKG[@]}" remove openpbs-*-ohpc || true
 rm -f /etc/pbs.conf
 
 # Setup slurm
-echo "127.0.0.1 node0 node1" >> /etc/hosts
+echo "127.0.0.1 node0 node1" >>/etc/hosts
 
 cp /etc/slurm/slurm.conf.example /etc/slurm/slurm.conf
 
@@ -50,13 +78,15 @@ sed -i -e "
 	echo "NodeName=c0 NodeHostname=node0 Port=17004 CPUs=2"
 	echo "NodeName=c1 NodeHostname=node1 Port=17005 CPUs=2"
 	echo "PartitionName=normal Nodes=c0,c1 Default=YES MaxTime=24:00:00 State=UP"
-} >> /etc/slurm/slurm.conf
+} >>/etc/slurm/slurm.conf
 
 # cgroupv2 support does not yet work in containers.
 # Force cgroupv1 even on hosts with v2.
-echo "CgroupPlugin=cgroup/v1" >  /etc/slurm/cgroup.conf
+echo "CgroupPlugin=cgroup/v1" >/etc/slurm/cgroup.conf
 
 chown root.root /var/log/munge
+
+mkdir -p /run/munge
 
 /usr/sbin/munged -f
 /usr/sbin/slurmctld
@@ -69,7 +99,7 @@ retry_counter=0
 max_retries=5
 
 while true; do
-	(( retry_counter+=1 ))
+	((retry_counter += 1))
 	if [ "${retry_counter}" -gt "${max_retries}" ]; then
 		exit 1
 	fi
@@ -87,30 +117,57 @@ srun -N2 hostname
 # This script returns three array variables:
 #  PKGS and TESTS and ADMIN_TESTS
 # shellcheck disable=SC2068 # (we want individual elements)
-eval "$(tests/ci/spec_to_test_mapping.py $@)"
+eval "$(tests/ci/spec_to_test_mapping.py --compiler-family "${COMPILER_FAMILY}" $@)"
 
 if [ "${#PKGS[@]}" -gt 0 ]; then
-	dnf -y install "${PKGS[@]}"
+	"${PKG[@]}" install "${PKGS[@]}"
 fi
 
 export SIMPLE_CI=1
 TESTS_FAILED=1
 
+export OHPC_USE_CCACHE=yes
+chown -R ohpc:ohpc /var/cache/ccache
+
 set +e
+
+# AppArmor on the Ubuntu GitHub Actions host might block
+# access to /etc/shadow.
+chmod 644 /etc/shadow
 
 sudo --user="${USER}" --login bash -c "cd ${PWD}/tests; find ./ -name '*.log' -delete"
 
 # Always running at least with '--enable-modules'. No need to check for
 # an empty TESTS array.
-if sudo --user="${USER}" --preserve-env=SIMPLE_CI --login bash -c "cd ${PWD}/tests; ./bootstrap; ./configure --disable-all --enable-modules --enable-rms-harness --with-mpi-families='openmpi4 mpich' ${TESTS[*]}; make check";
-then
-    TESTS_FAILED=0
+MPI_FAMILIES="openmpi4 mpich"
+#if [ "$(uname -m)" != "aarch64" ]; then
+#	MPI_FAMILIES="${MPI_FAMILIES} mvapich2"
+#fi
+if sudo \
+	--user="${USER}" \
+	--preserve-env=SIMPLE_CI \
+	--preserve-env=OHPC_USE_CCACHE \
+	--login \
+	bash -c "\
+		export PATH=/opt/ohpc/pub/utils/autotools/bin:\${PATH}; \
+		cd ${PWD}/tests; \
+		./bootstrap; \
+		./configure \
+			--disable-all \
+			--enable-modules \
+			--enable-rms-harness \
+			--enable-compilers \
+			--with-compiler-families='${COMPILER_FAMILY}' \
+			--with-mpi-families='${MPI_FAMILIES}' \
+			${TESTS[*]}; \
+		make check"; then
+	TESTS_FAILED=0
 fi
-
 
 if [ "${#ADMIN_TESTS[@]}" -gt 0 ]; then
 	# The configure script uses the variable $USER to decide if root or not
 	export USER=root
+	export PATH=/opt/ohpc/pub/utils/autotools/bin:${PATH}
 	cd tests
 	./bootstrap
 	./configure --disable-all --disable-bos --disable-oob --disable-spack "${ADMIN_TESTS[*]}"
@@ -120,6 +177,8 @@ if [ "${#ADMIN_TESTS[@]}" -gt 0 ]; then
 fi
 
 if [ "${TESTS_FAILED}" -eq 0 ]; then
+	cd tests
+	make distclean >/dev/null 2>&1 || true
 	exit 0
 fi
 
@@ -127,10 +186,9 @@ set -e
 
 # If we are here, the tests failed. Print the logs and exit with an error code.
 echo -e "\nThe tests execution failed. Printing the logs.\n"
-find ./ -name "*.log" -print0 | while IFS= read -r -d '' log_file
-do
+find ./ -name "*.log" -print0 | while IFS= read -r -d '' log_file; do
 	echo "================================================"
-	echo "Log file: ${log_file}";
-	cat "${log_file}";
+	echo "Log file: ${log_file}"
+	cat "${log_file}"
 done
 exit 1


### PR DESCRIPTION
Replicate what is already happening on the 3.x and 4.x branches by switching from vanilla base images to the pre-built ohpc-analysis and ohpc-validate container images. This removes the need for manual package installation steps at runtime.