### PR TITLE
Update Slurm to 25.11.8

### DIFF
--- a/components/rms/slurm/SPECS/slurm.spec
+++ b/components/rms/slurm/SPECS/slurm.spec
@@ -30,7 +30,7 @@
 # $Id$
 #
 Name:		%{pname}%{PROJ_DELIM}
-Version:	25.11.4
+Version:	25.11.8
 %global rel	1
 Release:	%{?dist}.1
 Summary:	Slurm Workload Manager


### PR DESCRIPTION
This release provides a few security fixes: CVE-2026-65107, CVE-2026-65108, CVE-2026-65109, CVE-2026-65138, CVE-2026-65139, CVE-2026-65140, CVE-2026-65165, CVE-2026-65168.

See https://github.com/SchedMD/slurm/blob/slurm-25.11/CHANGELOG/slurm-25.11.md#changes-in-25118
