### PR TITLE
gnu-compilers: test build with tmate debug on failure

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -330,6 +330,12 @@ jobs:
           /home/ohpc/rpmbuild/RPMS/noarch/*rpm
           /home/ohpc/rpmbuild/RPMS/x86_64/*rpm
           /tmp/empty
+    - name: Debug via SSH
+      if: failure()
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 60
+      with:
+        limit-access-to-actor: true
     - name: Save ccache
       if: always()
       uses: actions/cache/save@v6

--- a/components/compiler-families/gnu-compilers/SPECS/gnu-compilers.spec
+++ b/components/compiler-families/gnu-compilers/SPECS/gnu-compilers.spec
@@ -148,6 +148,7 @@ cd obj
              --prefix=%{install_path} \
              --disable-static \
              --enable-shared
+
 make %{?_smp_mflags}
 
 


### PR DESCRIPTION
Add tmate SSH debug session to the openEuler build job to investigate brp-strip failure on aarch64. Includes a dummy spec change to trigger the gnu-compilers build.