### PR TITLE
tests/ci: fix ruff check-lint and format-lint findings

### DIFF
--- a/misc/build_order.py
+++ b/misc/build_order.py
@@ -2,7 +2,6 @@
 
 # To be able to use this script with python2 and python3 the following
 # is needed (just for the last line: print('%s' % i, end=' '))
-from __future__ import print_function
 
 import sys
 
@@ -36,9 +35,7 @@ def topological_sort(source):
                 next_emitted.append(name)
         if not next_emitted:
             # all entries have unmet deps, one of two things is wrong...
-            raise ValueError(
-                "cyclic or missing dependency detected: %r" % (next_pending,)
-            )
+            raise ValueError(f"cyclic or missing dependency detected: {next_pending!r}")
         pending = next_pending
         emitted = next_emitted
 
@@ -52,37 +49,38 @@ if len(sys.argv) != 2:
     sys.exit(1)
 
 
-for line in open(sys.argv[1]):
-    line = line.rstrip().split(":")
-    # The spec_dict is later used to translate
-    # package names into spec files
-    spec_dict[line[1]] = line[0]
-    # Store full path mapping if available (field 4)
-    if len(line) >= 4:
-        spec_path_dict[line[0]] = line[3]
-    # Ignore the meta_packages
-    if line[1] == "meta-packages":
-        continue
-    # Ignore non ohpc (Build)Requires
-    if line[2] == "NA":
-        continue
-    # Ignore kernel modules
-    if line[2].startswith("kmod"):
-        continue
-    # Ignore the nagios_plugins
-    if line[2].startswith("nagios"):
-        continue
-    # Filter out version strings (e.g. "1.2.3") and _isa markers (e.g. "(x86-64)").
-    # But keep package names that contain dots (e.g. "python3.12-foo-ohpc").
-    if "(" in line[2]:
-        continue
-    if "." in line[2] and "ohpc" not in line[2]:
-        continue
-    if line[0] in dependency:
-        if line[2] not in dependency[line[0]]:
-            dependency[line[0]].append(line[2])
-    else:
-        dependency[line[0]] = [line[2]]
+with open(sys.argv[1]) as depfile:
+    for line in depfile:
+        line = line.rstrip().split(":")
+        # The spec_dict is later used to translate
+        # package names into spec files
+        spec_dict[line[1]] = line[0]
+        # Store full path mapping if available (field 4)
+        if len(line) >= 4:
+            spec_path_dict[line[0]] = line[3]
+        # Ignore the meta_packages
+        if line[1] == "meta-packages":
+            continue
+        # Ignore non ohpc (Build)Requires
+        if line[2] == "NA":
+            continue
+        # Ignore kernel modules
+        if line[2].startswith("kmod"):
+            continue
+        # Ignore the nagios_plugins
+        if line[2].startswith("nagios"):
+            continue
+        # Filter out version strings (e.g. "1.2.3") and _isa markers (e.g. "(x86-64)").
+        # But keep package names that contain dots (e.g. "python3.12-foo-ohpc").
+        if "(" in line[2]:
+            continue
+        if "." in line[2] and "ohpc" not in line[2]:
+            continue
+        if line[0] in dependency:
+            if line[2] not in dependency[line[0]]:
+                dependency[line[0]].append(line[2])
+        else:
+            dependency[line[0]] = [line[2]]
 
 additional = {}
 
@@ -90,7 +88,7 @@ additional = {}
 for v in dependency.values():
     for value in v:
         try:
-            if spec_dict[value] not in dependency.keys():
+            if spec_dict[value] not in dependency:
                 additional[spec_dict[value]] = []
         except KeyError:
             # Handle python_prefix rpm macro
@@ -126,6 +124,6 @@ dep_list = [(k, set(v)) for (k, v) in dependency.items()]
 for i in topological_sort(dep_list):
     # Use full path if available, otherwise fall back to spec filename
     output_path = spec_path_dict.get(i, i)
-    print("%s" % output_path, end=" ")
+    print(f"{output_path}", end=" ")
 
-print("")
+print()

--- a/misc/check_for_package_updates.py
+++ b/misc/check_for_package_updates.py
@@ -74,12 +74,12 @@ class Result:
     """Container for a single package-check result."""
 
     __slots__ = (
-        "name",
         "current_version",
         "latest_version",
-        "status",
+        "name",
         "repo",
         "spec_file",
+        "status",
         "version_pin",
     )
 
@@ -589,10 +589,11 @@ def get_latest_jsc_perftools_version(
 
     versions = []
     for version in matches:
-        if not check_prereleases:
-            if re.search(r"-(rc|alpha|beta|pre|dev)\d*$", version):
-                debug_info(f"Skipping pre-release version: {version}", verbose)
-                continue
+        if not check_prereleases and re.search(
+            r"-(rc|alpha|beta|pre|dev)\d*$", version
+        ):
+            debug_info(f"Skipping pre-release version: {version}", verbose)
+            continue
         if version_pin and not _matches_version_pin(version, version_pin):
             continue
         versions.append(version)
@@ -697,10 +698,11 @@ def get_latest_bsc_ftp_version(
     for v in raw_versions:
         if v == "latest" or not re.match(r"\d", v):
             continue
-        if not check_prereleases:
-            if re.search(r"(rc|alpha|beta|pre|dev)\d*", v, re.IGNORECASE):
-                debug_info(f"Skipping pre-release version: {v}", verbose)
-                continue
+        if not check_prereleases and re.search(
+            r"(rc|alpha|beta|pre|dev)\d*", v, re.IGNORECASE
+        ):
+            debug_info(f"Skipping pre-release version: {v}", verbose)
+            continue
         if version_pin and not _matches_version_pin(v, version_pin):
             continue
         versions.append(v)
@@ -800,10 +802,11 @@ def get_latest_pnetcdf_version(check_prereleases, verbose, version_pin=None):
     for v in raw_versions:
         if v not in seen:
             seen.add(v)
-            if not check_prereleases:
-                if re.search(r"(alpha|beta|rc|pre|dev)", v, re.IGNORECASE):
-                    debug_info(f"Skipping pre-release version: {v}", verbose)
-                    continue
+            if not check_prereleases and re.search(
+                r"(alpha|beta|rc|pre|dev)", v, re.IGNORECASE
+            ):
+                debug_info(f"Skipping pre-release version: {v}", verbose)
+                continue
             if version_pin and not _matches_version_pin(v, version_pin):
                 continue
             versions.append(v)
@@ -1410,9 +1413,8 @@ def commit_updates(updated_results):
         subprocess.run(
             ["git", "add"] + spec_files,
             check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            universal_newlines=True,
+            capture_output=True,
+            text=True,
         )
     except FileNotFoundError:
         log_warn("git not found; skipping commit")
@@ -1424,8 +1426,8 @@ def commit_updates(updated_results):
     # Check if there are actually staged changes
     rc = subprocess.run(
         ["git", "diff", "--cached", "--quiet"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
+        check=False,
     )
     if rc.returncode == 0:
         log_info("No changes to commit")
@@ -1483,16 +1485,14 @@ def commit_updates(updated_results):
     try:
         sob_name = subprocess.run(
             ["git", "config", "user.name"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            universal_newlines=True,
+            capture_output=True,
+            text=True,
             check=True,
         ).stdout.strip()
         sob_email = subprocess.run(
             ["git", "config", "user.email"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            universal_newlines=True,
+            capture_output=True,
+            text=True,
             check=True,
         ).stdout.strip()
         body_lines.append("")
@@ -1506,9 +1506,8 @@ def commit_updates(updated_results):
         subprocess.run(
             ["git", "commit", "-m", message],
             check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            universal_newlines=True,
+            capture_output=True,
+            text=True,
         )
     except subprocess.CalledProcessError as exc:
         log_warn(f"Failed to create commit: {exc.stderr.strip()}")
@@ -1752,7 +1751,8 @@ def display_results_markdown(results, no_glow):
         proc = subprocess.run(
             ["glow", "-w", "0", "-"],
             input=md_text,
-            universal_newlines=True,
+            text=True,
+            check=False,
         )
         if proc.returncode != 0:
             print(md_text, end="")
@@ -1809,13 +1809,13 @@ class Config:
     """Configuration parsed from command-line arguments."""
 
     __slots__ = (
-        "verbose",
-        "prereleases",
-        "output",
-        "token",
         "no_glow",
+        "output",
         "package",
+        "prereleases",
+        "token",
         "update",
+        "verbose",
     )
 
     def __init__(self, args):

--- a/tests/ci/check_spec.py
+++ b/tests/ci/check_spec.py
@@ -24,9 +24,11 @@ regex_wrong = [
 regex_required = [
     # Group designation should include %{PROJ_NAME} delimiter and
     # known component area
-    "^Group:.*%{PROJ_NAME}/(admin|compiler-families|dev-tools|distro-packages|"
-    "io-libs|lustre|meta-package|mpi-families|parallel-libs|perf-tools|"
-    "provisioning|rms|runtimes|serial-libs)$",
+    (
+        "^Group:.*%{PROJ_NAME}/(admin|compiler-families|dev-tools|distro-packages|"
+        "io-libs|lustre|meta-package|mpi-families|parallel-libs|perf-tools|"
+        "provisioning|rms|runtimes|serial-libs)$"
+    ),
     # Need a URL
     "(^URL:.*$|Url:.*$)",
 ]
@@ -37,7 +39,7 @@ if len(sys.argv) <= 1:
 
 regex_wrong_string = "(" + "|".join(regex_wrong) + ")"
 
-print("Checking that %s does not exist" % regex_wrong_string)
+print(f"Checking that {regex_wrong_string} does not exist")
 
 pattern = re.compile(regex_wrong_string)
 
@@ -53,26 +55,25 @@ for spec in sys.argv[1:]:
     if not spec.endswith(".spec"):
         continue
     if spec in skip_ci_specs:
-        print("--> Skipping spec file %s" % spec)
+        print(f"--> Skipping spec file {spec}")
         continue
     spec_found = True
-    print("--> Scanning spec file %s" % spec)
+    print(f"--> Scanning spec file {spec}")
 
     # cache spec file contents
-    infile = open(spec)
-    contents = infile.read()
-    infile.close()
+    with open(spec) as infile:
+        contents = infile.read()
 
     # first, verify patterns which should *not* be present
     for line in contents.split("\n"):
         if pattern.match(line):
-            print("    [+] Found %s" % (line.rstrip()))
+            print(f"    [+] Found {line.rstrip()}")
             error = True
 
     # next, verify items which should be present
     for requirement in regex_required:
         if not re.findall(requirement, contents, re.MULTILINE):
-            print("    [-] Missing %s" % requirement)
+            print(f"    [-] Missing {requirement}")
             error = True
 
 if not spec_found:

--- a/tests/ci/run_build.py
+++ b/tests/ci/run_build.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python3
 
-import subprocess
-import selectors
 import argparse
-import logging
-import shutil
-import time
-import sys
 import csv
-import pwd
-import os
 import io
+import logging
+import os
+import pwd
+import selectors
+import shutil
+import subprocess
+import sys
+import time
 
 logging.basicConfig(format="%(asctime)s %(message)s", level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -46,21 +47,22 @@ dist = "9999.ci.ohpc"
 version_id = ""
 
 # Check which base OS we are using
-reader = csv.DictReader(open("/etc/os-release"), delimiter="=")
+with open("/etc/os-release") as os_release:
+    reader = csv.DictReader(os_release, delimiter="=")
 
-skip_ci_specs = []
-skip_ci_specs_env = os.getenv("SKIP_CI_SPECS")
-if skip_ci_specs_env:
-    skip_ci_specs = skip_ci_specs_env.rstrip().split()
+    skip_ci_specs = []
+    skip_ci_specs_env = os.getenv("SKIP_CI_SPECS")
+    if skip_ci_specs_env:
+        skip_ci_specs = skip_ci_specs_env.rstrip().split()
 
-for row in reader:
-    key = row.pop("NAME")
-    if key in ["ID_LIKE", "ID"]:
-        for item in list(row.items())[0]:
-            if "fedora" in item or "openEuler" in item:
-                dnf_based = True
-    if key == "VERSION_ID":
-        version_id = list(row.items())[0][1]
+    for row in reader:
+        key = row.pop("NAME")
+        if key in ["ID_LIKE", "ID"]:
+            for item in next(iter(row.items())):
+                if "fedora" in item or "openEuler" in item:
+                    dnf_based = True
+        if key == "VERSION_ID":
+            version_id = next(iter(row.items()))[1]
 
 # Enable ccache for CI builds
 os.makedirs("/etc/rpm", exist_ok=True)
@@ -85,7 +87,7 @@ local_repo_configured = False
 
 
 def run_command(command):
-    logging.info("About to run command %s" % " ".join(command))
+    logger.info(f"About to run command {' '.join(command)}")
     process = subprocess.Popen(
         command,
         bufsize=1,
@@ -134,20 +136,20 @@ def loop_command(command, max_attempts=5):
             (success, output) = run_command(command)
             if success:
                 return (True, output)
-        except Exception as e:
-            logging.error("Exception: %s" % e)
+        except OSError as e:
+            logger.error(f"Exception: {e}")
 
         if attempt_counter >= abs(max_attempts):
             return (False, output)
 
-        logging.info("Retrying attempt '%i'" % attempt_counter)
+        logger.info(f"Retrying attempt '{attempt_counter}'")
         time.sleep(attempt_counter)
 
 
 def get_build_order(specfiles):
     """Use misc/build_order.sh to determine the correct build order
     for the given spec files."""
-    logging.info("Determining build order using misc/build_order.sh")
+    logger.info("Determining build order using misc/build_order.sh")
 
     # Ensure RPM build environment is set up (build_order.sh requires
     # OHPC_macros in the RPM source directory)
@@ -164,13 +166,13 @@ def get_build_order(specfiles):
         macros_src = "components/OHPC_macros"
         if os.path.exists(macros_src):
             shutil.copy2(macros_src, macros_dest)
-            logging.info("Copied OHPC_macros to %s" % macros_dest)
+            logger.info(f"Copied OHPC_macros to {macros_dest}")
         else:
-            logging.warning("components/OHPC_macros not found")
+            logger.warning("components/OHPC_macros not found")
 
     success, output = run_command(["misc/build_order.sh"])
     if not success:
-        logging.warning("misc/build_order.sh failed, using original spec file order")
+        logger.warning("misc/build_order.sh failed, using original spec file order")
         return specfiles
 
     # build_order.sh prints all spec paths in order on one line
@@ -202,9 +204,7 @@ def get_build_order(specfiles):
         return len(ordered)
 
     sorted_specs = sorted(specfiles, key=sort_key)
-    logging.info(
-        "Build order: %s" % " ".join([os.path.basename(s) for s in sorted_specs])
-    )
+    logger.info(f"Build order: {' '.join(os.path.basename(s) for s in sorted_specs)}")
     return sorted_specs
 
 
@@ -222,10 +222,10 @@ def setup_local_repo():
     ]:
         os.chown(d, uid, gid)
 
-    logging.info("Running createrepo_c on %s" % rpmbuild_rpms_dir)
+    logger.info(f"Running createrepo_c on {rpmbuild_rpms_dir}")
     success, _ = run_command(["createrepo_c", rpmbuild_rpms_dir])
     if not success:
-        logging.error("createrepo_c failed on %s" % rpmbuild_rpms_dir)
+        logger.error(f"createrepo_c failed on {rpmbuild_rpms_dir}")
         return False
 
     if not local_repo_configured:
@@ -234,11 +234,11 @@ def setup_local_repo():
             with open(repo_file, "w") as f:
                 f.write("[local-ohpc-ci]\n")
                 f.write("name=Local OpenHPC CI builds\n")
-                f.write("baseurl=file://%s\n" % rpmbuild_rpms_dir)
+                f.write(f"baseurl=file://{rpmbuild_rpms_dir}\n")
                 f.write("enabled=1\n")
                 f.write("gpgcheck=0\n")
                 f.write("metadata_expire=0\n")
-            logging.info("Configured local DNF repository at %s" % repo_file)
+            logger.info(f"Configured local DNF repository at {repo_file}")
         else:
             success, _ = run_command(
                 [
@@ -251,9 +251,9 @@ def setup_local_repo():
                 ]
             )
             if not success:
-                logging.error("Failed to add local zypper repository")
+                logger.error("Failed to add local zypper repository")
                 return False
-            logging.info("Configured local zypper repository")
+            logger.info("Configured local zypper repository")
 
         local_repo_configured = True
 
@@ -285,10 +285,10 @@ def build_srpm_and_rpm(
         if output is not None:
             for line in output.split("\n"):
                 if "No compatible architectures found for build" in line:
-                    logging.info("Skipping unsupported architecture RPM")
+                    logger.info("Skipping unsupported architecture RPM")
                     return True
 
-        logging.error("Running misc/build_srpm.sh failed")
+        logger.error("Running misc/build_srpm.sh failed")
         return False
 
     src_rpm = ""
@@ -298,10 +298,10 @@ def build_srpm_and_rpm(
             break
 
     if src_rpm == "":
-        logging.error("SRPM generation failed")
+        logger.error("SRPM generation failed")
         return False
 
-    logging.info(src_rpm)
+    logger.info(src_rpm)
 
     if dnf_based:
         builddep_command = [
@@ -321,7 +321,7 @@ def build_srpm_and_rpm(
 
     success, _ = loop_command(builddep_command)
     if not success:
-        logging.error("Running '%s' failed" % " ".join(builddep_command))
+        logger.error(f"Running '{' '.join(builddep_command)}' failed")
         return False
 
     tmp_src_rpm = os.path.join("/tmp", os.path.basename(src_rpm))
@@ -338,27 +338,27 @@ def build_srpm_and_rpm(
         build_user,
         "-l",
         "-c",
-        'rpmbuild --define "dist %s" --rebuild %s' % (dist, src_rpm),
+        f'rpmbuild --define "dist {dist}" --rebuild {src_rpm}',
     ]
 
     if mpi_family is not None:
-        rebuild_command[-1] += " --define 'mpi_family %s'" % mpi_family
+        rebuild_command[-1] += f" --define 'mpi_family {mpi_family}'"
 
     if compiler_family is not None:
-        rebuild_command[-1] += " --define 'compiler_family %s'" % compiler_family
+        rebuild_command[-1] += f" --define 'compiler_family {compiler_family}'"
 
     if not_mpi_dependent:
         rebuild_command[-1] += " --define 'ohpc_mpi_dependent 0'"
 
     # Disable parallel builds for below packages on aarch64 to avoid OOM
     pkgs = ["boost-", "paraver-"]
-    if any([x in src_rpm for x in pkgs]) and os.uname().machine == "aarch64":
+    if any(x in src_rpm for x in pkgs) and os.uname().machine == "aarch64":
         rebuild_command[-1] += " --define '_smp_mflags -j1'"
 
-    logging.warning(rebuild_command)
+    logger.warning(rebuild_command)
     success, _ = run_command(rebuild_command)
     if not success:
-        logging.error("Running 'rpmbuild --rebuild' failed")
+        logger.error("Running 'rpmbuild --rebuild' failed")
         return False
 
     return True
@@ -421,12 +421,12 @@ for spec in specfiles:
     just_spec = os.path.basename(spec)
     total += 1
     if spec in skip_ci_specs:
-        logging.info("--> Skipping spec file %s" % spec)
+        logger.info(f"--> Skipping spec file {spec}")
         skipped.append(just_spec)
         continue
 
     spec_found = True
-    logging.info("--> Building RPM from spec file %s" % spec)
+    logger.info(f"--> Building RPM from spec file {spec}")
 
     command = [
         "misc/get_source.sh",
@@ -435,14 +435,13 @@ for spec in specfiles:
 
     success, _ = run_command(command)
     if not success:
-        logging.error("Running misc/get_source.sh failed")
+        logger.error("Running misc/get_source.sh failed")
         failed.append(just_spec)
         continue
 
     # cache spec file contents
-    infile = open(spec)
-    contents = infile.read()
-    infile.close()
+    with open(spec) as infile:
+        contents = infile.read()
 
     if "ohpc_mpi_dependent" in contents:
         families = [
@@ -462,10 +461,10 @@ for spec in specfiles:
                 mpi_family=family,
                 compiler_family=args.compiler_family,
             ):
-                failed.append("%s (%s, %s)" % (just_spec, args.compiler_family, family))
+                failed.append(f"{just_spec} ({args.compiler_family}, {family})")
             else:
                 rebuild_success.append(
-                    "%s (%s, %s)" % (just_spec, args.compiler_family, family)
+                    f"{just_spec} ({args.compiler_family}, {family})"
                 )
 
         if "!?ohpc_mpi_dependent" in contents:
@@ -479,18 +478,18 @@ for spec in specfiles:
                 compiler_family=args.compiler_family,
                 not_mpi_dependent=True,
             ):
-                failed.append("%s (%s)" % (just_spec, args.compiler_family))
+                failed.append(f"{just_spec} ({args.compiler_family})")
             else:
-                rebuild_success.append("%s (%s)" % (just_spec, args.compiler_family))
+                rebuild_success.append(f"{just_spec} ({args.compiler_family})")
 
     elif "ohpc_compiler_dependent" in contents:
         if not build_srpm_and_rpm(
             spec,
             compiler_family=args.compiler_family,
         ):
-            failed.append("%s (%s)" % (just_spec, args.compiler_family))
+            failed.append(f"{just_spec} ({args.compiler_family})")
         else:
-            rebuild_success.append("%s (%s)" % (just_spec, args.compiler_family))
+            rebuild_success.append(f"{just_spec} ({args.compiler_family})")
 
     else:
         if not build_srpm_and_rpm(spec):
@@ -506,27 +505,27 @@ for spec in specfiles:
 
 
 if not spec_found:
-    logging.info("SKIP. Commit without changes to a SPEC file.")
+    logger.info("SKIP. Commit without changes to a SPEC file.")
 
-logging.info("Found %d spec file(s)" % total)
+logger.info(f"Found {total} spec file(s)")
 if build_order_used:
-    logging.info("--> Build order: %s" % " -> ".join(build_order_used))
-logging.info("--> %d rebuild successfully" % len(rebuild_success))
+    logger.info(f"--> Build order: {' -> '.join(build_order_used)}")
+logger.info(f"--> {len(rebuild_success)} rebuild successfully")
 for success in rebuild_success:
-    logging.info("----> %s" % success)
+    logger.info(f"----> {success}")
 
-logging.info("--> %d rebuilds skipped" % len(skipped))
+logger.info(f"--> {len(skipped)} rebuilds skipped")
 
 for skip in skipped:
-    logging.info("----> %s skipped" % skip)
+    logger.info(f"----> {skip} skipped")
 
 if len(failed) > 0:
-    logging.error("--> %d rebuilds failed" % len(failed))
+    logger.error(f"--> {len(failed)} rebuilds failed")
     for fail in failed:
-        logging.info("----> %s failed" % fail)
+        logger.info(f"----> {fail} failed")
 
-    logging.error("ERROR")
+    logger.error("ERROR")
     sys.exit(1)
 
-logging.info("No errors found. Exiting.")
+logger.info("No errors found. Exiting.")
 sys.exit(0)

--- a/tests/ci/spec_to_test_mapping.py
+++ b/tests/ci/spec_to_test_mapping.py
@@ -134,7 +134,7 @@ admin_tests = ""
 pkgs = ""
 
 for i in sys.argv[1:]:
-    if i in test_map.keys():
+    if i in test_map:
         if len(tests) > 0:
             tests += " "
         if len(admin_tests) > 0:
@@ -149,11 +149,4 @@ for i in sys.argv[1:]:
             admin_tests += f"--enable-{test_map[i][1]}"
         pkgs += test_map[i][2]
 
-print(
-    "TESTS=(%s) ADMIN_TESTS=(%s) PKGS=(%s)"
-    % (
-        tests,
-        admin_tests,
-        pkgs,
-    )
-)
+print(f"TESTS=({tests}) ADMIN_TESTS=({admin_tests}) PKGS=({pkgs})")


### PR DESCRIPTION
Same class of ruff findings already fixed on 3.x/4.x, adapted here for 2.x's version of these files (older subprocess.run style with stdout/stderr=PIPE + universal_newlines, no regenerate_source_ checksums() helper, no ohpc-filesystem.spec ordering logic, etc.):

- Replace %-style string formatting with f-strings (UP031).
- Open files with a context manager instead of a bare open() call (SIM115).
- Use next(iter(d.items())) instead of list(d.items())[0] (RUF015).
- Add a module-level logger instead of calling the root logger directly (LOG015).
- Narrow the blind `except Exception` catch in the retry loop to OSError, the specific exception subprocess failures raise (BLE001).
- Prefer capture_output=True over stdout=PIPE, stderr=PIPE (UP022), and text=True over universal_newlines=True (UP021).
- Pass an explicit check=False to subprocess.run() calls whose return code is already checked manually (PLW1510).
- Remove the unnecessary `from __future__ import print_function` (UP010) and empty string passed to print() (FURB105).
- Collapse nested if-statements (SIM102), drop `.keys()` from membership tests (SIM118), sort __slots__ (RUF023), parenthesize an implicitly concatenated string (ISC004), and drop an unnecessary list comprehension (C419).

Also ran `ruff format` on the touched files to satisfy ruff-format-lint.