### PR TITLE
boost: gate fdupes BuildRequires to SUSE

### DIFF
--- a/components/parallel-libs/boost/SPECS/boost.spec
+++ b/components/parallel-libs/boost/SPECS/boost.spec
@@ -51,7 +51,6 @@ BuildRequires:  libquadmath-devel
 
 BuildRequires:  make
 BuildRequires:  which
-BuildRequires:  fdupes
 BuildRequires:  dos2unix
 BuildRequires:  gmp-devel
 BuildRequires:  python3-devel


### PR DESCRIPTION
fdupes isn’t in openEuler’s ppc64le repo and is only used on SUSE.

Proposed solution is to gate it for SUSE, if one day we will support them again…

On EL the package comes from EPEL which we leverage. So seems like a good solution.