### PR TITLE
docs: backport Confluent, OpenCHAMI, and openEuler fixes from 3.x

### DIFF
--- a/docs/install/recipes/almalinux10-aarch64-confluent-slurm.yaml
+++ b/docs/install/recipes/almalinux10-aarch64-confluent-slurm.yaml
@@ -1,2 +1,1 @@
-distro_id: "alma-10.1-aarch64-default"
-distro_iso_image: "AlmaLinux-10.1-aarch64-dvd.iso"
+distro_iso_image: "AlmaLinux-10-latest-aarch64-dvd.iso"

--- a/docs/install/recipes/almalinux10-x86_64-confluent-slurm.yaml
+++ b/docs/install/recipes/almalinux10-x86_64-confluent-slurm.yaml
@@ -1,2 +1,1 @@
-distro_id: "alma-10.1-x86_64-default"
-distro_iso_image: "AlmaLinux-10.1-x86_64-dvd.iso"
+distro_iso_image: "AlmaLinux-10-latest-x86_64-dvd.iso"

--- a/docs/install/recipes/rocky10-aarch64-confluent-slurm.yaml
+++ b/docs/install/recipes/rocky10-aarch64-confluent-slurm.yaml
@@ -1,2 +1,1 @@
-distro_id: "rocky-10.1-aarch64-default"
-distro_iso_image: "Rocky-10.1-aarch64-dvd1.iso"
+distro_iso_image: "Rocky-10-latest-aarch64-dvd.iso"

--- a/docs/install/recipes/rocky10-x86_64-confluent-slurm.yaml
+++ b/docs/install/recipes/rocky10-x86_64-confluent-slurm.yaml
@@ -1,2 +1,1 @@
-distro_id: "rocky-10.1-x86_64-default"
-distro_iso_image: "Rocky-10.1-x86_64-dvd1.iso"
+distro_iso_image: "Rocky-10-latest-x86_64-dvd.iso"

--- a/docs/install/templates/base-os/proxy.md.j2
+++ b/docs/install/templates/base-os/proxy.md.j2
@@ -1,8 +1,10 @@
 ## Configure HTTPS Proxy (Optional)
 
 If your environment requires an HTTPS caching proxy for external network access,
-configure it here before installing any packages. The placeholder below marks
-where site-specific proxy setup should be injected by a pre-processing step.
+configure it here before installing any packages.
+
+{# The placeholder below marks where site-specific proxy setup should be injected by
+a pre-processing step. #}
 
 <!-- ohpc_begin -->
 <!-- ohpc_comment Configure HTTPS proxy for head node (site-specific) -->

--- a/docs/install/templates/distro/openeuler/repos.md.j2
+++ b/docs/install/templates/distro/openeuler/repos.md.j2
@@ -2,12 +2,11 @@ In addition to the OpenHPC package repository, the *head node* also requires
 access to the standard base OS distro repositories in order to resolve necessary
 dependencies. For {{ distro_full_name }}, the requirements are to have access to
 the OS, Everything, EPOL main, and EPOL update repositories. Note that the OS,
-Everything, and EPOL main repositories are typically enabled by default. To
-enable the EPOL update repository on {{ distro_full_name }}, you can run the
-following command:
+Everything, and EPOL main repositories are typically enabled by default. The
+OpenHPC COPR repository also provides additional required tools such as `yq`:
 
 <!-- ohpc_begin -->
-<!-- ohpc_comment Install EPOL -->
+<!-- ohpc_comment Enable OpenHPC COPR repository -->
 
 ```bash
 {{ pkg_add_repo }} {{ openeuler_ohpc_repo_server }}\

--- a/docs/install/templates/provisioner/confluent/add-nodes.md.j2
+++ b/docs/install/templates/provisioner/confluent/add-nodes.md.j2
@@ -73,6 +73,6 @@ network services like DNS and DHCP. These tasks are accomplished as follows:
 <!-- ohpc_comment Complete networking setup, associate provisioning image -->
 ```bash
 # Associate desired provisioning image for computes
-nodedeploy -n compute -p {{ distro_id }}
+nodedeploy -n compute -p ${distro_id}
 ```
 <!-- ohpc_end -->

--- a/docs/install/templates/provisioner/confluent/init-os-images.md.j2
+++ b/docs/install/templates/provisioner/confluent/init-os-images.md.j2
@@ -18,7 +18,10 @@ initialize -i`
 <!-- ohpc_comment Initialize OS images for use with Confluent -->
 ```bash
 osdeploy initialize -${initialize_options:-usklpta}
-osdeploy import ${iso_path:-{{ distro_iso_image }}}
+: "${iso_path:={{ distro_iso_image }}}"
+distro_id=$(osdeploy importcheck "${iso_path}" 2>&1 \
+	| sed -En 's/Detected distribution name: (.*)/\1-default/p')
+osdeploy import "${iso_path}"
 restorecon -Rv /var/lib/confluent/
 ```
 <!-- ohpc_end -->
@@ -36,10 +39,12 @@ You could also add `debug` here as well to increase debug messages.
 
 <!-- ohpc_begin -->
 ```bash
-# Update kernel arguments
-yq -i '.kernelargs = "console=ttyS0,115200 console=tty0 rd.shell"' \
-  /var/lib/confluent/public/os/{{ distro_id }}/profile.yaml
-osdeploy updateboot {{ distro_id }}
+# Update kernel arguments: drop quiet, add serial console
+yq -i '.kernelargs |= sub("quiet ?", "")' \
+  /var/lib/confluent/public/os/${distro_id}/profile.yaml
+yq -i ".kernelargs += \" console=tty0 console={% if is_aarch64 %}ttyAMA0{% else %}ttyS0{% endif %},115200 rd.shell\"" \
+  /var/lib/confluent/public/os/${distro_id}/profile.yaml
+osdeploy updateboot ${distro_id}
 ```
 <!-- ohpc_end -->
 
@@ -53,6 +58,6 @@ command should be run.
 <!-- ohpc_comment Sync the hosts file in cluster -->
 ```bash
 echo "/etc/hosts -> /etc/hosts" >> \
-	/var/lib/confluent/public/os/{{ distro_id }}/syncfiles
+	/var/lib/confluent/public/os/${distro_id}/syncfiles
 ```
 <!-- ohpc_end -->

--- a/docs/install/templates/provisioner/confluent/post-add-user.md.j2
+++ b/docs/install/templates/provisioner/confluent/post-add-user.md.j2
@@ -17,9 +17,9 @@ credential files on *compute* nodes:
 ```bash
 # Create a sync file for pushing user credentials to the nodes
 echo "/etc/passwd -> /etc/passwd" >> \
-	/var/lib/confluent/public/os/{{ distro_id }}/syncfiles
+	/var/lib/confluent/public/os/${distro_id}/syncfiles
 echo "/etc/group -> /etc/group" >> \
-	/var/lib/confluent/public/os/{{ distro_id }}/syncfiles
+	/var/lib/confluent/public/os/${distro_id}/syncfiles
 
 # Use Confluent to distribute credentials to nodes
 nodeapply -F compute

--- a/docs/install/templates/provisioner/openchami/compute-image-build.md.j2
+++ b/docs/install/templates/provisioner/openchami/compute-image-build.md.j2
@@ -222,6 +222,9 @@ repos:
   - alias: 'OpenHPC'
     url: '{{ ohpc_repo_server }}/OpenHPC/{{ ohpc_version_tree }}/{{ ostree }}'
     gpg: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-OpenHPC-{{ ohpc_version_tree }}'
+  - alias: 'OpenHPC-updates'
+    url: '{{ ohpc_repo_server }}/OpenHPC/{{ ohpc_version_tree }}/updates/{{ ostree }}'
+    gpg: 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-OpenHPC-{{ ohpc_version_tree }}'
 copyfiles:
   - src: '/data/hosts'
     dest: '/etc/hosts'


### PR DESCRIPTION
Backports documentation and template fixes from the 3.x branch to bring 4.x in sync for the Confluent, OpenCHAMI, and openEuler provisioner paths.

Confluent (dc35d5ab)

- Replace Jinja {{ distro_id }} with shell ${distro_id} throughout Confluent templates — Jinja variables are not available at script runtime
- Detect distro_id dynamically from osdeploy importcheck output instead of assuming it from the config; this makes the import step robust across OS variants
- Improve kernel argument handling: instead of overwriting kernelargs wholesale, remove quiet and append the console/rd.shell arguments — preserves any existing args set by the OS image
- Add arch-conditional serial console (ttyAMA0 on aarch64, ttyS0 on x86_64)
- Update all four Confluent recipe YAMLs (AlmaLinux 10 and Rocky 10, both arches)


OpenCHAMI (7af8737c)

- Add the OpenHPC updates repository to the compute image build configuration, so that update packages resolve correctly alongside the base OpenHPC repo
- Split the proxy placeholder comment out of the prose paragraph in proxy.md.j2 and convert it to a Jinja comment ({# #}) so it does not appear in rendered output
- 

openEuler repository setup (778e6c37)

- Correct the description of the OpenHPC COPR ohpc_begin block in repos.md.j2: the block adds the COPR repository on the head node (required for tools such as yq used during Warewulf configuration), not just the EPOL update repo as the previous prose implied. Update the comment label accordingly.


Tested on aarch64 on qemu on a M3 for AlmaLinux