### PR TITLE
hwloc: fix malformed Release macro

### DIFF
--- a/components/dev-tools/hwloc/SPECS/hwloc.spec
+++ b/components/dev-tools/hwloc/SPECS/hwloc.spec
@@ -18,7 +18,7 @@
 
 Name:           %{pname}%{PROJ_DELIM}
 Version:        %{major}.%{minor}.%{extra}
-Release:        %{?dist}.1
+Release:        1%{?dist}
 Summary:        Portable Hardware Locality
 License:        BSD-3-Clause
 Group:          %{PROJ_NAME}/dev-tools


### PR DESCRIPTION
## Summary
`hwloc`'s `Release` expands to a malformed, leading-dot string with no numeric component:
```
$ rpm --define 'dist .el10' --eval '%{?dist}.1'
.el10.1
```
`hwloc` is the **only** spec in the tree using this form — every other package (`numpy`, `ucx`, `boost`, …) uses `1%{?dist}`. Align it:
```
-Release:        %{?dist}.1
+Release:        1%{?dist}
```
→ `1.el10`.
