### PR TITLE
add note about naming of IB interface to the documentation about adding nodes using warewulf

### DIFF
--- a/docs/install/templates/provisioner/warewulf/deploy-add-nodes.md.j2
+++ b/docs/install/templates/provisioner/warewulf/deploy-add-nodes.md.j2
@@ -23,6 +23,17 @@ done
 <!-- ohpc_fi -->
 <!-- ohpc_end -->
 
+::: {.tip}
+**Note:** If, once you boot the nodes, you find that the IB interface
+was renamed to something other than ib0 and hence not assigned the
+given IP, you can fix it by setting `--type="Infiniband"` and
+`--hwaddr` to the **literal last 6 bytes** of the interface's
+hardware address (the trailing 6 octets of the 20-byte IPoIB
+address, *not* the 48-bit InfiniBand "compatibility MAC"), so that
+the udev.netname overlay can set the persistent interface name.
+This does not make it PXE/DHCP-boot over IB.
+:::
+
 Finally, rebuild the image to incorporate any optional packages installed into
 the chroot during customization, then rebuild the overlays and update the
 Warewulf configuration.


### PR DESCRIPTION
(cherry picked from commit 34ad9e7c550139c7083a2c4f182adb8711330c39 to branch 4.x, https://github.com/openhpc/ohpc/pull/2618)