### PR TITLE
ci: disable AppArmor on host for integration test

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -245,6 +245,10 @@ jobs:
       with:
         name: rhel-rpms-gnu15-ubuntu-latest
         path: rpms
+    - name: Disable AppArmor
+      run: |
+        sudo aa-teardown || true
+        sudo systemctl disable apparmor
     - name: Start AlmaLinux 10 container
       run: >-
         sudo mkdir -p /mnt/nested-container;


### PR DESCRIPTION
Host-level AppArmor profiles on Ubuntu runners deny access to /run/systemd/notify for processes like chronyd inside privileged containers, even with --security-opt apparmor=unconfined. Stop and disable AppArmor on the runner before launching the container.

Generated with Claude Code (https://claude.ai/code)