### PR TITLE
ucx: restore Source0 v-prefix and disable incomplete Go bindings

### DIFF
--- a/components/mpi-families/ucx/SPECS/ucx.spec
+++ b/components/mpi-families/ucx/SPECS/ucx.spec
@@ -19,6 +19,7 @@
 %bcond_with    ugni
 %bcond_with    xpmem
 %bcond_with    java
+%bcond_with    go
 
 %include %{_sourcedir}/OHPC_macros
 %undefine _annotated_build
@@ -110,6 +111,7 @@ This package was built from '' branch, commit c30b7da.
            %_with_arg xpmem xpmem \
            %_with_arg ugni ugni \
            %_with_arg java java \
+           %_with_arg go go \
            %{?configure_options}
 
 make %{?_smp_mflags} V=1

--- a/components/mpi-families/ucx/SPECS/ucx.spec
+++ b/components/mpi-families/ucx/SPECS/ucx.spec
@@ -33,7 +33,7 @@ Summary: UCX is a communication library implementing high-performance messaging
 Group:   %{PROJ_NAME}/mpi-families
 License: BSD
 URL:     http://www.openucx.org
-Source0: https://github.com/openucx/%{pname}/releases/download/%{version}/%{pname}-%{version}.tar.gz
+Source0: https://github.com/openucx/%{pname}/releases/download/v%{version}/%{pname}-%{version}.tar.gz
 
 # UCX currently supports only the following architectures
 ExclusiveArch: aarch64 ppc64le x86_64


### PR DESCRIPTION
## Summary
Two small, arch-independent fixes to the `ucx` spec (one commit each). Neither changes what is shipped today on x86_64/aarch64.

## 1 — `Source0` lost its `v` tag prefix (regression in the 1.20.0 bump)
The 1.20.0 upgrade (`10d0b88a4`) accidentally dropped the `v` from the release tag:
```
-Source0: .../releases/download/v%{version}/...   # 1.18.0
+Source0: .../releases/download/%{version}/...     # 1.20.0
```
UCX release assets live under the `v`-prefixed tag, so the un-prefixed path **404s for every version**:

| version | `download/<v>/` | `download/v<v>/` |
|---|---|---|
| 1.17.0 | 404 | 200 |
| 1.18.0 | 404 | 200 |
| 1.20.0 | 404 | 200 |

This doesn't affect OBS (which builds from its uploaded tarball), but it breaks any spec-level source fetch (`spectool -g`, downstream rebuilds). Restore the prefix.

## 2 — disable the incomplete Go bindings
The UCX 1.20.0 release tarball ships `bindings/go/Makefile.{am,in}` but **omits the Go source tree**:
```
$ tar tzf ucx-1.20.0.tar.gz | grep bindings/go
ucx-1.20.0/bindings/go/
ucx-1.20.0/bindings/go/Makefile.am
ucx-1.20.0/bindings/go/Makefile.in
```
So when `configure` autodetects a `go` compiler, the bindings are enabled and the build fails:
```
cd .../bindings/go/src/ucx ; go build
go: go.mod file not found in current directory or any parent directory
make[2]: *** [Makefile:640: build] Error 1
```
OBS builds pass today only because the chroot has no `go` (there's no `golang` BuildRequires), so this is latent. Disable it explicitly using the spec's existing idiom — `%bcond_with go` (default off) + `%_with_arg go go` — matching the other optional bindings (cuda/ib/rocm/java/…). Ships the same result (no Go bindings); just deterministic.

## Testing
- Confirmed the new `Source0` resolves (200) and the old one 404s, for 1.17/1.18/1.20.
- Built `ucx` on ppc64le three ways — Go absent, Go present (autodetect), `--with-go` forced — confirming the bindings fail whenever `go` is present and the disable is required.
- Built `ucx` cleanly on x86_64 and ppc64le.
