### PR TITLE
charliecloud: point Source0 at the published release asset

### DIFF
--- a/components/runtimes/charliecloud/SPECS/charliecloud.spec
+++ b/components/runtimes/charliecloud/SPECS/charliecloud.spec
@@ -20,18 +20,17 @@
 %define versionize_script() (sed -i 's,/env python,/env %1,g' %2)
 
 # Unfortunately this changes with every release
-%define package_file_id 290882913
 
 %{!?build_ldflags:%global build_ldflags %nil}
 
 Summary:   Lightweight user-defined software stacks for high-performance computing
 Name:      %{pname}%{PROJ_DELIM}
-Version:   0.44
+Version:   0.45.1
 Release:   1%{?dist}
 License:   Apache-2.0
 Group:     %{PROJ_NAME}/runtimes
 URL:       https://charliecloud.io/
-Source0:   https://gitlab.com/charliecloud/charliecloud/-/package_files/%{package_file_id}/download#/charliecloud-%{version}.tar.gz
+Source0:   https://gitlab.com/%{pname}/%{pname}/-/releases/v%{version}/downloads/%{pname}-%{version}.tar.gz
 Source1:   Build
 
 BuildRequires: make


### PR DESCRIPTION
The package_files URL returns 404. Use the release asset URL for 0.44 and
drop the now unused package_file_id macro.