### PR TITLE
docs: style fix

### DIFF
--- a/docs/install/templates/base-os/disable-firewall.md.j2
+++ b/docs/install/templates/base-os/disable-firewall.md.j2
@@ -11,6 +11,6 @@ follows:
 <!-- ohpc_begin -->
 <!-- ohpc_comment Disable firewall -->
 ```bash
-systemctl disable --now firewalld || true
+systemctl disable --now firewalld.service || true
 ```
 <!-- ohpc_end -->

--- a/docs/install/templates/base-os/nfs.md.j2
+++ b/docs/install/templates/base-os/nfs.md.j2
@@ -21,7 +21,7 @@ echo "/opt/ohpc/pub *(ro,no_subtree_check,fsid=11)" >> /etc/exports
 exportfs -a
 
 # Restart and enable nfs server
-systemctl restart nfs-server
-systemctl enable nfs-server
+systemctl restart nfs-server.service
+systemctl enable nfs-server.service
 ```
 <!-- ohpc_end -->

--- a/docs/install/templates/base-os/time.md.j2
+++ b/docs/install/templates/base-os/time.md.j2
@@ -13,7 +13,7 @@ systemctl enable chronyd.service
 echo "local stratum 10" >> /etc/chrony.conf
 echo "server ${ntp_server}" >> /etc/chrony.conf
 echo "allow all" >> /etc/chrony.conf
-systemctl restart chronyd
+systemctl restart chronyd.service
 ```
 <!-- ohpc_end -->
 

--- a/docs/install/templates/customize/conman.md.j2
+++ b/docs/install/templates/customize/conman.md.j2
@@ -20,8 +20,8 @@ for ((i=0; i<num_computes; i++)) ; do
     done >> /etc/conman.conf
 
 # Enable and start conman
-systemctl enable conman
-systemctl start conman
+systemctl enable conman.service
+systemctl start conman.service
 ```
 <!-- ohpc_fi -->
 <!-- ohpc_end -->

--- a/docs/install/templates/customize/gpu.md.j2
+++ b/docs/install/templates/customize/gpu.md.j2
@@ -24,7 +24,7 @@ standard OpenHPC user environment.
 {{ compute_install("nvidia-driver:latest-dkms") }}
 
 # Enable DKMS service to automatically rebuild driver
-{{ compute_run("systemctl enable dkms") }}
+{{ compute_run("systemctl enable dkms.service") }}
 
 # Install the toolkit on the head node
 {{ compute_install(["cuda-devel-ohpc", "nvidia-driver-cuda"]) }}

--- a/docs/install/templates/customize/memlimits.md.j2
+++ b/docs/install/templates/customize/memlimits.md.j2
@@ -16,6 +16,7 @@ echo '* soft memlock unlimited' >> \
   /etc/security/limits.d/40-ohpc-limits.conf
 echo '* hard memlock unlimited' >> \
   /etc/security/limits.d/40-ohpc-limits.conf
+
 # Update memlock settings on compute
 {{ compute_echo("* soft memlock unlimited", "/etc/security/limits.d/40-ohpc-limits.conf") }}
 {{ compute_echo("* hard memlock unlimited", "/etc/security/limits.d/40-ohpc-limits.conf") }}

--- a/docs/install/templates/customize/nhc.md.j2
+++ b/docs/install/templates/customize/nhc.md.j2
@@ -33,6 +33,7 @@ bad nodes, reducing the risk of system-induced job failures.
 ```bash
 # Register as SLURM's health check program
 echo "HealthCheckProgram=/usr/sbin/nhc" >> /etc/slurm/slurm.conf
+
 # execute every five minutes
 echo "HealthCheckInterval=300" >> /etc/slurm/slurm.conf
 ```

--- a/docs/install/templates/customize/syslog.md.j2
+++ b/docs/install/templates/customize/syslog.md.j2
@@ -13,7 +13,7 @@ to accept these log requests.
 # Configure head node to receive messages and reload rsyslog configuration
 echo 'module(load="imudp")' >> /etc/rsyslog.d/ohpc.conf
 echo 'input(type="imudp" port="514")' >> /etc/rsyslog.d/ohpc.conf
-systemctl restart rsyslog
+systemctl restart rsyslog.service
 
 # Define compute node forwarding destination
 {{ compute_run("echo '*.* @${sms_ip}:514' > /etc/rsyslog.d/ohpc-forward.conf") }}

--- a/docs/install/templates/network/infiniband/head-node.md.j2
+++ b/docs/install/templates/network/infiniband/head-node.md.j2
@@ -45,7 +45,7 @@ echo "[main]"   >  /etc/NetworkManager/conf.d/90-dns-none.conf
 echo "dns=none" >> /etc/NetworkManager/conf.d/90-dns-none.conf
 
 # Start up NetworkManager to initiate ib0
-systemctl start NetworkManager
+systemctl start NetworkManager.service
 
 ```
 <!-- ohpc_fi -->

--- a/docs/install/templates/network/infiniband/head-node.md.j2
+++ b/docs/install/templates/network/infiniband/head-node.md.j2
@@ -43,6 +43,7 @@ sed -i "s/ipoib_netmask/${ipoib_netmask}/" \
 # configure NetworkManager to *not* override local /etc/resolv.conf
 echo "[main]"   >  /etc/NetworkManager/conf.d/90-dns-none.conf
 echo "dns=none" >> /etc/NetworkManager/conf.d/90-dns-none.conf
+
 # Start up NetworkManager to initiate ib0
 systemctl start NetworkManager
 

--- a/docs/install/templates/network/infiniband/opensm.md.j2
+++ b/docs/install/templates/network/infiniband/opensm.md.j2
@@ -10,7 +10,7 @@ you choose to run it on the *head node*.
 <!-- ohpc_comment Optionally enable opensm subnet manager -->
 <!-- ohpc_if_set enable_opensm -->
 <!-- ohpc_command {{ pkg_install }} opensm -->
-<!-- ohpc_command systemctl enable opensm -->
-<!-- ohpc_command systemctl start opensm -->
+<!-- ohpc_command systemctl enable opensm.service -->
+<!-- ohpc_command systemctl start opensm.service -->
 <!-- ohpc_fi -->
 <!-- ohpc_end -->

--- a/docs/install/templates/network/omnipath/opafm.md.j2
+++ b/docs/install/templates/network/omnipath/opafm.md.j2
@@ -10,7 +10,7 @@ you choose to run it on the *head node*.
 <!-- ohpc_comment Optionally enable OPA fabric manager -->
 <!-- ohpc_if_set enable_opafm -->
 <!-- ohpc_command {{ pkg_install }} opa-fm -->
-<!-- ohpc_command systemctl enable opafm -->
-<!-- ohpc_command systemctl start opafm -->
+<!-- ohpc_command systemctl enable opafm.service -->
+<!-- ohpc_command systemctl start opafm.service -->
 <!-- ohpc_fi -->
 <!-- ohpc_end -->

--- a/docs/install/templates/provisioner/confluent/compute-setup.md.j2
+++ b/docs/install/templates/provisioner/confluent/compute-setup.md.j2
@@ -13,7 +13,7 @@ We first disable the firewall on the compute nodes.
 <!-- ohpc_comment Disable firewall -->
 ```bash
 # Disable firewall for computes
-nodeshell compute systemctl disable --now firewalld
+nodeshell compute systemctl disable --now firewalld.service
 ```
 <!-- ohpc_end -->
 

--- a/docs/install/templates/provisioner/confluent/confluent-install.md.j2
+++ b/docs/install/templates/provisioner/confluent/confluent-install.md.j2
@@ -24,8 +24,8 @@ provisioning service on the *head node*:
 {{ pkg_install }} confluent_ipxe-aarch64 confluent_osdeploy-aarch64
 
 # Enable Confluent and its tools for use in current shell
-systemctl enable --now confluent
-systemctl enable --now httpd
+systemctl enable --now confluent.service
+systemctl enable --now httpd.service
 setsebool -P httpd_can_network_connect on
 semanage fcontext -a -t httpd_sys_content_t '/var/lib/confluent(/.*)?'
 systemctl enable --now tftp.socket

--- a/docs/install/templates/provisioner/confluent/deploy-slurm.md.j2
+++ b/docs/install/templates/provisioner/confluent/deploy-slurm.md.j2
@@ -12,8 +12,8 @@ We now start the Slurm daemon on the compute nodes.
 <!-- ohpc_comment Client Resource Manager Startup -->
 ```bash
 # Start munge and slurm controller on head node
-{{ compute_run("systemctl enable --now munge") }}
-{{ compute_run("systemctl enable --now slurmd") }}
+{{ compute_run("systemctl enable --now munge.service") }}
+{{ compute_run("systemctl enable --now slurmd.service") }}
 ```
 <!-- ohpc_end -->
 

--- a/docs/install/templates/provisioner/openchami/cloud-init.md.j2
+++ b/docs/install/templates/provisioner/openchami/cloud-init.md.j2
@@ -87,8 +87,8 @@ cat > /opt/ohpc/admin/cloud-init/compute.yaml <<EOF
           owner: munge:munge
           encoding: base64
       runcmd:
-        - systemctl restart munge
-        - systemctl restart slurmd
+        - systemctl restart munge.service
+        - systemctl restart slurmd.service
 EOF
 ```
 <!-- ohpc_end -->

--- a/docs/install/templates/provisioner/openchami/compute-image-build.md.j2
+++ b/docs/install/templates/provisioner/openchami/compute-image-build.md.j2
@@ -236,7 +236,7 @@ packages:
   - pdsh-ohpc
   - lmod-ohpc
 cmds:
-  - cmd: systemctl disable firewalld
+  - cmd: systemctl disable firewalld.service
     loglevel: INFO
   - cmd: >-
       echo '${sms_ip}:/home /home nfs nfsvers=3,nodev,nosuid 0 0'
@@ -250,7 +250,7 @@ cmds:
     loglevel: INFO
   - cmd: echo "account required pam_slurm.so" >> /etc/pam.d/sshd
     loglevel: INFO
-  - cmd: systemctl enable munge slurmd
+  - cmd: systemctl enable munge.service slurmd.service
     loglevel: INFO
   - cmd: ln -sf ../usr/share/zoneinfo/UTC /etc/localtime
     loglevel: INFO

--- a/docs/install/templates/provisioner/openchami/setup.md.j2
+++ b/docs/install/templates/provisioner/openchami/setup.md.j2
@@ -12,9 +12,9 @@ which interface with systemd allowing you to perform normal systemd operations
 on them like:
 
 ```bash
-systemctl status registry
-systemctl restart minio-server
-journalctl -u registry
+systemctl status registry.service
+systemctl restart minio-server.service
+journalctl -u registry.service
 ```
 :::
 

--- a/docs/install/templates/provisioner/warewulf/warewulf-setup.md.j2
+++ b/docs/install/templates/provisioner/warewulf/warewulf-setup.md.j2
@@ -27,7 +27,7 @@ yq -i '.nodeprofiles.default.kernel.args -= ["quiet"]' \
 echo "log-debug" >> /etc/dnsmasq.d/ww4-debug.conf
 
 # Enable and start the warewulfd service before using wwctl.
-systemctl enable --now warewulfd
+systemctl enable --now warewulfd.service
 
 # Create a new "nodes" profile and inherit the "default" profile
 wwctl profile add nodes --profile default --comment "Nodes profile"

--- a/docs/install/templates/scheduler/slurm/compute-startup.md.j2
+++ b/docs/install/templates/scheduler/slurm/compute-startup.md.j2
@@ -6,7 +6,7 @@ We now directly (re)start Slurm on the compute nodes.
 <!-- ohpc_comment Resource Manager Startup -->
 ```bash
 # Start slurm clients on compute hosts
-pdsh -w "${compute_prefix}[1-${num_computes}]" systemctl restart munge
-pdsh -w "${compute_prefix}[1-${num_computes}]" systemctl restart slurmd
+pdsh -w "${compute_prefix}[1-${num_computes}]" systemctl restart munge.service
+pdsh -w "${compute_prefix}[1-${num_computes}]" systemctl restart slurmd.service
 ```
 <!-- ohpc_end -->

--- a/docs/install/templates/scheduler/slurm/install.md.j2
+++ b/docs/install/templates/scheduler/slurm/install.md.j2
@@ -14,6 +14,7 @@ also needs to be running on all hosts within the resource management pool.
 
 # Use ohpc-provided file for starting SLURM configuration
 cp /etc/slurm/slurm.conf.ohpc /etc/slurm/slurm.conf
+
 # Setup default cgroups file
 cp /etc/slurm/cgroup.conf.example /etc/slurm/cgroup.conf
 

--- a/docs/install/templates/scheduler/slurm/startup.md.j2
+++ b/docs/install/templates/scheduler/slurm/startup.md.j2
@@ -9,8 +9,8 @@ preparation for running user jobs.
 <!-- ohpc_comment Resource Manager Startup -->
 ```bash
 # Start munge and slurm controller on head node
-systemctl enable --now munge
-systemctl enable --now slurmctld
+systemctl enable --now munge.service
+systemctl enable --now slurmctld.service
 ```
 <!-- ohpc_end -->
 

--- a/tests/ci/integration-test.sh
+++ b/tests/ci/integration-test.sh
@@ -355,7 +355,7 @@ export OHPC_INPUT_LOCAL="${INPUT_LOCAL}"
 if [[ "${PROVISIONER}" == "warewulf" ]]; then
 	sed -i \
 		-e 's/\(\["rd.shell"\]\)/\1 + ["console=hvc0", "loglevel=5"]/' \
-		-e 's/\(systemctl restart rsyslog\)/\1 || true/' \
+		-e 's/\(systemctl restart rsyslog\.service\)/\1 || true/' \
 		-e 's|#<<< ohpc_proxy:compute >>>#|echo "max_parallel_downloads=10" >> $CHROOT/etc/dnf/dnf.conf\necho "debuglevel=1" >> $CHROOT/etc/dnf/dnf.conf|' \
 		"${RECIPE}"
 elif [[ "${PROVISIONER}" == "openchami" ]]; then
@@ -375,7 +375,7 @@ elif [[ "${PROVISIONER}" == "openchami" ]]; then
 	rm -rf /opt/ohpc/admin/data/
 	sed -i \
 		-e 's/console=ttyS0,115200/console=hvc0 loglevel=5/' \
-		-e 's/\(systemctl restart rsyslog\)/\1 || true/' \
+		-e 's/\(systemctl restart rsyslog\.service\)/\1 || true/' \
 		-e 's|--network host \\|--network host \\\n        -v /etc/containers/storage.conf:/etc/containers/storage.conf:ro \\\n        -v /home/builder:/home/builder/.local \\|' \
 		-e 's|dracut --add "dmsquash-live livenet network-manager"|dracut --add "dmsquash-live livenet network-manager" --install "/usr/lib/systemd/systemd-sysroot-fstab-check"|' \
 		"${RECIPE}"


### PR DESCRIPTION
This PR normalizes `systemctl` calls in the install guides to always spell out `.service`, and adds line spacing to some code snippets.

The guides were inconsistent: most call sites used the bare unit name while a handful spelled out `.service`, sometimes both ways within the same file (`nfs.md.j2`, `time.md.j2`). Per the discussion below, this now normalizes **towards** `.service` rather than away from it, which also matches the other unit types the recipes already reference (`.socket`, `.target`).

Non-service units keep their own suffix. `tests/ci/integration-test.sh` matches `systemctl restart rsyslog` with `sed` to append `|| true`, so that pattern is updated to keep matching.

Spacing change keeps the pattern of:

```
# comment
code
<empty line>
# comment
code
```