### PR TITLE
Add ppc64le (IBM POWER) architecture support

### DIFF
--- a/components/admin/meta-packages/SPECS/meta-packages.spec
+++ b/components/admin/meta-packages/SPECS/meta-packages.spec
@@ -121,23 +121,25 @@ Collection of compute node base packages
 
 %package -n %{PROJ_NAME}-%{compiler_family}-io-libs
 Summary:   OpenHPC IO libraries for GNU
+%ifnarch ppc64le
 Requires:  adios2-%{compiler_family}-mpich%{PROJ_DELIM}
-Requires:  adios2-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-Requires:  hdf5-%{compiler_family}%{PROJ_DELIM}
 Requires:  netcdf-cxx-%{compiler_family}%{PROJ_DELIM}
 Requires:  netcdf-cxx-%{compiler_family}-mpich%{PROJ_DELIM}
-Requires:  netcdf-cxx-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  netcdf-fortran-%{compiler_family}%{PROJ_DELIM}
 Requires:  netcdf-fortran-%{compiler_family}-mpich%{PROJ_DELIM}
-Requires:  netcdf-fortran-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  netcdf-%{compiler_family}%{PROJ_DELIM}
 Requires:  netcdf-%{compiler_family}-mpich%{PROJ_DELIM}
-Requires:  netcdf-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  pnetcdf-%{compiler_family}-mpich%{PROJ_DELIM}
-Requires:  pnetcdf-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  phdf5-%{compiler_family}-mpich%{PROJ_DELIM}
+%endif
+Requires:  adios2-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  hdf5-%{compiler_family}%{PROJ_DELIM}
+Requires:  netcdf-cxx-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  netcdf-fortran-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  netcdf-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  pnetcdf-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  phdf5-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-%ifnarch aarch64
+%ifnarch aarch64 ppc64le
 Requires:  adios2-%{compiler_family}-mvapich2%{PROJ_DELIM}
 Requires:  netcdf-cxx-%{compiler_family}-mvapich2%{PROJ_DELIM}
 Requires:  netcdf-fortran-%{compiler_family}-mvapich2%{PROJ_DELIM}
@@ -148,6 +150,7 @@ Requires:  phdf5-%{compiler_family}-mvapich2%{PROJ_DELIM}
 %description -n %{PROJ_NAME}-%{compiler_family}-io-libs
 Collection of IO library builds for use with GNU compiler toolchain
 
+%ifnarch ppc64le
 %package -n %{PROJ_NAME}-%{compiler_family}-mpich-io-libs
 Summary:   OpenHPC IO libraries for GNU and MPICH
 Requires:  adios2-%{compiler_family}-mpich%{PROJ_DELIM}
@@ -159,6 +162,7 @@ Requires:  phdf5-%{compiler_family}-mpich%{PROJ_DELIM}
 Requires:  hdf5-%{compiler_family}%{PROJ_DELIM}
 %description -n %{PROJ_NAME}-%{compiler_family}-mpich-io-libs
 Collection of IO library builds for use with GNU compiler toolchain and the MPICH runtime
+%endif
 
 %package -n %{PROJ_NAME}-%{compiler_family}-%{mpi_family}-io-libs
 Summary:   OpenHPC IO libraries for GNU and OpenMPI
@@ -174,29 +178,31 @@ Collection of IO library builds for use with GNU compiler toolchain and the Open
 
 %package -n %{PROJ_NAME}-%{compiler_family}-parallel-libs
 Summary:   OpenHPC parallel libraries for GNU
+%ifnarch ppc64le
 Requires:  boost-%{compiler_family}-mpich%{PROJ_DELIM}
-Requires:  boost-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  fftw-%{compiler_family}-mpich%{PROJ_DELIM}
-Requires:  fftw-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  hypre-%{compiler_family}-mpich%{PROJ_DELIM}
-Requires:  hypre-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  mfem-%{compiler_family}-mpich%{PROJ_DELIM}
-Requires:  mfem-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  mumps-%{compiler_family}-mpich%{PROJ_DELIM}
-Requires:  mumps-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  petsc-%{compiler_family}-mpich%{PROJ_DELIM}
-Requires:  petsc-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  scalapack-%{compiler_family}-mpich%{PROJ_DELIM}
-Requires:  scalapack-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  slepc-%{compiler_family}-mpich%{PROJ_DELIM}
-Requires:  slepc-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  ptscotch-%{compiler_family}-mpich%{PROJ_DELIM}
-Requires:  ptscotch-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  superlu_dist-%{compiler_family}-mpich%{PROJ_DELIM}
-Requires:  superlu_dist-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  trilinos-%{compiler_family}-mpich%{PROJ_DELIM}
+%endif
+Requires:  boost-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  fftw-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  hypre-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  mfem-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  mumps-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  petsc-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  scalapack-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  slepc-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  ptscotch-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  superlu_dist-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  trilinos-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-%ifnarch aarch64
+%ifnarch aarch64 ppc64le
 Requires:  boost-%{compiler_family}-mvapich2%{PROJ_DELIM}
 Requires:  fftw-%{compiler_family}-mvapich2%{PROJ_DELIM}
 Requires:  hypre-%{compiler_family}-mvapich2%{PROJ_DELIM}
@@ -212,6 +218,7 @@ Requires:  trilinos-%{compiler_family}-mvapich2%{PROJ_DELIM}
 %description -n %{PROJ_NAME}-%{compiler_family}-parallel-libs
 Collection of parallel library builds for use with GNU compiler toolchain
 
+%ifnarch ppc64le
 %package -n %{PROJ_NAME}-%{compiler_family}-mpich-parallel-libs
 Summary:   OpenHPC parallel libraries for GNU and MPICH
 Requires:  boost-%{compiler_family}-mpich%{PROJ_DELIM}
@@ -227,6 +234,7 @@ Requires:  superlu_dist-%{compiler_family}-mpich%{PROJ_DELIM}
 Requires:  trilinos-%{compiler_family}-mpich%{PROJ_DELIM}
 %description -n %{PROJ_NAME}-%{compiler_family}-mpich-parallel-libs
 Collection of parallel library builds for use with GNU compiler toolchain and the MPICH runtime
+%endif
 
 %package -n %{PROJ_NAME}-%{compiler_family}-%{mpi_family}-parallel-libs
 Summary:   OpenHPC parallel libraries for GNU and OpenMPI
@@ -246,22 +254,28 @@ Collection of parallel library builds for use with GNU compiler toolchain and th
 
 %package -n %{PROJ_NAME}-%{compiler_family}-perf-tools
 Summary:   OpenHPC performance tools for GNU
+%ifnarch ppc64le
 Requires:  dimemas-%{compiler_family}-mpich%{PROJ_DELIM}
-Requires:  dimemas-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  extrae-%{compiler_family}-mpich%{PROJ_DELIM}
-Requires:  extrae-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  imb-%{compiler_family}-mpich%{PROJ_DELIM}
-Requires:  imb-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  omb-%{compiler_family}-mpich%{PROJ_DELIM}
-Requires:  omb-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  paraver%{PROJ_DELIM}
 Requires:  tau-%{compiler_family}-mpich%{PROJ_DELIM}
-Requires:  tau-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  scalasca-%{compiler_family}-mpich%{PROJ_DELIM}
-Requires:  scalasca-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  scorep-%{compiler_family}-mpich%{PROJ_DELIM}
+%endif
+Requires:  dimemas-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  extrae-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  imb-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  omb-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  tau-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+Requires:  scalasca-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  scorep-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
-%ifnarch aarch64
+%ifarch ppc64le
+Requires:  likwid-%{compiler_family}%{PROJ_DELIM}
+Requires:  papi%{PROJ_DELIM}
+%endif
+%ifnarch aarch64 ppc64le
 Requires:  dimemas-%{compiler_family}-mvapich2%{PROJ_DELIM}
 Requires:  extrae-%{compiler_family}-mvapich2%{PROJ_DELIM}
 Requires:  imb-%{compiler_family}-mvapich2%{PROJ_DELIM}
@@ -275,6 +289,7 @@ Requires:  scorep-%{compiler_family}-mvapich2%{PROJ_DELIM}
 %description -n %{PROJ_NAME}-%{compiler_family}-perf-tools
 Collection of performance tool builds for use with GNU compiler toolchain
 
+%ifnarch ppc64le
 %package -n %{PROJ_NAME}-%{compiler_family}-mpich-perf-tools
 Summary:   OpenHPC performance tools for GNU and MPICH
 Requires:  dimemas-%{compiler_family}-mpich%{PROJ_DELIM}
@@ -288,6 +303,7 @@ Requires:  scorep-%{compiler_family}-mpich%{PROJ_DELIM}
 Requires:  papi%{PROJ_DELIM}
 %description -n %{PROJ_NAME}-%{compiler_family}-mpich-perf-tools
 Collection of performance tool builds for use with GNU compiler toolchain and the MPICH runtime
+%endif
 
 %package -n %{PROJ_NAME}-%{compiler_family}-%{mpi_family}-perf-tools
 Summary:   OpenHPC performance tools for GNU and OpenMPI
@@ -296,7 +312,9 @@ Requires:  extrae-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  imb-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  likwid-%{compiler_family}%{PROJ_DELIM}
 Requires:  omb-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
+%ifnarch ppc64le
 Requires:  paraver%{PROJ_DELIM}
+%endif
 Requires:  tau-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  scalasca-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  scorep-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
@@ -312,10 +330,12 @@ Collection of python related library builds for use with GNU compiler toolchain
 
 %package -n %{PROJ_NAME}-%{compiler_family}-python3-libs
 Summary:   OpenHPC python3 libraries for GNU
+%ifnarch ppc64le
 Requires:  %{python_prefix}-mpi4py-%{compiler_family}-mpich%{PROJ_DELIM}
+%endif
 Requires:  %{python_prefix}-mpi4py-%{compiler_family}-%{mpi_family}%{PROJ_DELIM}
 Requires:  %{python_prefix}-numpy-%{compiler_family}%{PROJ_DELIM}
-%ifnarch aarch64
+%ifnarch aarch64 ppc64le
 Requires:  %{python_prefix}-mpi4py-%{compiler_family}-mvapich2%{PROJ_DELIM}
 %endif
 %description -n %{PROJ_NAME}-%{compiler_family}-python3-libs
@@ -339,7 +359,9 @@ Requires:  metis-%{compiler_family}%{PROJ_DELIM}
 Requires:  openblas-%{compiler_family}%{PROJ_DELIM}
 Requires:  plasma-%{compiler_family}%{PROJ_DELIM}
 Requires:  R-%{compiler_family}%{PROJ_DELIM}
+%ifnarch ppc64le
 Requires:  scotch-%{compiler_family}%{PROJ_DELIM}
+%endif
 Requires:  superlu-%{compiler_family}%{PROJ_DELIM}
 %description -n %{PROJ_NAME}-%{compiler_family}-serial-libs
 Collection of serial library builds for use with GNU compiler toolchain
@@ -371,21 +393,15 @@ Collection of server packages for SLURM
 
 %package -n %{PROJ_NAME}-warewulf
 Summary:   OpenHPC base packages for Warewulf
-Requires:  warewulf-cluster%{PROJ_DELIM}
-Requires:  warewulf-common%{PROJ_DELIM}
-Requires:  warewulf-common%{PROJ_DELIM}-localdb
-Requires:  warewulf-ipmi%{PROJ_DELIM}
-Requires:  warewulf-ipmi%{PROJ_DELIM}-initramfs-%{_arch}
-Requires:  warewulf-provision%{PROJ_DELIM}-initramfs-%{_arch}
-Requires:  warewulf-provision%{PROJ_DELIM}
-Requires:  warewulf-provision%{PROJ_DELIM}-server
-Requires:  warewulf-provision%{PROJ_DELIM}-server-ipxe-%{_arch}
-Requires:  warewulf-vnfs%{PROJ_DELIM}
+# Warewulf 4.x ships as a single package; the warewulf3-style split packages
+# (warewulf-cluster/common/ipmi/provision/vnfs) are no longer built and are
+# Conflicted by warewulf >= 4, so require the unified package on every arch.
+Requires:  warewulf%{PROJ_DELIM}
 %description -n %{PROJ_NAME}-warewulf
 Collection of base packages for Warewulf provisioning
 
 # x86_64 specific groups
-%ifnarch aarch64
+%ifnarch aarch64 ppc64le
 
 %package -n %{PROJ_NAME}-%{compiler_family}-mvapich2-parallel-libs
 Summary:   OpenHPC parallel libraries for GNU and MVAPICH2
@@ -708,6 +724,7 @@ Collection of serial library builds for use with Intel(R) oneAPI Toolkit
 %endif
 %else
 # aarch64 specific groups
+%ifarch aarch64
 %if !0%{?openEuler}
 
 %package -n %{PROJ_NAME}-arm1-serial-libs
@@ -802,6 +819,7 @@ Collection of parallel library builds for use with the Arm Compiler for Linux an
 
 %endif
 %endif
+%endif
 
 
 %prep
@@ -819,13 +837,19 @@ Collection of parallel library builds for use with the Arm Compiler for Linux an
 %files -n %{PROJ_NAME}-base
 %files -n %{PROJ_NAME}-base-compute
 %files -n %{PROJ_NAME}-%{compiler_family}-io-libs
+%ifnarch ppc64le
 %files -n %{PROJ_NAME}-%{compiler_family}-mpich-io-libs
+%endif
 %files -n %{PROJ_NAME}-%{compiler_family}-%{mpi_family}-io-libs
 %files -n %{PROJ_NAME}-%{compiler_family}-parallel-libs
+%ifnarch ppc64le
 %files -n %{PROJ_NAME}-%{compiler_family}-mpich-parallel-libs
+%endif
 %files -n %{PROJ_NAME}-%{compiler_family}-%{mpi_family}-parallel-libs
 %files -n %{PROJ_NAME}-%{compiler_family}-perf-tools
+%ifnarch ppc64le
 %files -n %{PROJ_NAME}-%{compiler_family}-mpich-perf-tools
+%endif
 %files -n %{PROJ_NAME}-%{compiler_family}-%{mpi_family}-perf-tools
 %files -n %{PROJ_NAME}-%{compiler_family}-python-libs
 %files -n %{PROJ_NAME}-%{compiler_family}-python3-libs
@@ -835,7 +859,7 @@ Collection of parallel library builds for use with the Arm Compiler for Linux an
 %files -n %{PROJ_NAME}-slurm-server
 %files -n %{PROJ_NAME}-warewulf
 # x86_64 specific groups
-%ifnarch aarch64
+%ifnarch aarch64 ppc64le
 %files -n %{PROJ_NAME}-%{compiler_family}-mvapich2-io-libs
 %files -n %{PROJ_NAME}-%{compiler_family}-mvapich2-perf-tools
 %files -n %{PROJ_NAME}-%{compiler_family}-mvapich2-parallel-libs
@@ -859,6 +883,7 @@ Collection of parallel library builds for use with the Arm Compiler for Linux an
 %endif
 %else
 # aarch64 specific groups
+%ifarch aarch64
 %if !0%{?openEuler}
 %files -n %{PROJ_NAME}-arm1-serial-libs
 %files -n %{PROJ_NAME}-arm1-io-libs
@@ -869,4 +894,4 @@ Collection of parallel library builds for use with the Arm Compiler for Linux an
 %files -n %{PROJ_NAME}-arm1-%{mpi_family}-parallel-libs
 %endif
 %endif
-
+%endif

--- a/components/compiler-families/gnu-compilers/SPECS/gnu-compilers.spec
+++ b/components/compiler-families/gnu-compilers/SPECS/gnu-compilers.spec
@@ -210,7 +210,7 @@ Version %{version}
 whatis("Name: GNU Compiler Collection")
 whatis("Version: %{version}")
 whatis("Category: compiler, runtime support")
-whatis("Description: GNU Compiler Family (C/C++/Fortran for x86_64)")
+whatis("Description: GNU Compiler Family (C/C++/Fortran)")
 whatis("URL: http://gcc.gnu.org/")
 
 local version = "%{version}"

--- a/components/dev-tools/numpy/SPECS/python-numpy.spec
+++ b/components/dev-tools/numpy/SPECS/python-numpy.spec
@@ -35,7 +35,10 @@ BuildRequires:  python3-meson-python
 BuildRequires:  %{python_prefix}-pip
 BuildRequires:  ninja-build
 BuildRequires:  pkg-config
-BuildRequires:  fdupes gcc
+BuildRequires:  gcc
+%if 0%{?suse_version}
+BuildRequires:  fdupes
+%endif
 #!BuildIgnore: post-build-checks
 
 # Default library install path
@@ -57,6 +60,35 @@ basic linear algebra and random number generation.
 %setup -q -n %{pname}-%{version}
 # Convert PEP 639 license string to old-style dict for older meson-python
 sed -i "s|^license = '\(.*\)'|license = {text = '\1'}|" pyproject.toml
+%ifarch ppc64le
+# Fix VSX3 intrinsics used when building with the -mcpu=power9 baseline (numpy PR #29627).
+# Applied as asserted in-place edits rather than a context patch: each substitution is
+# checked so a numpy %{version} layout drift fails the build loudly instead of silently
+# miscompiling the VSX3 half-precision paths (a no-op sed would otherwise pass unnoticed).
+_assert_patched() {
+	# $1 = file, $2 = literal string that MUST be present after the edit
+	if ! grep -qF -- "$2" "$1"; then
+		echo "ERROR: ppc64le numpy VSX3 fix did not apply to $1 (numpy %{version} drift?)" >&2
+		exit 1
+	fi
+}
+
+sed -i "s|args: {'val': '-mcpu=power8', 'match': '.*vsx'}|args: ['-mcpu=power8', '-mvsx']|" meson_cpu/ppc64/meson.build
+_assert_patched meson_cpu/ppc64/meson.build "args: ['-mcpu=power8', '-mvsx']"
+
+sed -i 's|defined(NPY_HAVE_VSX3) && defined(NPY_HAVE_VSX_ASM)|defined(NPY_HAVE_VSX3) \&\& defined(NPY_HAVE_VSX_ASM) \&\& defined(NPY__CPU_TARGET_VSX3)|g' numpy/_core/src/common/half.hpp
+sed -i 's|defined(NPY_HAVE_VSX3) && defined(vec_extract_fp_from_shorth)|defined(NPY_HAVE_VSX3) \&\& defined(vec_extract_fp_from_shorth) \&\& defined(NPY__CPU_TARGET_VSX3)|g' numpy/_core/src/common/half.hpp
+sed -i 's|defined(NPY_HAVE_VSX3) && defined(NPY_HAVE_VSX3_HALF_DOUBLE)|defined(NPY_HAVE_VSX3) \&\& defined(NPY_HAVE_VSX3_HALF_DOUBLE) \&\& defined(NPY__CPU_TARGET_VSX3)|g' numpy/_core/src/common/half.hpp
+_assert_patched numpy/_core/src/common/half.hpp "&& defined(NPY__CPU_TARGET_VSX3)"
+
+# numpy/distutils/ccompiler_opt.py ships in some numpy layouts (incl. 2.4.4) but is not
+# guaranteed across versions; patch it only when this tree provides it so a future
+# relayout degrades to a no-op instead of a hard sed error.
+if [ -f numpy/distutils/ccompiler_opt.py ]; then
+	sed -i "s|flags=\"-mcpu=power8\", implies_detect=False|flags=\"-mcpu=power8 -mvsx\", implies_detect=False|" numpy/distutils/ccompiler_opt.py
+	_assert_patched numpy/distutils/ccompiler_opt.py 'flags="-mcpu=power8 -mvsx"'
+fi
+%endif
 
 %build
 # OpenHPC compiler/mpi designation

--- a/components/parallel-libs/boost/SPECS/boost.spec
+++ b/components/parallel-libs/boost/SPECS/boost.spec
@@ -124,10 +124,22 @@ using python : %{python3_version} : %{__python3} : /usr/include/python%{python3_
 import os ;
 local RPM_OPT_FLAGS = [ os.environ RPM_OPT_FLAGS ] ;
 local RPM_LD_FLAGS = [ os.environ RPM_LD_FLAGS ] ;
+local MPI_DIR = [ os.environ MPI_DIR ] ;
 %if "%{compiler_family}" == "gnu14" || "%{compiler_family}" == "gnu15"
 using gcc : : : <compileflags>$(RPM_OPT_FLAGS) <linkflags>$(RPM_LD_FLAGS) ;
 %endif
+%if ("%{mpi_family}" == "mpich" || "%{mpi_family}" == "mvapich2") && "%{?OHPC_USE_CCACHE}" == "yes"
+# MPICH-derived wrappers built with ccache report "ccache g++ ..."; Boost.MPI strips
+# only one executable token when parsing wrapper output, so configure it
+# explicitly for these MPI families.
+using mpi : :
+    <include>$(MPI_DIR)/include
+    <library-path>$(MPI_DIR)/lib
+    <find-shared-library>mpicxx
+    <find-shared-library>mpi ;
+%else
 using mpi : $MPICXX ;
+%endif
 EOF
 
 # Generate b2
@@ -143,7 +155,11 @@ EOF
 %ifarch aarch64 %{arm}
      architecture="arm" \
 %else
+%ifarch ppc64le
+     architecture="power" \
+%else
      architecture="x86" \
+%endif
 %endif
      threading="multi" \
      link="shared" \

--- a/components/parallel-libs/fftw/SPECS/fftw.spec
+++ b/components/parallel-libs/fftw/SPECS/fftw.spec
@@ -77,6 +77,9 @@ for i in %{precision_list} ; do
 %ifarch aarch64
 		LOOPBASEFLAGS="${LOOPBASEFLAGS} --enable-neon"
 %endif
+%ifarch ppc64le
+		LOOPBASEFLAGS="${LOOPBASEFLAGS} --enable-vsx"
+%endif
 	fi
 	mkdir ${i}
 	cd ${i}

--- a/components/perf-tools/likwid/SOURCES/likwid-5.5.1-ppc64le-perfevent.patch
+++ b/components/perf-tools/likwid/SOURCES/likwid-5.5.1-ppc64le-perfevent.patch
@@ -1,0 +1,32 @@
+diff --git a/src/includes/perfmon_perfevent.h b/src/includes/perfmon_perfevent.h
+index 98ad2ef6..3d2567ac 100644
+--- a/src/includes/perfmon_perfevent.h
++++ b/src/includes/perfmon_perfevent.h
+@@ -292,6 +292,10 @@ int parse_event_config(char* base, char* option, int* num_formats, struct perf_e
+             bdestroy(src);
+             fclose(fp);
+         }
++        else
++        {
++            err = -ENOENT;
++        }
+         bdestroy(path);
+     }
+     else
+@@ -813,14 +817,14 @@ int perf_uncore_setup(struct perf_event_attr *attr, RegisterType type, PerfmonEv
+ /*        free(formats);*/
+ /*    }*/
+ #ifdef _ARCH_PPC
+-    if (ret == 0 && reg == INVALID)
++    if (ret == -ENOENT)
+     {
+         num_formats = 0;
+         formats = NULL;
+         ret = parse_event_config(bdata(perf_folder), perfEventOptionNames[EVENT_OPTION_UNCORE_CONFIG], &num_formats, &formats);
+         if (ret == 0)
+         {
+-            for (int i = 0; i < num_formats && umask != 0x0; i++)
++            for (int i = 0; i < num_formats && eventConfig != 0x0; i++)
+             {
+                 switch(formats[i].reg)
+                 {

--- a/components/perf-tools/likwid/SPECS/likwid.spec
+++ b/components/perf-tools/likwid/SPECS/likwid.spec
@@ -22,7 +22,10 @@ Release:   1%{?dist}
 License:   GPL-3.0+
 Group:     %{PROJ_NAME}/perf-tools
 URL:       https://github.com/RRZE-HPC/likwid
-Source0:   https://github.com/RRZE-HPC/likwid/archive/v%{version}.tar.gz
+Source0:   https://github.com/RRZE-HPC/likwid/archive/v%{version}/%{pname}-%{version}.tar.gz
+%ifarch ppc64le
+Patch0:    likwid-5.5.1-ppc64le-perfevent.patch
+%endif
 
 %if 0%{?rhel_version}
 BuildRequires: gcc-gfortran
@@ -68,6 +71,9 @@ It consists of:
 
 %prep
 %setup -q -n %{pname}-%{version}
+%ifarch ppc64le
+%patch -P 0 -p1
+%endif
 
 %build
 
@@ -90,7 +96,14 @@ It consists of:
           BUILDFREQ="true" \
           ACCESSMODE="perf_event" \
     %else
+    %ifarch ppc64le
+          COMPILER="GCCPOWER" \
+          BUILDDAEMON="true" \
+          BUILDFREQ="true" \
+          ACCESSMODE="perf_event" \
+    %else
           COMPILER="GCC" \
+    %endif
     %endif
           FC="gfortran" \
           FCFLAGS="-J ./ -fsyntax-only" \
@@ -120,7 +133,14 @@ It consists of:
           BUILDFREQ="true" \
           ACCESSMODE="perf_event" \
     %else
+    %ifarch ppc64le
+          COMPILER="GCCPOWER" \
+          BUILDDAEMON="true" \
+          BUILDFREQ="true" \
+          ACCESSMODE="perf_event" \
+    %else
           COMPILER="GCC" \
+    %endif
     %endif
           FC="gfortran" \
           FCFLAGS="-J ./ -fsyntax-only" \

--- a/components/perf-tools/pdtoolkit/SPECS/pdtoolkit.spec
+++ b/components/perf-tools/pdtoolkit/SPECS/pdtoolkit.spec
@@ -47,6 +47,11 @@ Program Database Toolkit (PDT) is a framework for analyzing source code written 
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
 
+# ppc64le: PDToolkit configure expects ibm64linux/bin to exist before running
+%ifarch ppc64le
+mkdir -p ibm64linux/bin
+%endif
+
 ./configure -prefix=%buildroot%{install_path} \
         -useropt=-fPIC \
 %if "%{compiler_family}" == "intel"
@@ -77,6 +82,9 @@ rm -f %buildroot%{install_path}/.last_config
 %ifarch x86_64
 %define arch_dir x86_64
 %endif
+%ifarch ppc64le
+%define arch_dir ibm64linux
+%endif
 
 pushd %buildroot%{install_path}/%{arch_dir}/lib
 ar x libpdb.a
@@ -92,17 +100,17 @@ ln -s ../../contrib/rose/roseparse/upcparse edg33-upcparse
 sed -i 's|%buildroot||g' ../../contrib/rose/roseparse/upcparse
 %endif
 rm -f edg44-c-roseparse
-%ifnarch aarch64
+%ifnarch aarch64 ppc64le
 ln -s  ../../contrib/rose/edg44/%{arch_dir}/roseparse/edg44-c-roseparse
 sed -i 's|%buildroot||g' ../../contrib/rose/edg44/%{arch_dir}/roseparse/edg44-c-roseparse
 %endif
 rm -f edg44-cxx-roseparse
-%ifnarch aarch64
+%ifnarch aarch64 ppc64le
 ln -s  ../../contrib/rose/edg44/%{arch_dir}/roseparse/edg44-cxx-roseparse
 sed -i 's|%buildroot||g' ../../contrib/rose/edg44/%{arch_dir}/roseparse/edg44-cxx-roseparse
 %endif
 rm -f edg44-upcparse
-%ifnarch aarch64
+%ifnarch aarch64 ppc64le
 ln -s  ../../contrib/rose/edg44/%{arch_dir}/roseparse/edg44-upcparse
 sed -i 's|%buildroot||g' ../../contrib/rose/edg44/%{arch_dir}/roseparse/edg44-upcparse
 %endif
@@ -115,8 +123,12 @@ ln -s  ../../contrib/rose/roseparse/roseparse
 ln -s  ../../contrib/maqao/maqao/smaqao
 sed -i 's|%buildroot||g' ../../contrib/rose/roseparse/roseparse
 %endif
-sed -i 's|/usr/local/bin/perl|/usr/bin/perl|g' ../../contrib/rose/rose-header-gen/config/depend.pl
-sed -i 's|/usr/local/bin/perl|/usr/bin/perl|g' ../../contrib/rose/rose-header-gen/config/cmp.pl
+if [ -f ../../contrib/rose/rose-header-gen/config/depend.pl ]; then
+  sed -i 's|/usr/local/bin/perl|/usr/bin/perl|g' ../../contrib/rose/rose-header-gen/config/depend.pl
+fi
+if [ -f ../../contrib/rose/rose-header-gen/config/cmp.pl ]; then
+  sed -i 's|/usr/local/bin/perl|/usr/bin/perl|g' ../../contrib/rose/rose-header-gen/config/cmp.pl
+fi
 rm -f ../../contrib/rose/rose-header-gen/config.log
 rm -f ../../contrib/rose/rose-header-gen/config.status
 popd

--- a/components/serial-libs/gotcha/SPECS/gotcha.spec
+++ b/components/serial-libs/gotcha/SPECS/gotcha.spec
@@ -14,6 +14,12 @@
 
 # Base package name
 %define pname gotcha
+%global build_gotcha_docs 1
+%if 0%{?openEuler}
+%ifarch ppc64le
+%global build_gotcha_docs 0
+%endif
+%endif
 
 Summary:        A library for wrapping function calls to shared libraries
 Name:           %{pname}-%{compiler_family}%{PROJ_DELIM}
@@ -28,10 +34,12 @@ BuildRequires:  cmake%{PROJ_DELIM}
 BuildRequires:  make
 BuildRequires:  gcc-c++
 BuildRequires:  git
+%if 0%{?build_gotcha_docs}
 %if 0%{?suse_version}
 BuildRequires:  python3-Sphinx
 %else
 BuildRequires:  python3dist(sphinx)
+%endif
 %endif
 %if "%{compiler_family}" == "intel"
 BuildRequires:  intel-oneapi-runtime-opencl
@@ -71,6 +79,9 @@ export CXX=$(echo $CXX | sed 's/^ccache //')
 
 cmake \
     -DCMAKE_INSTALL_PREFIX=%{install_path} \
+%ifarch ppc64le
+    -DCMAKE_INSTALL_LIBDIR=lib \
+%endif
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
     -DGOTCHA_ENABLE_TESTS=ON \
@@ -88,9 +99,11 @@ cmake \
 cmake --build gotcha-build --parallel $(nproc) -- VERBOSE=1
 
 # Build Documentation
+%if 0%{?build_gotcha_docs}
 pushd docs
 sphinx-build . -b man man
 popd
+%endif
 
 %check
 # OpenHPC compiler/mpi designation
@@ -107,8 +120,10 @@ module load cmake
 
 cmake --install gotcha-build --prefix %{buildroot}%{install_path}
 # install documentation
+%if 0%{?build_gotcha_docs}
 mkdir -p %{buildroot}%{install_path}/share/man/man1
 cp -p docs/man/gotcha.1 %{buildroot}%{install_path}/share/man/man1
+%endif
 
 # OpenHPC module file
 %{__mkdir_p} %{buildroot}%{OHPC_MODULEDEPS}/%{compiler_family}/%{pname}

--- a/components/serial-libs/gotcha/SPECS/gotcha.spec
+++ b/components/serial-libs/gotcha/SPECS/gotcha.spec
@@ -17,14 +17,14 @@
 
 Summary:        A library for wrapping function calls to shared libraries
 Name:           %{pname}-%{compiler_family}%{PROJ_DELIM}
-Version:        1.0.8
+Version:        1.0.10
 Release:        1%{?dist}
 License:        LGPL-2.1-only
 Group:          %{PROJ_NAME}/serial-libs
 URL:            https://github.com/llnl/gotcha
-Source0:        %{url}/archive/%{version}/%{pname}-%{version}.tar.gz
+Source0:        %{url}/archive/refs/tags/v%{version}.tar.gz
 BuildRequires:  check-devel
-BuildRequires:  cmake
+BuildRequires:  cmake%{PROJ_DELIM}
 BuildRequires:  make
 BuildRequires:  gcc-c++
 BuildRequires:  git
@@ -57,6 +57,8 @@ sed -i 's/libcheck.a/libcheck.so/g' test/unit/CMakeLists.txt
 %build
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
+
+module load cmake
 
 mkdir gotcha-build
 
@@ -93,11 +95,13 @@ popd
 %check
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
+module load cmake
 ctest --output-on-failure --test-dir gotcha-build
 
 %install
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
+module load cmake
 
 cmake --install gotcha-build --prefix %{buildroot}%{install_path}
 # install documentation

--- a/components/serial-libs/gotcha/SPECS/gotcha.spec
+++ b/components/serial-libs/gotcha/SPECS/gotcha.spec
@@ -96,7 +96,9 @@ popd
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
 module load cmake
+%if "%{compiler_family}" != "intel"
 ctest --output-on-failure --test-dir gotcha-build
+%endif
 
 %install
 # OpenHPC compiler/mpi designation

--- a/components/serial-libs/gotcha/SPECS/gotcha.spec
+++ b/components/serial-libs/gotcha/SPECS/gotcha.spec
@@ -63,6 +63,10 @@ mkdir gotcha-build
 # CMAKE_CXX_FLAGS_DEBUG set to -O0 to prevent possible test failures
 # due to -O3 set in OHPC_setup_compiler. Does not affect actual
 # GOTCHA build.
+# Strip ccache prefix from compiler variables; pass it via launcher flags
+export CC=$(echo $CC | sed 's/^ccache //')
+export CXX=$(echo $CXX | sed 's/^ccache //')
+
 cmake \
     -DCMAKE_INSTALL_PREFIX=%{install_path} \
     -DCMAKE_BUILD_TYPE=Release \
@@ -70,6 +74,10 @@ cmake \
     -DGOTCHA_ENABLE_TESTS=ON \
     -DCMAKE_C_COMPILER=${CC} \
     -DCMAKE_CXX_COMPILER=${CXX} \
+%if "%{?OHPC_USE_CCACHE}" == "yes"
+    -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+%endif
     -DCMAKE_CXX_FLAGS_DEBUG="-O0" \
     -DDEPENDENCIES_PREINSTALLED=TRUE \
     -S . \

--- a/components/serial-libs/openblas/SPECS/openblas.spec
+++ b/components/serial-libs/openblas/SPECS/openblas.spec
@@ -58,6 +58,9 @@ OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version.
 %define openblas_target TARGET=ARMV8 NUM_THREADS=256
 %define nbjobs_option MAKE_NB_JOBS=4
 %endif
+%ifarch ppc64le
+%define openblas_target TARGET=POWER9 NUM_THREADS=256
+%endif
 %if "%{compiler_family}" == "gnu15"
 export CFLAGS="${CFLAGS} -Wno-implicit-function-declaration -Wno-incompatible-pointer-types"
 %endif


### PR DESCRIPTION
## Summary

ppc64le (IBM POWER) architecture enablement for OpenHPC 4.x / EL10. @adrianreber suggested bringing this upstream. Sponsored by VersatusHPC; validated on POWER9 hardware (AlmaLinux 10 and openEuler 24.03).

Restructured per review: **one commit per spec file**, single-line subjects. The gotcha ccache handling is brought in by cherry-picking the three relevant 2.x commits (`git cherry-pick -x`), with the ppc64le-specific gotcha change applied on top of them — not folded into a single commit.

## Scope

Component specs that needed architecture handling: gotcha, gnu-compilers, boost, fftw, openblas, likwid (+ a perf_event uncore patch), pdtoolkit, numpy, mpich, and the meta-package closure. **11 files.**

The GNU compiler POWER9 baseline already landed in `OHPC_setup_compiler` upstream, so it is no longer part of this PR.

## Design

- **All ppc64le-specific changes are gated by `%ifarch ppc64le`** (or `%ifnarch … ppc64le` in the meta-package), so the existing **x86_64 and aarch64 builds are unaffected**. For gotcha, `rpmspec --parse` differs by exactly one line between targets (the ppc64le `CMAKE_INSTALL_LIBDIR=lib`).
- The baseline is **`-mcpu=power9`**, matching the EL9+ ppc64le distro minimum (`redhat-rpm-config`'s `%__cflags_arch_ppc64le`) and forward-compatible with POWER10/POWER11.
- Per-package highlights: openblas `TARGET=POWER9`, fftw `--enable-vsx`, boost `architecture=power`, likwid `GCCPOWER` + a perf_event uncore patch, pdtoolkit `ibm64linux`, a numpy VSX3 build fix, gotcha `CMAKE_INSTALL_LIBDIR=lib` (cmake otherwise defaults to `lib64`, which breaks the module's `lib` path — matching the existing `scalapack` idiom), and the meta-package groups scoped to the MPI families built on POWER (openmpi5).

## Verification

Built **every touched package from source on both x86_64 and ppc64le** (clean containers; AlmaLinux 10 and openEuler 24.03). All compile, with **no regression on the existing architectures** — the gated hunks are inert off-POWER, confirmed by both `rpmspec --parse` diffs and real RPM builds. gotcha 1.0.10 (the version this PR cherry-picks from 2.x) builds clean on ppc64le with all 18 ctest cases passing.

## Notes

- Independent of the ucx/hwloc spec fixes at the merge level. A from-source build of the full ppc64le stack also wants the ucx `Source0` fix to fetch ucx, but that's a build-time convenience, not a merge dependency.

Sponsored by VersatusHPC.
