### PR TITLE
genders: require perl-devel on EL

### DIFF
--- a/components/admin/genders/SPECS/genders.spec
+++ b/components/admin/genders/SPECS/genders.spec
@@ -32,7 +32,7 @@ BuildRequires: python3-devel
 BuildRequires: byacc
 %endif
 
-%if 0%{?openEuler}
+%if 0%{?openEuler} || 0%{?rhel}
 BuildRequires: perl-devel
 %endif
 


### PR DESCRIPTION
The Perl bindings need /usr/share/perl5/ExtUtils/typemap, which perl-devel
provides. The BuildRequires applied only to openEuler.

The guard stays because SUSE has no perl-devel package.