### PR TITLE
scorep: gate fdupes BuildRequires to SUSE

### DIFF
--- a/components/perf-tools/scorep/SPECS/scorep.spec
+++ b/components/perf-tools/scorep/SPECS/scorep.spec
@@ -32,7 +32,6 @@ BuildRequires: chrpath
 BuildRequires: cmake
 BuildRequires: cubelib-%{compiler_family}%{PROJ_DELIM} >= 4.9
 BuildRequires: cubew-%{compiler_family}%{PROJ_DELIM} >= 4.9
-BuildRequires: fdupes
 BuildRequires: gcc-c++
 BuildRequires: gotcha-%{compiler_family}%{PROJ_DELIM}
 BuildRequires: libunwind-devel


### PR DESCRIPTION
Same issue as described in the `boost` PR. Gate to SUSE since we don’t use it in OpenEuler and it’s necessary for ppc64le build.