### PR TITLE
numpy: ignore distro installed pkgs in pip install

### DIFF
--- a/components/dev-tools/numpy/SPECS/python-numpy.spec
+++ b/components/dev-tools/numpy/SPECS/python-numpy.spec
@@ -92,8 +92,11 @@ PKG_CONFIG_PATH="${OPENBLAS_LIB}/pkgconfig:${PKG_CONFIG_PATH}" \
 # OpenHPC compiler/mpi designation
 %ohpc_setup_compiler
 
-%__python -m pip install --prefix=%{install_path} --root=%{buildroot} \
+%__python -m pip install --ignore-installed --prefix=%{install_path} --root=%{buildroot} \
 	--no-index --find-links=dist --no-deps numpy
+
+# Fail the build if pip satisfied the request from a distro numpy already in the build environment.
+test -f %{buildroot}%{install_path}/lib64/%{python_lib_dir}/site-packages/%{pname}/__init__.py
 
 %if 0%{?suse_version}
 %fdupes -s %{buildroot}%{install_path}


### PR DESCRIPTION
Hi @adrianreber this is PR to fix the CI/CD failure in the initial `ppc64le` support PR.

Failed here: https://github.com/openhpc/ohpc/actions/runs/28473398738/job/84424354415?pr=2637

The issue here is that `pip` checks whether numpy is already installed in the build chroot, not in --prefix. If `python3-numpy` already exists, from the distribution, `pip` prints "Requirement already satisfied". 

That simples does not install anything into the buildroot.

So the proposed solution is to add `--ignore-installed`.

Regards,