### PR TITLE
plasma: pass BLAS_LIBRARIES explicitly to cmake

### DIFF
--- a/components/serial-libs/plasma/SPECS/plasma.spec
+++ b/components/serial-libs/plasma/SPECS/plasma.spec
@@ -62,6 +62,7 @@ least squares problems, eigenvalue problems, and singular value problems.
 
 %if "%{compiler_family}" != "intel" && "%{compiler_family}" != "arm1"
 module load openblas
+%define blas_lib "-L${OPENBLAS_LIB} -lopenblas"
 %endif
 
 module load cmake
@@ -72,12 +73,19 @@ python3 tools/fortran_gen.py --prefix include/ include/plasma*h
 # Create plasma.mod
 ${FC} -fPIC -c -o include/plasma_mod.o include/plasma_mod.f90
 
+# Point cmake at the openblas module explicitly: FindBLAS searches the
+# system library directories before LD_LIBRARY_PATH, so a distro openblas
+# (e.g. pulled in by python3-numpy) would otherwise be picked up instead.
 mkdir build
 cd build
 cmake \
 	-DPLASMA_DETECT_LUA=1 \
 	-DCMAKE_C_FLAGS="$CFLAGS" \
 	-DCMAKE_INSTALL_PREFIX=%{install_path} \
+%if "%{compiler_family}" != "intel" && "%{compiler_family}" != "arm1"
+	-DBLAS_LIBRARIES=%{blas_lib} \
+	-DLAPACK_LIBRARIES=%{blas_lib} \
+%endif
 %if "%{compiler_family}" == "intel"
 	-DCMAKE_EXE_LINKER_FLAGS_INIT="-lifcore" \
 %endif


### PR DESCRIPTION
cmake's FindBLAS searches the system library directories before the `LD_LIBRARY_PATH` hint, so when a distro openblas is installed it is picked over the openblas module. On openEuler, python3-numpy (a boost BuildRequires) pulls in the distro `openblas` package, which ships a static `/usr/lib64/libopenblas.a`. On aarch64 the link probe against that archive fails and configure aborts with `Could NOT find BLAS`; on x86_64 the wrong library is linked silently.

This is what broke the openEuler aarch64 job of #2680, where the build-order fallback put boost before plasma: https://github.com/openhpc/ohpc/actions/runs/34351765319/job/102466796823

Point `BLAS_LIBRARIES` and `LAPACK_LIBRARIES` at the openblas module, as scalapack already does.

Verified in the openEuler CI container with the distro openblas present: cmake resolves BLAS/LAPACK to the module on both x86_64 (full `run_build.py` build) and aarch64 (configure).