### PR TITLE
papi: add perl to BuildRequires

### DIFF
--- a/components/perf-tools/papi/SPECS/papi.spec
+++ b/components/perf-tools/papi/SPECS/papi.spec
@@ -29,6 +29,7 @@ BuildRequires: ncurses-devel make
 BuildRequires: gcc-gfortran
 BuildRequires: chrpath
 BuildRequires: kernel-headers
+BuildRequires: perl
 
 # Default library install path
 %define install_path %{OHPC_LIBS}/%{pname}/%version


### PR DESCRIPTION
The build runs maint/genpapifdef.pl. It fails in a buildroot that does not
already provide perl, such as Fedora Copr's.