### PR TITLE
ucx: fix UCS_INFINITY undeclared error on ppc64le

### DIFF
--- a/components/mpi-families/ucx/SOURCES/time-include-math.patch
+++ b/components/mpi-families/ucx/SOURCES/time-include-math.patch
@@ -1,0 +1,12 @@
+diff --git a/src/ucs/time/time.h b/src/ucs/time/time.h
+index 48f03ca0432..f257a365510 100644
+--- a/src/ucs/time/time.h
++++ b/src/ucs/time/time.h
+@@ -9,6 +9,7 @@
+ 
+ #include <ucs/arch/cpu.h>
+ #include <ucs/time/time_def.h>
++#include <ucs/sys/math.h>
+ #include <sys/time.h>
+ #include <limits.h>
+ #include <math.h>

--- a/components/mpi-families/ucx/SPECS/ucx.spec
+++ b/components/mpi-families/ucx/SPECS/ucx.spec
@@ -35,6 +35,8 @@ Group:   %{PROJ_NAME}/mpi-families
 License: BSD
 URL:     http://www.openucx.org
 Source0: https://github.com/openucx/%{pname}/releases/download/v%{version}/%{pname}-%{version}.tar.gz
+# https://github.com/openucx/ucx/pull/11608
+Patch0:  time-include-math.patch
 
 # UCX currently supports only the following architectures
 ExclusiveArch: aarch64 ppc64le x86_64
@@ -90,6 +92,7 @@ This package was built from '' branch, commit c30b7da.
 
 %prep
 %setup -q -n ucx-%{version}
+%patch -P0 -p1
 
 %build
 %define _with_arg()   %{expand:%%{?with_%{1}:--with-%{2}}%%{!?with_%{1}:--without-%{2}}}


### PR DESCRIPTION
Add upstream patch to include ucs/sys/math.h in
ucs/time/time.h, which provides the UCS_INFINITY macro.

https://github.com/openucx/ucx/pull/11608