### PR TITLE
docs/install: include the scheduler chapter dynamically

### DIFF
--- a/docs/install/templates/chapters/main.md.j2
+++ b/docs/install/templates/chapters/main.md.j2
@@ -2,7 +2,7 @@
 {% include "chapters/introduction.md.j2" %}
 {% include "chapters/base-os.md.j2" %}
 {% include "chapters/ohpc.md.j2" %}
-{% include "chapters/scheduler-slurm.md.j2" %}
+{% include "chapters/scheduler-" ~ scheduler ~ ".md.j2" %}
 {% include "chapters/provisioner-" ~ provisioner ~ ".md.j2" %}
 {% include "chapters/customize.md.j2" %}
 {% include "chapters/deploy-" ~ provisioner ~ ".md.j2" %}


### PR DESCRIPTION
Use the same dynamic include idiom as the provisioner chapters so new schedulers only need config + templates.


Sponsored-by: VersatusHPC