### PR TITLE
trilinos: drop unused doxygen BuildRequires

### DIFF
--- a/components/parallel-libs/trilinos/SPECS/trilinos.spec
+++ b/components/parallel-libs/trilinos/SPECS/trilinos.spec
@@ -37,7 +37,6 @@ Requires:       python3
 
 BuildRequires:  make
 BuildRequires:  cmake
-BuildRequires:  doxygen
 BuildRequires:  expat
 BuildRequires:  graphviz
 BuildRequires:  libxml2-devel


### PR DESCRIPTION
This PR removes the dependency with `doxygen`. Since it was already effectively disabled, so it should not be listed as a BuildRequires.

This unblocks the build of trilinos in openEuler with ppc64le.
