### PR TITLE
improve time sync for non-UTC systems

### DIFF
--- a/components/admin/examples/SOURCES/chrony.conf.ww
+++ b/components/admin/examples/SOURCES/chrony.conf.ww
@@ -1,1 +1,2 @@
 server {{.Tags.ntpserver}} iburst
+makestep 1.0 3

--- a/docs/install/templates/provisioner/warewulf/warewulf-setup.md.j2
+++ b/docs/install/templates/provisioner/warewulf/warewulf-setup.md.j2
@@ -31,9 +31,10 @@ systemctl enable --now warewulfd
 wwctl profile add nodes --profile default --comment "Nodes profile"
 
 # Create a new "nodeconfig" overlay to store node
-# configuration files and use the syncuser overlay.
+# configuration files, inherit the timezone settings
+# from the SMS, and use the syncuser overlay.
 wwctl overlay create nodeconfig
-wwctl profile set --yes nodes --system-overlays nodeconfig \
+wwctl profile set --yes nodes --system-overlays nodeconfig,localtime \
 	--runtime-overlays syncuser
 
 # Set default network configuration


### PR DESCRIPTION
Out of the box, compute node clocks are synced to the SMS, but always with a UTC timezone. This breaks munge in non-UTC settings. We should also take steps to ensure that chrony jumps if time is too far out of sync.

Whether or not we should abandon the local chrony.conf.ww and use [the upstream one](https://github.com/warewulf/warewulf/blob/main/overlays/chrony/rootfs/etc/chrony.conf.ww) can be discussed.