### PR TITLE
slurm: add perl to BuildRequires

### DIFF
--- a/components/rms/slurm/SPECS/slurm.spec
+++ b/components/rms/slurm/SPECS/slurm.spec
@@ -124,6 +124,7 @@ BuildRequires: systemd
 BuildRequires: munge-devel
 BuildRequires: python3
 BuildRequires: readline-devel
+BuildRequires: perl
 Obsoletes: slurm-lua%{PROJ_DELIM} slurm-munge%{PROJ_DELIM} slurm-plugins%{PROJ_DELIM}
 
 #!BuildIgnore: post-build-checks


### PR DESCRIPTION
The build calls perl. It fails in a buildroot that does not already provide
perl, such as Fedora Copr's.