### PR TITLE
ci: select ruff rules explicitly

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,3 @@
+# TODO: ease the ruleset for future ruff versions
+[lint]
+select = ["E4", "E7", "E9", "F"]


### PR DESCRIPTION
`ruff check` started failing on pull requests that do not touch Python code. The failures comes from a change in Ruff's default rule set, combined with the lint container installing from `fedora:latest`.

To temporaly address the issues, we explicitly select the rules that Ruff previously enabled by default. This keeps lint behavior stable for now until we adapt everything for the new rules.
